### PR TITLE
Make Orchard.Core.Common.Utilities.LazyField<T> [Obsolete]

### DIFF
--- a/src/Orchard.Web/Core/Common/Models/CommonPart.cs
+++ b/src/Orchard.Web/Core/Common/Models/CommonPart.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Orchard.Core.Common.Utilities;
 using Orchard.ContentManagement;
 using Orchard.ContentManagement.Aspects;
+using Orchard.ContentManagement.Utilities;
 using Orchard.Security;
 
 namespace Orchard.Core.Common.Models {

--- a/src/Orchard.Web/Core/Common/Utilities/LazyField.cs
+++ b/src/Orchard.Web/Core/Common/Utilities/LazyField.cs
@@ -1,6 +1,7 @@
 using System;
 
 namespace Orchard.Core.Common.Utilities {
+    [Obsolete("Use Orchard.ContentManagement.Utilities.LazyField instead.")]
     public class LazyField<T> {
         private T _value;
         private Func<T> _loader;

--- a/src/Orchard.Web/Core/Common/Utilities/LazyField.cs
+++ b/src/Orchard.Web/Core/Common/Utilities/LazyField.cs
@@ -7,8 +7,8 @@ namespace Orchard.Core.Common.Utilities {
         private Func<T, T> _setter;
 
         public T Value {
-            get {return GetValue();}
-            set {SetValue(value);}
+            get { return GetValue(); }
+            set { SetValue(value); }
         }
 
         public void Loader(Func<T> loader) {
@@ -22,7 +22,7 @@ namespace Orchard.Core.Common.Utilities {
         private T GetValue() {
             if (_loader != null) {
                 _value = _loader();
-                _loader = null;                
+                _loader = null;
             }
             return _value;
         }

--- a/src/Orchard.Web/Core/Containers/Models/ContainerPart.cs
+++ b/src/Orchard.Web/Core/Containers/Models/ContainerPart.cs
@@ -2,7 +2,7 @@
 using Orchard.ContentManagement;
 using Orchard.ContentManagement.MetaData.Models;
 using Orchard.ContentManagement.Records;
-using Orchard.Core.Common.Utilities;
+using Orchard.ContentManagement.Utilities;
 using Orchard.Core.Containers.Services;
 using Orchard.Core.Containers.Settings;
 using Orchard.UI.Navigation;

--- a/src/Orchard.Web/Core/Navigation/Handlers/MenuPartHandler.cs
+++ b/src/Orchard.Web/Core/Navigation/Handlers/MenuPartHandler.cs
@@ -35,7 +35,7 @@ namespace Orchard.Core.Navigation.Handlers {
                 return menu;
             });
 
-            menuPart.MenuField.Loader(ctx =>
+            menuPart.MenuField.Loader(() =>
                 _contentManager.Get(menuPart.Record.MenuId, menuPart.IsPublished() ? VersionOptions.Published : VersionOptions.Latest)
             );
         }
@@ -46,7 +46,7 @@ namespace Orchard.Core.Navigation.Handlers {
             if (part != null) {
                 string stereotype;
                 if (context.ContentItem.TypeDefinition.Settings.TryGetValue("Stereotype", out stereotype) && stereotype == "MenuItem") {
-                    context.Metadata.DisplayText = part.MenuText;    
+                    context.Metadata.DisplayText = part.MenuText;
                 }
             }
         }

--- a/src/Orchard.Web/Modules/Orchard.ArchiveLater/Handlers/ArchiveLaterPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.ArchiveLater/Handlers/ArchiveLaterPartHandler.cs
@@ -14,7 +14,7 @@ namespace Orchard.ArchiveLater.Handlers {
         }
 
         protected void LazyLoadHandlers(ArchiveLaterPart part) {
-            part.ScheduledArchiveUtc.Loader((value) => _archiveLaterService.GetScheduledArchiveUtc(part));        
+            part.ScheduledArchiveUtc.Loader(() => _archiveLaterService.GetScheduledArchiveUtc(part));
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Models/AuditTrailSettingsPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Models/AuditTrailSettingsPart.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using Orchard.ContentManagement;
-using Orchard.Core.Common.Utilities;
+using Orchard.ContentManagement.Utilities;
 
 namespace Orchard.AuditTrail.Models {
     public class AuditTrailSettingsPart : ContentPart {

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Models/Assets/Asset.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Models/Assets/Asset.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using Orchard.Azure.MediaServices.Models.Records;
-using Microsoft.WindowsAzure.MediaServices.Client;
 using Orchard.ContentManagement.FieldStorage;
 using Orchard.Core.Common.Utilities;
 using Orchard.FileSystems.Media;

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Models/Assets/Asset.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Models/Assets/Asset.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Orchard.Azure.MediaServices.Models.Records;
 using Orchard.ContentManagement.FieldStorage;
-using Orchard.Core.Common.Utilities;
+using Orchard.ContentManagement.Utilities;
 using Orchard.FileSystems.Media;
 
 namespace Orchard.Azure.MediaServices.Models.Assets {

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Models/Jobs/Job.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Models/Jobs/Job.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Orchard.Azure.MediaServices.Helpers;
 using Orchard.Azure.MediaServices.Models.Records;
-using Orchard.Core.Common.Utilities;
+using Orchard.ContentManagement.Utilities;
 
 namespace Orchard.Azure.MediaServices.Models.Jobs {
 	public class Job {

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Models/Jobs/Task.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Models/Jobs/Task.cs
@@ -1,6 +1,6 @@
 ﻿using System.Xml.Linq;
 using Orchard.Azure.MediaServices.Models.Records;
-using Orchard.Core.Common.Utilities;
+using Orchard.ContentManagement.Utilities;
 
 namespace Orchard.Azure.MediaServices.Models.Jobs {
     public class Task {

--- a/src/Orchard.Web/Modules/Orchard.Comments/Handlers/CommentPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Handlers/CommentPartHandler.cs
@@ -16,11 +16,11 @@ namespace Orchard.Comments.Handlers {
 
             OnLoading<CommentPart>((context, comment) => {
                 comment.CommentedOnContentItemField.Loader(
-                    item => contentManager.Get(comment.CommentedOn)
+                    () => contentManager.Get(comment.CommentedOn)
                 );
 
                 comment.CommentedOnContentItemMetadataField.Loader(
-                    item => contentManager.GetItemMetadata(comment.CommentedOnContentItem)
+                    () => contentManager.GetItemMetadata(comment.CommentedOnContentItem)
                 );
             });
 

--- a/src/Orchard.Web/Modules/Orchard.Comments/Handlers/CommentsPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Handlers/CommentsPartHandler.cs
@@ -22,13 +22,13 @@ namespace Orchard.Comments.Handlers {
             });
 
             OnLoading<CommentsPart>((context, comments) => {
-                comments.CommentsField.Loader(list =>
+                comments.CommentsField.Loader(() =>
                     commentService.GetCommentsForCommentedContent(context.ContentItem.Id)
                     .Where(x => x.Status == CommentStatus.Approved)
                     .OrderBy(x => x.Position)
                     .List().ToList());
 
-                comments.PendingCommentsField.Loader(list => 
+                comments.PendingCommentsField.Loader(() => 
                     commentService.GetCommentsForCommentedContent(context.ContentItem.Id)
                     .Where(x => x.Status == CommentStatus.Pending)
                     .List().ToList());

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Handlers/ContentMenuItemPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Handlers/ContentMenuItemPartHandler.cs
@@ -12,7 +12,7 @@ namespace Orchard.ContentPicker.Handlers {
             Filters.Add(new ActivatingFilter<ContentMenuItemPart>("ContentMenuItem"));
             Filters.Add(StorageFilter.For(repository));
 
-            OnLoading<ContentMenuItemPart>((context, part) => part._content.Loader(p => {
+            OnLoading<ContentMenuItemPart>((context, part) => part._content.Loader(() => {
                 if (part.ContentItemId != null) {
                     return contentManager.Get(part.ContentItemId.Value);
                 }

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Handlers/ContentPickerFieldHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Handlers/ContentPickerFieldHandler.cs
@@ -30,7 +30,7 @@ namespace Orchard.ContentPicker.Handlers {
 
             foreach (var field in fields) {
                 var localField = field;
-                field._contentItems.Loader(x => _contentManager.GetMany<ContentItem>(localField.Ids, VersionOptions.Published, QueryHints.Empty));
+                field._contentItems.Loader(() => _contentManager.GetMany<ContentItem>(localField.Ids, VersionOptions.Published, QueryHints.Empty));
             }
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Email/Handlers/SmtpSettingsPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Handlers/SmtpSettingsPartHandler.cs
@@ -47,7 +47,7 @@ namespace Orchard.Email.Handlers {
                 part.Store(x => x.Password, encryptedPassword);
             });
 
-            part.AddressPlaceholderField.Loader(value => (string)((dynamic)ConfigurationManager.GetSection("system.net/mailSettings/smtp")).From);
+            part.AddressPlaceholderField.Loader(() => (string)((dynamic)ConfigurationManager.GetSection("system.net/mailSettings/smtp")).From);
         }
 
         public Localizer T { get; set; }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Handlers/LocalizationPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Handlers/LocalizationPartHandler.cs
@@ -42,10 +42,10 @@ namespace Orchard.Localization.Handlers {
         }
 
         protected void LazyLoadHandlers(LocalizationPart localizationPart) {
-            localizationPart.CultureField.Loader(ctx => 
+            localizationPart.CultureField.Loader(() => 
                 _cultureManager.GetCultureById(localizationPart.Record.CultureId));
 
-            localizationPart.MasterContentItemField.Loader(ctx =>
+            localizationPart.MasterContentItemField.Loader(() =>
                 _contentManager.Get(localizationPart.Record.MasterContentItemId, VersionOptions.AllVersions));
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaPartHandler.cs
@@ -17,7 +17,7 @@ namespace Orchard.MediaLibrary.Handlers {
             OnRemoving<MediaPart>((context, part) => RemoveMedia(part));
             OnLoaded<MediaPart>((context, part) => {
                 if (!String.IsNullOrEmpty(part.FileName)) {
-                    part._publicUrl.Loader(x => _mediaLibraryService.GetMediaPublicUrl(part.FolderPath, part.FileName));
+                    part._publicUrl.Loader(() => _mediaLibraryService.GetMediaPublicUrl(part.FolderPath, part.FileName));
                 }
             });
 

--- a/src/Orchard.Web/Modules/Orchard.MediaPicker/Handlers/MediaGalleryFieldHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaPicker/Handlers/MediaGalleryFieldHandler.cs
@@ -30,7 +30,7 @@ namespace Orchard.MediaPicker.Handlers {
 
             foreach (var field in fields) {
                 var localField = field;
-                field._mediaGalleryItems.Loader(x => _jsonConverter.Deserialize<MediaGalleryItem[]>(localField.SelectedItems ?? "[]") ?? new MediaGalleryItem[0]);
+                field._mediaGalleryItems.Loader(() => _jsonConverter.Deserialize<MediaGalleryItem[]>(localField.SelectedItems ?? "[]") ?? new MediaGalleryItem[0]);
             }
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.PublishLater/Handlers/PublishLaterPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.PublishLater/Handlers/PublishLaterPartHandler.cs
@@ -18,7 +18,7 @@ namespace Orchard.PublishLater.Handlers {
         }
 
         protected void LazyLoadHandlers(PublishLaterPart part) {
-            part.ScheduledPublishUtc.Loader((value) => _publishLaterService.GetScheduledPublishUtc(part));
+            part.ScheduledPublishUtc.Loader(() => _publishLaterService.GetScheduledPublishUtc(part));
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Roles/Handlers/UserRolesPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Handlers/UserRolesPartHandler.cs
@@ -11,7 +11,7 @@ namespace Orchard.Roles.Handlers {
             _userRolesRepository = userRolesRepository;
 
             Filters.Add(new ActivatingFilter<UserRolesPart>("User"));
-            OnInitialized<UserRolesPart>((context, userRoles) => userRoles._roles.Loader(value => _userRolesRepository
+            OnInitialized<UserRolesPart>((context, userRoles) => userRoles._roles.Loader(() => _userRolesRepository
                 .Fetch(x => x.UserId == context.ContentItem.Id)
                 .Select(x => x.Role.Name).ToList()));
         }

--- a/src/Orchard.Web/Modules/Orchard.Tags/Handlers/TagCloudHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Tags/Handlers/TagCloudHandler.cs
@@ -17,7 +17,7 @@ namespace Orchard.Tags.Handlers {
             _signals = signals;
 
             OnInitializing<TagCloudPart>((context, part) => part
-                ._tagCountField.Loader(tags =>
+                ._tagCountField.Loader(() =>
                     tagCloudService.GetPopularTags(part.Buckets, part.Slug).ToList()
                     ));
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TaxonomyPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TaxonomyPartHandler.cs
@@ -42,7 +42,7 @@ namespace Orchard.Taxonomies.Handlers {
                 }
             });
 
-            OnLoading<TaxonomyPart>( (context, part) => part.TermsField.Loader(x => taxonomyService.GetTerms(part.Id)));
+            OnLoading<TaxonomyPart>( (context, part) => part.TermsField.Loader(() => taxonomyService.GetTerms(part.Id)));
 
             OnUpdating<TitlePart>((context, part) => {
                 // if altering the title of a taxonomy, save the name

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TermsPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TermsPartHandler.cs
@@ -65,7 +65,7 @@ namespace Orchard.Taxonomies.Handlers {
 
             foreach (var field in part.ContentItem.Parts.SelectMany(p => p.Fields).OfType<TaxonomyField>()) {
                 var tempField = field.Name;
-                field.TermsField.Loader(value => {
+                field.TermsField.Loader(() => {
                     var fieldTermRecordIds = part.Record.Terms.Where(t => t.Field == tempField).Select(tci => tci.TermRecord.Id);
                     var terms = _contentManager.GetMany<TermPart>(fieldTermRecordIds, VersionOptions.Published, queryHint);
                     return terms.ToList();
@@ -73,7 +73,7 @@ namespace Orchard.Taxonomies.Handlers {
             }
 
             part._termParts = new LazyField<IEnumerable<TermContentItemPart>>();
-            part._termParts.Loader(value => {
+            part._termParts.Loader(() => {
                 var ids = part.Terms.Select(t => t.TermRecord.Id).Distinct();
                 var terms = _contentManager.GetMany<TermPart>(ids, VersionOptions.Published, queryHint)
                     .ToDictionary(t => t.Id, t => t);

--- a/src/Orchard/ContentManagement/Handlers/StorageFilter.cs
+++ b/src/Orchard/ContentManagement/Handlers/StorageFilter.cs
@@ -30,8 +30,7 @@ namespace Orchard.ContentManagement.Handlers {
             return _repository.Get(versionRecord.ContentItemRecord.Id);
         }
 
-        protected virtual TRecord CreateRecordCore(ContentItemVersionRecord versionRecord, TRecord record = null)
-        {
+        protected virtual TRecord CreateRecordCore(ContentItemVersionRecord versionRecord, TRecord record = null) {
             if (record == null) {
                 record = new TRecord();
             }

--- a/src/Orchard/ContentManagement/Handlers/StorageFilter.cs
+++ b/src/Orchard/ContentManagement/Handlers/StorageFilter.cs
@@ -30,7 +30,11 @@ namespace Orchard.ContentManagement.Handlers {
             return _repository.Get(versionRecord.ContentItemRecord.Id);
         }
 
-        protected virtual TRecord CreateRecordCore(ContentItemVersionRecord versionRecord, TRecord record) {
+        protected virtual TRecord CreateRecordCore(ContentItemVersionRecord versionRecord, TRecord record = null)
+        {
+            if (record == null) {
+                record = new TRecord();
+            }
             record.ContentItemRecord = versionRecord.ContentItemRecord;
             _repository.Create(record);
             return record;
@@ -51,7 +55,7 @@ namespace Orchard.ContentManagement.Handlers {
 
         protected override void Loading(LoadContentContext context, ContentPart<TRecord> instance) {
             var versionRecord = context.ContentItemVersionRecord;
-            instance._record.Loader(prior => GetRecordCore(versionRecord) ?? CreateRecordCore(versionRecord, prior));
+            instance._record.Loader(() => GetRecordCore(versionRecord) ?? CreateRecordCore(versionRecord));
         }
 
         protected override void Versioning(VersionContentContext context, ContentPart<TRecord> existing, ContentPart<TRecord> building) {

--- a/src/Orchard/ContentManagement/Handlers/StorageVersionFilter.cs
+++ b/src/Orchard/ContentManagement/Handlers/StorageVersionFilter.cs
@@ -12,7 +12,10 @@ namespace Orchard.ContentManagement.Handlers {
             return _repository.Get(versionRecord.Id);
         }
 
-        protected override TRecord CreateRecordCore(ContentItemVersionRecord versionRecord, TRecord record) {
+        protected override TRecord CreateRecordCore(ContentItemVersionRecord versionRecord, TRecord record = null) {
+            if (record == null) {
+                record = new TRecord();
+            }
             record.ContentItemRecord = versionRecord.ContentItemRecord;
             record.ContentItemVersionRecord = versionRecord;
             _repository.Create(record);

--- a/src/Orchard/ContentManagement/Utilities/LazyField.cs
+++ b/src/Orchard/ContentManagement/Utilities/LazyField.cs
@@ -3,7 +3,7 @@
 namespace Orchard.ContentManagement.Utilities {
     public class LazyField<T> {
         private T _value;
-        private Func<T, T> _loader;
+        private Func<T> _loader;
         private Func<T, T> _setter;
 
         public T Value {
@@ -11,7 +11,7 @@ namespace Orchard.ContentManagement.Utilities {
             set { SetValue(value); }
         }
 
-        public void Loader(Func<T, T> loader) {
+        public void Loader(Func<T> loader) {
             _loader = loader;
         }
 
@@ -21,7 +21,7 @@ namespace Orchard.ContentManagement.Utilities {
 
         private T GetValue() {
             if (_loader != null) {
-                _value = _loader(_value);
+                _value = _loader();
                 _loader = null;
             }
             return _value;

--- a/src/Orchard/ContentManagement/Utilities/LazyField.cs
+++ b/src/Orchard/ContentManagement/Utilities/LazyField.cs
@@ -15,6 +15,11 @@ namespace Orchard.ContentManagement.Utilities {
             _loader = loader;
         }
 
+        [Obsolete]
+        public void Loader(Func<T, T> loader) {
+            _loader = () => loader(_value);
+        }
+
         public void Setter(Func<T, T> setter) {
             _setter = setter;
         }


### PR DESCRIPTION
It closes #765 and closes #3746 and closes #5191.

I removed _value parameter from loader delegate because it was pointless (_value was always null if noone run setter before loader) and it is used nowhere except storage filters.

Please check if all is well.
W.