### PR TITLE
Read additional module and them folders from web.config appSettings

### DIFF
--- a/src/Orchard.Web/Web.config
+++ b/src/Orchard.Web/Web.config
@@ -15,6 +15,11 @@
         <add key="webpages:Version" value="3.0.0.0"/>
         <add key="log4net.Config" value="Config\log4net.config"/>
         <add key="owin:AppStartup" value="Orchard.Owin.Startup, Orchard.Framework"/>
+    
+<!-- optional additional comma-separated list of folders for Modules or Themes
+        <add key="Modules" value="~/Modules/MyAdditionalModulesFolder, ~/MoreModules"/>
+        <add key="Themes" value="~/Themes/MoreThemes" />
+-->
     </appSettings>
     
     <system.web.webPages.razor>

--- a/src/Orchard/Environment/OrchardStarter.cs
+++ b/src/Orchard/Environment/OrchardStarter.cs
@@ -35,6 +35,8 @@ using Orchard.Mvc.ViewEngines.ThemeAwareness;
 using Orchard.Services;
 using Orchard.WebApi;
 using Orchard.WebApi.Filters;
+using System.Linq;
+using System.Web.Configuration;
 
 namespace Orchard.Environment {
     public static class OrchardStarter {
@@ -100,11 +102,11 @@ namespace Orchard.Environment {
                         {
                             builder.RegisterType<ExtensionHarvester>().As<IExtensionHarvester>().SingleInstance();
                             builder.RegisterType<ModuleFolders>().As<IExtensionFolders>().SingleInstance()
-                                .WithParameter(new NamedParameter("paths", new[] { "~/Modules" }));
+                                .WithParameter(new NamedParameter("paths", GetPaths("Modules", "~/Modules" )));
                             builder.RegisterType<CoreModuleFolders>().As<IExtensionFolders>().SingleInstance()
                                 .WithParameter(new NamedParameter("paths", new[] { "~/Core" }));
                             builder.RegisterType<ThemeFolders>().As<IExtensionFolders>().SingleInstance()
-                                .WithParameter(new NamedParameter("paths", new[] { "~/Themes" }));
+                                .WithParameter(new NamedParameter("paths", GetPaths("Themes", "~/Themes" )));
 
                             builder.RegisterType<CoreExtensionLoader>().As<IExtensionLoader>().SingleInstance();
                             builder.RegisterType<ReferencedExtensionLoader>().As<IExtensionLoader>().SingleInstance();
@@ -172,6 +174,16 @@ namespace Orchard.Environment {
             ModelValidatorProviders.Providers.Add(new LocalizedModelValidatorProvider());
 
             return container;
+        }
+
+        /// <summary>
+        /// Get list of comma separated paths from web.config appSettings
+        /// Also return the default path
+        /// </summary>
+        static IEnumerable<string> GetPaths(string key, string defaultPath)
+        {
+            char[] delim = new char[]{','};
+            return (WebConfigurationManager.AppSettings[key] ?? "").Split(delim, StringSplitOptions.RemoveEmptyEntries).Concat(new string[]{defaultPath}).Select(s => s.Trim()).Distinct();
         }
 
 


### PR DESCRIPTION
Should resolve  #5019,  #5241,  #5354 

Additional comma separated lists can be defined in web.config (example included).
Default is added to the list in any case.
Includes trimming, should ignore empty strings and duplicates.

