### PR TITLE
#5148: Default recipe error on setup (Milestone: 1.8.x)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeStepQueue.cs
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeStepQueue.cs
@@ -57,7 +57,7 @@ namespace Orchard.Recipes.Services {
                 _appDataFolder.DeleteFile(stepPath);
             }
 
-            if (stepIndex < 1) {
+            if (stepIndex < 0) {
                 _appDataFolder.DeleteFile(Path.Combine(_recipeQueueFolder, executionId));
             }
 


### PR DESCRIPTION
This happens when trying to delete the recipe directory that isn't empty yet