### PR TITLE
Fixed the items count in media library when modify the item size in css

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Scripts/media-library.js
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Scripts/media-library.js
@@ -71,11 +71,12 @@ $(function () {
 
         var listWidth = $('#media-library-main-list').width();
         var listHeight = $('#media-library-main-list').height();
-        var itemSize = $('.thumbnail').first().width();
+        var itemWidth = $('.thumbnail').first().width();
+        var itemHeight = $('.thumbnail').first().height();
         var draftText = $("#media-library").data("draft-text");
 
-        var itemsPerRow = Math.floor(listWidth / itemSize);
-        var itemsPerColumn = Math.ceil(listHeight / itemSize);
+        var itemsPerRow = Math.floor(listWidth / itemWidth);
+        var itemsPerColumn = Math.ceil(listHeight / itemHeight);
 
         var pageCount = itemsPerRow * itemsPerColumn;
 


### PR DESCRIPTION
Item shape is square in the media library. If item height in orchard-medialibrary-admin.css modified and smaller than item width, the count of items will be wrong. This work fixed the issue.