### PR TITLE
 #5224: Fix for missing charset in response header for cached output

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -447,6 +447,9 @@ namespace Orchard.OutputCache.Filters {
         private void ServeCachedItem(ActionExecutingContext filterContext, CacheItem cacheItem) {
             var response = filterContext.HttpContext.Response;
 
+            // Fix for missing charset in response headers
+            response.Charset = response.Charset; 
+
             // Adds some caching information to the output if requested.
             if (CacheSettings.DebugMode) {
                 response.AddHeader("X-Cached-On", cacheItem.CachedOnUtc.ToString("r"));


### PR DESCRIPTION
Honestly I have no idea why this code is needed to get charset back into response headers, but it works ...