### PR TITLE
Added logging for invalid recipe files

### DIFF
--- a/src/Orchard.Tests.Modules/Recipes/Services/RecipeManagerTests.cs
+++ b/src/Orchard.Tests.Modules/Recipes/Services/RecipeManagerTests.cs
@@ -136,8 +136,8 @@ namespace Orchard.Tests.Modules.Recipes.Services {
         }
 
         [Test]
-        public void ParseRecipeReturnsNullOnInvalidXml() {
-            Assert.That(_recipeParser.ParseRecipe("<reipe></recipe>") == null);
+        public void ParseRecipeThrowsOnInvalidXml() {
+            Assert.Throws(typeof(XmlException), () => _recipeParser.ParseRecipe("<reipe></recipe>"));
         }
 
         [Test]

--- a/src/Orchard.Tests.Modules/Recipes/Services/RecipeManagerTests.cs
+++ b/src/Orchard.Tests.Modules/Recipes/Services/RecipeManagerTests.cs
@@ -136,8 +136,8 @@ namespace Orchard.Tests.Modules.Recipes.Services {
         }
 
         [Test]
-        public void ParseRecipeThrowsOnInvalidXml() {
-            Assert.Throws(typeof(XmlException), () => _recipeParser.ParseRecipe("<reipe></recipe>"));
+        public void ParseRecipeReturnsNullOnInvalidXml() {
+            Assert.That(_recipeParser.ParseRecipe("<reipe></recipe>") == null);
         }
 
         [Test]

--- a/src/Orchard.Web/Modules/Orchard.Modules/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Modules/Controllers/AdminController.cs
@@ -133,6 +133,7 @@ namespace Orchard.Modules.Controllers {
                     Module = x,
                     Recipes = _recipeHarvester.HarvestRecipes(x.Descriptor.Id).Where(recipe => !recipe.IsSetupRecipe).ToList()
                 })
+                .ToList()
                 .Where(x => x.Recipes.Any());
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Modules/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Modules/Controllers/AdminController.cs
@@ -133,8 +133,8 @@ namespace Orchard.Modules.Controllers {
                     Module = x,
                     Recipes = _recipeHarvester.HarvestRecipes(x.Descriptor.Id).Where(recipe => !recipe.IsSetupRecipe).ToList()
                 })
-                .ToList()
-                .Where(x => x.Recipes.Any());
+                .Where(x => x.Recipes.Any())
+                .ToList();
             }
 
             return View(viewModel);

--- a/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeHarvester.cs
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeHarvester.cs
@@ -35,10 +35,20 @@ namespace Orchard.Recipes.Services {
             if (extension != null) {
                 var recipeLocation = Path.Combine(extension.Location, extensionId, "Recipes");
                 var recipeFiles = _webSiteFolder.ListFiles(recipeLocation, true);
-                recipes.AddRange(
-                    from recipeFile in recipeFiles
-                    where recipeFile.EndsWith(".recipe.xml", StringComparison.OrdinalIgnoreCase)
-                    select _recipeParser.ParseRecipe(_webSiteFolder.ReadFile(recipeFile)));
+
+                recipeFiles.Where(r => r.EndsWith(".recipe.xml", StringComparison.OrdinalIgnoreCase)).ToList().ForEach(r =>
+                {
+                    var recipe = _recipeParser.ParseRecipe(_webSiteFolder.ReadFile(r));
+
+                    if (recipe == null)
+                    {
+                        Logger.Error(new Exception(string.Format("Invalid recipe file: {0}", r)), "Invalid recipe file: {0}", r);
+                    }
+                    else
+                    {
+                        recipes.Add(recipe);
+                    }
+                });
             }
             else {
                 Logger.Error("Could not discover recipes because module '{0}' was not found.", extensionId);

--- a/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeHarvester.cs
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeHarvester.cs
@@ -36,18 +36,15 @@ namespace Orchard.Recipes.Services {
                 var recipeLocation = Path.Combine(extension.Location, extensionId, "Recipes");
                 var recipeFiles = _webSiteFolder.ListFiles(recipeLocation, true);
 
-                recipeFiles.Where(r => r.EndsWith(".recipe.xml", StringComparison.OrdinalIgnoreCase)).ToList().ForEach(r =>
-                {
-                    var recipe = _recipeParser.ParseRecipe(_webSiteFolder.ReadFile(r));
+                recipeFiles.Where(r => r.EndsWith(".recipe.xml", StringComparison.OrdinalIgnoreCase)).ToList().ForEach(r => {
 
-                    if (recipe == null)
-                    {
-                        Logger.Error(new Exception(string.Format("Invalid recipe file: {0}", r)), "Invalid recipe file: {0}", r);
+                    try {
+                        recipes.Add(_recipeParser.ParseRecipe(_webSiteFolder.ReadFile(r)));
                     }
-                    else
-                    {
-                        recipes.Add(recipe);
+                    catch (Exception ex) {
+                        Logger.Error(new Exception(string.Format("Invalid recipe file: {0}\nError: {1}", r, ex.Message)), "Invalid recipe file: {0}\nError: {1}", r, ex.Message);
                     }
+
                 });
             }
             else {

--- a/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeParser.cs
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeParser.cs
@@ -20,21 +20,12 @@ namespace Orchard.Recipes.Services {
             var recipe = new Recipe();
             
             try {
-                if (string.IsNullOrEmpty(recipeText))
-                {
-                    return null;
+
+                if (string.IsNullOrEmpty(recipeText)) {
+                    throw new Exception("Recipe is empty");
                 }
 
-                XElement recipeTree;
-
-                try
-                {
-                    recipeTree = XElement.Parse(recipeText, LoadOptions.PreserveWhitespace);
-                }
-                catch
-                {
-                    return null;
-                }
+                XElement recipeTree = XElement.Parse(recipeText, LoadOptions.PreserveWhitespace);
 
                 var recipeSteps = new List<RecipeStep>();
 

--- a/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeParser.cs
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Services/RecipeParser.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Xml;
 using System.Xml.Linq;
 using Orchard.Localization;
@@ -21,10 +20,23 @@ namespace Orchard.Recipes.Services {
             var recipe = new Recipe();
             
             try {
+                if (string.IsNullOrEmpty(recipeText))
+                {
+                    return null;
+                }
+
+                XElement recipeTree;
+
+                try
+                {
+                    recipeTree = XElement.Parse(recipeText, LoadOptions.PreserveWhitespace);
+                }
+                catch
+                {
+                    return null;
+                }
+
                 var recipeSteps = new List<RecipeStep>();
-                TextReader textReader = new StringReader(recipeText);
-                var recipeTree = XElement.Load(textReader, LoadOptions.PreserveWhitespace);
-                textReader.Close();
 
                 foreach (var element in recipeTree.Elements()) {
                     // Recipe mETaDaTA


### PR DESCRIPTION
Currently, the recipe parser throws any recipe errors to the user, causing full page error on the tenant setup screen or ‘Recipes’ tab in the admin area. It would be beneficial for these errors to be trapped and logged, so that users can still work with valid recipes.

If the RecipeParser validated the recipe text, it could return a null for any invalid files. Any null recipes returned by RecipeParser could then be logged, along with the file name. No error would occur for the user.

The manner in which the user is informed is flexible. I would propose a message on-screen informing them of the problem file or files, as a logging-only solution could mask problems.

There are no breaking changes involved in the implementation of the proposed amendments.

While implementing the change, I noticed that when Recipes.cshtml iterates through the Modules list in the ViewModel, it causes deferred execution of a query. This calls RecipeHarvester for a second time, per item in the collection. I have added .ToList() on the initial load to fix this issue - it will prevent the log from being written twice, and also halve the time taken to load & parse recipe files.