### PR TITLE
Fixing #4963

### DIFF
--- a/src/Orchard.Web/Core/Navigation/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Core/Navigation/Views/Admin/Index.cshtml
@@ -135,7 +135,7 @@
 @using (Script.Foot()) {
 <script type="text/javascript">
 //<![CDATA[
-    var leaveConfirmation = '@T("Some items where not saved.")';
+    var leaveConfirmation = "@T("Some items where not saved.")";
 
     $('#menuId').change(function () {
         $(this).parents('form').submit();


### PR DESCRIPTION
To prevent translations that are using ' char like : Certains éléments n'ont pas été enregistrés.
To fail.

Fixing #4963