### PR TITLE
Fixed the sample of PostgreSQL's connection string

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Setup/Views/Setup/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Setup/Views/Setup/Index.cshtml
@@ -60,7 +60,7 @@ if (!Model.DatabaseIsPreconfigured) {
         </span>
 
         <span data-controllerid="postgresql" class="hint databaseTypeHint">
-            @T("Server=serverName;Port=5432;Encoding=UNICODE;Database=dbName;User Id=userName;Password=password")
+            @T("Server=serverName;Port=5432;Database=dbName;User Id=userName;Password=password")
         </span>
 
         <br /><br />


### PR DESCRIPTION
The parameter "ENCODING" has been obsoleted by newest Npgsql driver.

Reference:
https://github.com/npgsql/npgsql/wiki/User-Manual