### PR TITLE
Abstract active layer evaluation away from the Widget Filter

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Widgets/Filters/WidgetFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Filters/WidgetFilter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Linq;
 using System.Web.Mvc;
 using Orchard.ContentManagement;
 using Orchard.ContentManagement.Aspects;
@@ -9,25 +8,24 @@ using Orchard.Logging;
 using Orchard.Mvc.Filters;
 using Orchard.Themes;
 using Orchard.UI.Admin;
-using Orchard.Widgets.Models;
 using Orchard.Widgets.Services;
 
 namespace Orchard.Widgets.Filters {
     public class WidgetFilter : FilterProvider, IResultFilter {
         private readonly IWorkContextAccessor _workContextAccessor;
-        private readonly IRuleManager _ruleManager;
         private readonly IWidgetsService _widgetsService;
         private readonly IOrchardServices _orchardServices;
+        private readonly ILayerEvaluationService _layerEvaluationService;
 
         public WidgetFilter(
-            IWorkContextAccessor workContextAccessor, 
-            IRuleManager ruleManager, 
+            IWorkContextAccessor workContextAccessor,
             IWidgetsService widgetsService,
-            IOrchardServices orchardServices) {
+            IOrchardServices orchardServices,
+            ILayerEvaluationService layerEvaluationService) {
             _workContextAccessor = workContextAccessor;
-            _ruleManager = ruleManager;
             _widgetsService = widgetsService;
             _orchardServices = orchardServices;
+            _layerEvaluationService = layerEvaluationService;
             Logger = NullLogger.Instance;
             T = NullLocalizer.Instance;
         }
@@ -51,25 +49,7 @@ namespace Orchard.Widgets.Filters {
                 return;
             }
 
-            // Once the Rule Engine is done:
-            // Get Layers and filter by zone and rule
-            // NOTE: .ForType("Layer") is faster than .Query<LayerPart, LayerPartRecord>()
-            IEnumerable<LayerPart> activeLayers = _orchardServices.ContentManager.Query<LayerPart>().ForType("Layer").List();
-
-            var activeLayerIds = new List<int>();
-            foreach (var activeLayer in activeLayers) {
-                // ignore the rule if it fails to execute
-                try {
-                    if (_ruleManager.Matches(activeLayer.LayerRule)) {
-                        activeLayerIds.Add(activeLayer.ContentItem.Id);
-                    }
-                }
-                catch(Exception e) {
-                    Logger.Warning(e, T("An error occured during layer evaluation on: {0}", activeLayer.Name).Text);
-                }
-            }
-
-            IEnumerable<WidgetPart> widgetParts = _widgetsService.GetWidgets(layerIds: activeLayerIds.ToArray());
+            var widgetParts = _widgetsService.GetWidgets(_layerEvaluationService.GetActiveLayerIds().ToArray());
 
             // Build and add shape to zone.
             var zones = workContext.Layout.Zones;

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
@@ -90,6 +90,8 @@
     <Compile Include="RuleEngine\ContentDisplayedRuleProvider.cs" />
     <Compile Include="RuleEngine\RuleManager.cs" />
     <Compile Include="RuleEngine\UrlRuleProvider.cs" />
+    <Compile Include="Services\DefaultLayerEvaluationService.cs" />
+    <Compile Include="Services\ILayerEvaluationService.cs" />
     <Compile Include="Services\IRuleManager.cs" />
     <Compile Include="Services\IRuleProvider.cs" />
     <Compile Include="Services\IWidgetsService.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Widgets/RuleEngine/RuleManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/RuleEngine/RuleManager.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using Orchard.Localization;
 using Orchard.Scripting;
 using Orchard.Widgets.Services;
@@ -21,7 +20,7 @@ namespace Orchard.Widgets.RuleEngine {
         public bool Matches(string expression) {
             var evaluator = _evaluators.FirstOrDefault();
             if (evaluator == null) {
-                throw new OrchardException(T("There are currently not scripting engine enabled"));
+                throw new OrchardException(T("There are currently no scripting engines enabled"));
             }
 
             var result = evaluator.Evaluate(expression, new List<IGlobalMethodProvider> { new GlobalMethodProvider(this) });

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
@@ -21,6 +21,12 @@ namespace Orchard.Widgets.Services{
         public ILogger Logger { get; set; }
         public Localizer T { get; private set; }
 
+        /// <summary>
+        /// Retrieves every Layer from the Content Manager and evaluates each one.
+        /// </summary>
+        /// <returns>
+        /// A collection of integers that represents the Ids of each active Layer
+        /// </returns>
         public IEnumerable<int> GetActiveLayerIds(){
             // Once the Rule Engine is done:
             // Get Layers and filter by zone and rule

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
@@ -21,7 +21,7 @@ namespace Orchard.Widgets.Services{
         public ILogger Logger { get; set; }
         public Localizer T { get; private set; }
 
-        public IEnumerable<int> GetActiveLayerIds()        {
+        public IEnumerable<int> GetActiveLayerIds(){
             // Once the Rule Engine is done:
             // Get Layers and filter by zone and rule
             // NOTE: .ForType("Layer") is faster than .Query<LayerPart, LayerPartRecord>()

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using Orchard.Localization;
+using Orchard.Logging;
+using Orchard.Widgets.Models;
+using Orchard.ContentManagement;
+
+namespace Orchard.Widgets.Services{
+    public class DefaultLayerEvaluationService : ILayerEvaluationService {
+        private readonly IRuleManager _ruleManager;
+        private readonly IOrchardServices _orchardServices;
+
+        public DefaultLayerEvaluationService(IRuleManager ruleManager, IOrchardServices orchardServices) {
+            _ruleManager = ruleManager;
+            _orchardServices = orchardServices;
+
+            Logger = NullLogger.Instance;
+            T = NullLocalizer.Instance;
+        }
+
+        public ILogger Logger { get; set; }
+        public Localizer T { get; private set; }
+
+        public IEnumerable<int> GetActiveLayerIds()
+        {
+            // Once the Rule Engine is done:
+            // Get Layers and filter by zone and rule
+            // NOTE: .ForType("Layer") is faster than .Query<LayerPart, LayerPartRecord>()
+            var activeLayers = _orchardServices.ContentManager.Query<LayerPart>().ForType("Layer").List();
+
+            var activeLayerIds = new List<int>();
+            foreach (var activeLayer in activeLayers)
+            {
+                // ignore the rule if it fails to execute
+                try
+                {
+                    if (_ruleManager.Matches(activeLayer.LayerRule))
+                    {
+                        activeLayerIds.Add(activeLayer.ContentItem.Id);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.Warning(e, T("An error occured during layer evaluation on: {0}", activeLayer.Name).Text);
+                }
+            }
+
+            return activeLayerIds;
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
@@ -21,27 +21,22 @@ namespace Orchard.Widgets.Services{
         public ILogger Logger { get; set; }
         public Localizer T { get; private set; }
 
-        public IEnumerable<int> GetActiveLayerIds()
-        {
+        public IEnumerable<int> GetActiveLayerIds()        {
             // Once the Rule Engine is done:
             // Get Layers and filter by zone and rule
             // NOTE: .ForType("Layer") is faster than .Query<LayerPart, LayerPartRecord>()
             var activeLayers = _orchardServices.ContentManager.Query<LayerPart>().ForType("Layer").List();
 
             var activeLayerIds = new List<int>();
-            foreach (var activeLayer in activeLayers)
-            {
+            foreach (var activeLayer in activeLayers){
                 // ignore the rule if it fails to execute
-                try
-                {
-                    if (_ruleManager.Matches(activeLayer.LayerRule))
-                    {
+                try{
+                    if (_ruleManager.Matches(activeLayer.LayerRule)){
                         activeLayerIds.Add(activeLayer.ContentItem.Id);
                     }
                 }
-                catch (Exception e)
-                {
-                    Logger.Warning(e, T("An error occured during layer evaluation on: {0}", activeLayer.Name).Text);
+                catch (Exception e){
+                    Logger.Warning(e, T("An error occurred during layer evaluation on: {0}", activeLayer.Name).Text);
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/ILayerEvaluationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/ILayerEvaluationService.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace Orchard.Widgets.Services
+{
+    public interface ILayerEvaluationService : IDependency {
+        IEnumerable<int> GetActiveLayerIds();
+    }
+}


### PR DESCRIPTION
As it is, the `WidgetFilter` is very bloated.

This pull requests adds no new functionality, but instead abstracts the layer evaluation logic away from the `WidgetFilter`.

This allows developers to override the default functionality for retrieving/ evaluating layers during a request, without the need to override the entire widget filter. 

This would be useful in the following cases:
* To create an implementation that logged to Glimpse
* To create an implementation that took the layer rules from a cache (a major performance gain on a site with several layers)
* To create an implementation that would evaluate each layer only once per request, no matter how many times the call the get the active layers was made (for example to create an output cache key etc...)

Work Item: https://github.com/OrchardCMS/Orchard/issues/5356