### PR TITLE
fixing split extension method for #5348

### DIFF
--- a/src/Orchard/Mvc/Html/ContentItemExtensions.cs
+++ b/src/Orchard/Mvc/Html/ContentItemExtensions.cs
@@ -9,7 +9,7 @@ namespace Orchard.Mvc.Html {
     public static class ContentItemExtensions {
 
         public static MvcHtmlString ItemDisplayText(this HtmlHelper html, IContent content) {
-            return ItemDisplayText(content, true);
+            return ItemDisplayText(html, content, true);
         }
         
         public static MvcHtmlString ItemDisplayText(this HtmlHelper html, IContent content, bool encode) {


### PR DESCRIPTION
c337948 is causing a compiler error in 1.9.x
