### PR TITLE
Fix Layout element localization

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Services/ElementFactory.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Services/ElementFactory.cs
@@ -15,6 +15,8 @@ namespace Orchard.Layouts.Services {
 
         public Element Activate(Type elementType, Action<Element> initialize = null) {
             var element = (Element)Activator.CreateInstance(elementType);
+            
+            element.T = T;
 
             if (initialize != null)
                 initialize(element);
@@ -24,6 +26,8 @@ namespace Orchard.Layouts.Services {
 
         public T Activate<T>(Action<T> initialize = null) where T : Element {
             var element = (T)Activator.CreateInstance(typeof(T));
+
+            element.T = this.T;
 
             if (initialize != null)
                 initialize(element);


### PR DESCRIPTION
The ElementFactory does not always initialize the localizer of the
Element objects which causes the elements to end up with the
NullLocalizer.

This solution still has a major issue - the context of the localized
strings is wrong. It should be the source file in which the element
is defined, not "Orchard.Layouts.Services.ElementFactory".