### PR TITLE
Provide full table name prefix for migrations

### DIFF
--- a/src/Orchard.Tests/DataMigration/Utilities/NullInterpreter.cs
+++ b/src/Orchard.Tests/DataMigration/Utilities/NullInterpreter.cs
@@ -24,5 +24,10 @@ namespace Orchard.Tests.DataMigration.Utilities {
 
         public void Visit(DropForeignKeyCommand command) {
         }
+
+        public string PrefixTableName(string tableName) {
+            return tableName;
+        }
+
     }
 }

--- a/src/Orchard/Data/Migration/Interpreters/DefaultDataMigrationInterpreter.cs
+++ b/src/Orchard/Data/Migration/Interpreters/DefaultDataMigrationInterpreter.cs
@@ -91,7 +91,7 @@ namespace Orchard.Data.Migration.Interpreters {
             RunPendingStatements();
         }
 
-        private string PrefixTableName(string tableName) {
+        public string PrefixTableName(string tableName) {
             if (string.IsNullOrEmpty(_shellSettings.DataTablePrefix))
                 return tableName;
             return _shellSettings.DataTablePrefix + "_" + tableName;
@@ -285,6 +285,8 @@ namespace Orchard.Data.Migration.Interpreters {
         }
 
         private void Visit(StringBuilder builder, CreateColumnCommand command) {
+            bool emitNull = true;
+
             if (ExecuteCustomInterpreter(command)) {
                 return;
             }
@@ -297,8 +299,14 @@ namespace Orchard.Data.Migration.Interpreters {
             }
 
             // append identity if handled
+<<<<<<< HEAD
             if (command.IsIdentity && _dialectLazy.Value.SupportsIdentityColumns) {
                 builder.Append(Space).Append(_dialectLazy.Value.IdentityColumnString);
+=======
+            if (command.IsIdentity && _dialect.SupportsIdentityColumns) {
+                builder.Append(Space).Append(_dialect.IdentityColumnString);
+                emitNull = !_dialect.IdentityColumnString.ToLower().Contains("null"); // already defined by identity string
+>>>>>>> orchard4ibn/IBN-Labs/SchemaBuilder.TableDbName
             }
 
             // [default value]
@@ -307,11 +315,21 @@ namespace Orchard.Data.Migration.Interpreters {
             }
 
             // nullable
+<<<<<<< HEAD
             builder.Append(command.IsNotNull
                                ? " not null"
                                : !command.IsPrimaryKey && !command.IsUnique
                                      ? _dialectLazy.Value.NullColumnString
                                      : string.Empty);
+=======
+            if (emitNull) {
+                builder.Append(command.IsNotNull
+                                   ? " not null"
+                                   : !command.IsPrimaryKey && !command.IsUnique
+                                         ? _dialect.NullColumnString
+                                         : string.Empty);
+            }
+>>>>>>> orchard4ibn/IBN-Labs/SchemaBuilder.TableDbName
 
             // append unique if handled, otherwise at the end of the satement
             if (command.IsUnique && _dialectLazy.Value.SupportsUnique) {

--- a/src/Orchard/Data/Migration/Interpreters/DefaultDataMigrationInterpreter.cs
+++ b/src/Orchard/Data/Migration/Interpreters/DefaultDataMigrationInterpreter.cs
@@ -285,8 +285,6 @@ namespace Orchard.Data.Migration.Interpreters {
         }
 
         private void Visit(StringBuilder builder, CreateColumnCommand command) {
-            bool emitNull = true;
-
             if (ExecuteCustomInterpreter(command)) {
                 return;
             }
@@ -299,14 +297,8 @@ namespace Orchard.Data.Migration.Interpreters {
             }
 
             // append identity if handled
-<<<<<<< HEAD
             if (command.IsIdentity && _dialectLazy.Value.SupportsIdentityColumns) {
                 builder.Append(Space).Append(_dialectLazy.Value.IdentityColumnString);
-=======
-            if (command.IsIdentity && _dialect.SupportsIdentityColumns) {
-                builder.Append(Space).Append(_dialect.IdentityColumnString);
-                emitNull = !_dialect.IdentityColumnString.ToLower().Contains("null"); // already defined by identity string
->>>>>>> orchard4ibn/IBN-Labs/SchemaBuilder.TableDbName
             }
 
             // [default value]
@@ -315,21 +307,11 @@ namespace Orchard.Data.Migration.Interpreters {
             }
 
             // nullable
-<<<<<<< HEAD
             builder.Append(command.IsNotNull
                                ? " not null"
                                : !command.IsPrimaryKey && !command.IsUnique
                                      ? _dialectLazy.Value.NullColumnString
                                      : string.Empty);
-=======
-            if (emitNull) {
-                builder.Append(command.IsNotNull
-                                   ? " not null"
-                                   : !command.IsPrimaryKey && !command.IsUnique
-                                         ? _dialect.NullColumnString
-                                         : string.Empty);
-            }
->>>>>>> orchard4ibn/IBN-Labs/SchemaBuilder.TableDbName
 
             // append unique if handled, otherwise at the end of the satement
             if (command.IsUnique && _dialectLazy.Value.SupportsUnique) {

--- a/src/Orchard/Data/Migration/Interpreters/IDataMigrationInterpreter.cs
+++ b/src/Orchard/Data/Migration/Interpreters/IDataMigrationInterpreter.cs
@@ -9,5 +9,6 @@ namespace Orchard.Data.Migration.Interpreters {
         void Visit(SqlStatementCommand command);
         void Visit(CreateForeignKeyCommand command);
         void Visit(DropForeignKeyCommand command);
+        string PrefixTableName(string tableName);
     }
 }

--- a/src/Orchard/Data/Migration/Schema/SchemaBuilder.cs
+++ b/src/Orchard/Data/Migration/Schema/SchemaBuilder.cs
@@ -28,6 +28,13 @@ namespace Orchard.Data.Migration.Schema {
         public Func<string, string> FormatPrefix {
             get { return _formatPrefix; }
         }
+
+        /// <summary>
+        /// Translate Table name into database table name - including prefixes
+        /// </summary>
+        public virtual string TableDbName(string srcTable) {
+            return _interpreter.PrefixTableName(String.Concat(FormatPrefix(FeaturePrefix), srcTable));
+        }
       
         public SchemaBuilder CreateTable(string name, Action<CreateTableCommand> table) {
             var createTable = new CreateTableCommand(String.Concat(_formatPrefix(_featurePrefix), name));


### PR DESCRIPTION
Sometimes when performing a migration there is work to be done on the database tables.
This PR adds explicit calculation of table name with proper Orchard prefix.
