### PR TITLE
#5235: Awaiting activities not cleared on saving

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Workflows/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Controllers/AdminController.cs
@@ -265,6 +265,7 @@ namespace Orchard.Workflows.Controllers {
             var activitiesIndex = new Dictionary<string, ActivityRecord>();
 
             workflowDefinitionRecord.ActivityRecords.Clear();
+            workflowDefinitionRecord.WorkflowRecords.Clear();
 
             foreach (var activity in state.Activities) {
                 ActivityRecord activityRecord;

--- a/src/Orchard.Web/Modules/Orchard.Workflows/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Controllers/AdminController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Web;
 using System.Web.Mvc;
@@ -160,8 +161,11 @@ namespace Orchard.Workflows.Controllers {
         }
 
         public JsonResult State(int? id) {
+            if (!Services.Authorizer.Authorize(StandardPermissions.SiteOwner, T("Not authorized to edit workflows")))
+                throw new AuthenticationException("");
+
             var workflowDefinitionRecord = id.HasValue ? _workflowDefinitionRecords.Get(id.Value) : null;
-            var isRunning = workflowDefinitionRecord != null ? workflowDefinitionRecord.WorkflowRecords.Any() : false;
+            var isRunning = workflowDefinitionRecord != null && workflowDefinitionRecord.WorkflowRecords.Any();
             return Json(new { isRunning = isRunning }, JsonRequestBehavior.AllowGet);
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Workflows/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Controllers/AdminController.cs
@@ -159,6 +159,12 @@ namespace Orchard.Workflows.Controllers {
             return RedirectToAction("Edit", new { workflowDefinitionRecord.Id });
         }
 
+        public JsonResult State(int? id) {
+            var workflowDefinitionRecord = id.HasValue ? _workflowDefinitionRecords.Get(id.Value) : null;
+            var isRunning = workflowDefinitionRecord != null ? workflowDefinitionRecord.WorkflowRecords.Any() : false;
+            return Json(new { isRunning = isRunning }, JsonRequestBehavior.AllowGet);
+        }
+
         public ActionResult Edit(int id, string localId, int? workflowId) {
             if (!Services.Authorizer.Authorize(StandardPermissions.SiteOwner, T("Not authorized to edit workflows")))
                 return new HttpUnauthorizedResult();

--- a/src/Orchard.Web/Modules/Orchard.Workflows/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Views/Admin/Edit.cshtml
@@ -42,6 +42,7 @@
     //<![CDATA[
     var renderActivityUrl = '@HttpUtility.JavaScriptStringEncode(Url.Action("RenderActivity", "Admin", new { area = "Orchard.Workflows" }))';
     var editActivityUrl = '@HttpUtility.JavaScriptStringEncode(Url.Action("EditActivity", "Admin", new { area = "Orchard.Workflows" }))';
+    var stateUrl = '@HttpUtility.JavaScriptStringEncode(Url.Action("State", "Admin", new { area = "Orchard.Workflows" }))';
     var requestAntiForgeryToken = '@HttpUtility.JavaScriptStringEncode(Html.AntiForgeryTokenValueOrchard().ToString())';
     var localId = '@HttpUtility.JavaScriptStringEncode(Model.LocalId)';
     var updatedActivityClientId = null;
@@ -73,6 +74,7 @@
 @Html.Hidden("data", String.Empty)
 
 @Html.Hidden("confirm-delete-activity", T("Are you sure you want to remove this activity?"))
+@Html.Hidden("confirm-delete-instances", T("Are you sure you want to remove running instances of this workflow?"))
 
     using (Script.Foot()) {
 <script type="text/javascript">
@@ -82,6 +84,16 @@
         var workflow = loadWorkflow(localId);
         var data = JSON.stringify(workflow);
         $("[name='data']").val(data);
+
+        $.ajax({
+            url: stateUrl + "/" + $("#id").val(),
+            async: false,
+            success: function(state) {
+                if(state.isRunning && !confirm($("#confirm-delete-instances").val())) {
+                    e.preventDefault();
+                }
+            }
+        });
     });
     //]]>
 </script>


### PR DESCRIPTION
By clearing WorkflowRecords in the submit.Save controller action, the related workflows and their awaiting activities are cleared