### PR TITLE
#5109: Email field shouldn't specify email type in design mode

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Views/Elements/EmailField.Design.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Views/Elements/EmailField.Design.cshtml
@@ -5,7 +5,7 @@
     var tagBuilder = TagBuilderExtensions.CreateElementTagBuilder(Model, "input");
 
     tagBuilder.AddCssClass("text design");
-    tagBuilder.Attributes["type"] = "email";
+    tagBuilder.Attributes["type"] = "text";
     tagBuilder.Attributes["value"] = element.Value;
     tagBuilder.Attributes["name"] = element.Name;
 }


### PR DESCRIPTION
When `email` type is specified on an input it triggers browser validation on that field which prevents administrator from inserting tokens like `{User.Email}`.