### PR TITLE
#5235: Awaiting activities not cleared on saving

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Workflows/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Controllers/AdminController.cs
@@ -265,6 +265,7 @@ namespace Orchard.Workflows.Controllers {
             var activitiesIndex = new Dictionary<string, ActivityRecord>();
 
             workflowDefinitionRecord.ActivityRecords.Clear();
+            workflowDefinitionRecord.WorkflowRecords.Clear();
 
             foreach (var activity in state.Activities) {
                 ActivityRecord activityRecord;


### PR DESCRIPTION

After editing and updating a Workflow, the Workflow is stopped. But the workflow is still listed as running in the "Workflows Definitions" page. And in the "Running workflows" page related to a content item, you get an exception

By clearing WorkflowRecords in the submit.Save controller action, the related workflows and their awaiting activities are cleared