### PR TITLE
Fixed Azure Storage Assembly binding version

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Web.config
@@ -74,8 +74,8 @@
                 <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
             </dependentAssembly>
             <dependentAssembly>
-                <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0"/>
+                <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
             </dependentAssembly>
         </assemblyBinding>
     </runtime>


### PR DESCRIPTION
Azure Storage assembly binding should point to 4.3.0, not 3.1.0