### PR TITLE
Added assembly bindings for OData 5.6.3 - Fix for #5187

### DIFF
--- a/src/Orchard.Web/Web.config
+++ b/src/Orchard.Web/Web.config
@@ -177,6 +177,18 @@
                 <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
                 <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     


### PR DESCRIPTION
Microsoft.WindowsAzure.Storage tries to load Microsoft.Data.OData 5.6.2 unless there's a binding in app.config or web.config.  This binding needs to be in the root web.config of the application.  It does not work in the module web.config.