### PR TITLE
Issue #5061 GetImageProfileUrl reprocess images obtained through a dynamic profile on every restart

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Views/DefinitionTemplates/AuditTrailPartSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Views/DefinitionTemplates/AuditTrailPartSettings.cshtml
@@ -17,6 +17,6 @@
     <div>
         @Html.CheckBoxFor(m => m.ShowAuditTrailCommentInput)
         @Html.LabelFor(m => m.ShowAuditTrailCommentInput, T("Show comment input").Text, new { @class = "forcheckbox" })
-        <span class="hint">@T("Renders a text field to allow the user to enter a comment about the changes he made.")</span>
+        <span class="hint">@T("Renders a text field to allow the user to enter a comment about the changes they made.")</span>
     </div>
 </fieldset>

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
@@ -64,6 +64,18 @@ namespace Orchard.MediaProcessing.Services {
             var filePath = _fileNameProvider.GetFileName(profileName, System.Web.HttpUtility.UrlDecode(path));
             bool process = false;
 
+            //after reboot the app cache is empty so we reload the image in the cache if it exists in the _Profiles folder
+            if (string.IsNullOrEmpty(filePath))
+            {
+                var filterContext = new FilterContext { FilePath = _storageProvider.Combine("_Profiles", FormatProfilePath(profileName, System.Web.HttpUtility.UrlDecode(path))) };
+
+                if (_storageProvider.FileExists(filterContext.FilePath))
+                {
+                    _fileNameProvider.UpdateFileName(profileName, System.Web.HttpUtility.UrlDecode(path), filterContext.FilePath);
+                    filePath = _fileNameProvider.GetFileName(profileName, path);
+                }
+            }
+            
             // if the filename is not cached, process it
             if (string.IsNullOrEmpty(filePath)) {
                 Logger.Debug("FilePath is null, processing required, profile {0} for image {1}", profileName, path);

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
@@ -65,14 +65,12 @@ namespace Orchard.MediaProcessing.Services {
             bool process = false;
 
             //after reboot the app cache is empty so we reload the image in the cache if it exists in the _Profiles folder
-            if (string.IsNullOrEmpty(filePath))
-            {
-                var filterContext = new FilterContext { FilePath = _storageProvider.Combine("_Profiles", FormatProfilePath(profileName, System.Web.HttpUtility.UrlDecode(path))) };
+            if (string.IsNullOrEmpty(filePath)) {
+                var profileFilePath = _storageProvider.Combine("_Profiles", FormatProfilePath(profileName, System.Web.HttpUtility.UrlDecode(path)));
 
-                if (_storageProvider.FileExists(filterContext.FilePath))
-                {
-                    _fileNameProvider.UpdateFileName(profileName, System.Web.HttpUtility.UrlDecode(path), filterContext.FilePath);
-                    filePath = _fileNameProvider.GetFileName(profileName, path);
+                if (_storageProvider.FileExists(profileFilePath)) {
+                    _fileNameProvider.UpdateFileName(profileName, System.Web.HttpUtility.UrlDecode(path), profileFilePath);
+                    filePath = profileFilePath;
                 }
             }
             


### PR DESCRIPTION
Image cache is empty after every reboot of the Orchard app. It makes Dynamic ImageProfiles reprocess images after every reboot. It has a big impact on performance because all the images that use dynamic profiles are reprocessed when they are requested after a reboot. When you open a page with a number of images disk usage increases drammatically and the app answer very slow to other requests.

Related with issue https://github.com/OrchardCMS/Orchard/issues/5061