### PR TITLE
Fix moderator notification

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
@@ -117,7 +117,7 @@ namespace Orchard.Users.Services {
                         var parameters = new Dictionary<string, object> {
                             {"Subject", T("New account").Text},
                             {"Body", _shapeDisplay.Display(template)},
-                            {"Recipients", new [] { recipient.Email }}
+                            {"Recipients", recipient.Email }
                         };
 
                         _messageService.Send("Email", parameters);


### PR DESCRIPTION
`Orchard.Email.Services.SmtpMessageChannel.Process` expects a string for Recipients, not a string array. This results in an *Object reference not set to an instance of an object* exception and the moderator(s) do not get notified. Fixes #4928.