### PR TITLE
Issue #5432 Differentiator is ignored processing placement

### DIFF
--- a/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
+++ b/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
@@ -110,7 +110,6 @@ namespace Orchard.DisplayManagement.Descriptors.ShapePlacementStrategy {
         private void GetShapeType(PlacementShapeLocation shapeLocation, out string shapeType, out string differentiator) {
             differentiator = "";
             shapeType = shapeLocation.ShapeType;
-            var dashIndex = shapeType.LastIndexOf('-');
             var dashIndex = shapeType.LastIndexOf("__");
             if (dashIndex > 0 && dashIndex < shapeType.Length - 2) {
                 differentiator = shapeType.Substring(dashIndex + 2);

--- a/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
+++ b/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
@@ -111,8 +111,9 @@ namespace Orchard.DisplayManagement.Descriptors.ShapePlacementStrategy {
             differentiator = "";
             shapeType = shapeLocation.ShapeType;
             var dashIndex = shapeType.LastIndexOf('-');
-            if (dashIndex > 0 && dashIndex < shapeType.Length - 1) {
-                differentiator = shapeType.Substring(dashIndex + 1);
+            var dashIndex = shapeType.LastIndexOf("__");
+            if (dashIndex > 0 && dashIndex < shapeType.Length - 2) {
+                differentiator = shapeType.Substring(dashIndex + 2);
                 shapeType = shapeType.Substring(0, dashIndex);
             }
         }

--- a/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
+++ b/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
@@ -107,13 +107,24 @@ namespace Orchard.DisplayManagement.Descriptors.ShapePlacementStrategy {
             }
         }
 
-        private void GetShapeType(PlacementShapeLocation shapeLocation, out string shapeType, out string differentiator) {
+        private void GetShapeType(PlacementShapeLocation shapeLocation, out string shapeType, out string differentiator)
+        {
             differentiator = "";
             shapeType = shapeLocation.ShapeType;
-            var dashIndex = shapeType.LastIndexOf("__");
-            if (dashIndex > 0 && dashIndex < shapeType.Length - 2) {
-                differentiator = shapeType.Substring(dashIndex + 2);
-                shapeType = shapeType.Substring(0, dashIndex);
+            var separatorLengh = 2;
+            var separatorIndex = shapeType.LastIndexOf("__");
+
+            var dashIndex = shapeType.LastIndexOf('-');
+            if (dashIndex > separatorIndex)
+            {
+                separatorIndex = dashIndex;
+                separatorLengh = 1;
+            }
+
+            if (separatorIndex > 0 && separatorIndex < shapeType.Length - separatorLengh)
+            {
+                differentiator = shapeType.Substring(separatorIndex + separatorLengh);
+                shapeType = shapeType.Substring(0, separatorIndex);
             }
         }
 

--- a/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
+++ b/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
@@ -107,22 +107,19 @@ namespace Orchard.DisplayManagement.Descriptors.ShapePlacementStrategy {
             }
         }
 
-        private void GetShapeType(PlacementShapeLocation shapeLocation, out string shapeType, out string differentiator)
-        {
+        private void GetShapeType(PlacementShapeLocation shapeLocation, out string shapeType, out string differentiator) {
             differentiator = "";
             shapeType = shapeLocation.ShapeType;
             var separatorLengh = 2;
             var separatorIndex = shapeType.LastIndexOf("__");
 
             var dashIndex = shapeType.LastIndexOf('-');
-            if (dashIndex > separatorIndex)
-            {
+            if (dashIndex > separatorIndex) {
                 separatorIndex = dashIndex;
                 separatorLengh = 1;
             }
 
-            if (separatorIndex > 0 && separatorIndex < shapeType.Length - separatorLengh)
-            {
+            if (separatorIndex > 0 && separatorIndex < shapeType.Length - separatorLengh) {
                 differentiator = shapeType.Substring(separatorIndex + separatorLengh);
                 shapeType = shapeType.Substring(0, separatorIndex);
             }


### PR DESCRIPTION
In placement files shapeType uses "__" intead of '-' char for declaring a differenciator. The point is second one is used only in template files as can be seen in documentation http://docs.orchardproject.net/Documentation/Accessing-and-rendering-shapes#NamingShapesandTemplates
However GetShapeType looks for '-' character ignoring placements for a ShapeType with a differentiator. This produces strange behaviors and a lot of headaches to users because when they set for example: ```<Place Fields_Common_Text__SeoTitle="/Header:0"/>```  in a placement file it forces all Fields_Common_Text shapes within the same Match to be rendered at Header:0 area instead of only affecting those with the SeoTitle differentiator.

Related to this issue https://github.com/OrchardCMS/Orchard/issues/5432