### PR TITLE
Fix for duplicate version number on creating a new draft

### DIFF
--- a/src/Orchard.Tests/ContentManagement/DefaultContentManagerTests.cs
+++ b/src/Orchard.Tests/ContentManagement/DefaultContentManagerTests.cs
@@ -472,6 +472,46 @@ namespace Orchard.Tests.ContentManagement {
         }
 
         [Test]
+        public void DraftRequiredShouldAlwaysBuildNewVersionFromPublishedIfDraftNotFound()
+        {
+            Trace.WriteLine("gamma1");
+            var gamma1 = _manager.Create(DefaultGammaName, VersionOptions.Published);
+            Trace.WriteLine("flush");
+            _session.Flush();
+            _session.Clear();
+
+            Trace.WriteLine("gammaDraft1");
+            var gammaDraft1 = _manager.Get(gamma1.Id, VersionOptions.DraftRequired);
+            Assert.That(gammaDraft1.Version, Is.EqualTo(2));
+            Trace.WriteLine("flush");
+            _session.Flush();
+            _session.Clear();
+
+            Trace.WriteLine("Delete gammaDraft1");
+            var gammaDraft2 = _manager.Get(gammaDraft1.Id, VersionOptions.Draft);
+            gammaDraft2.VersionRecord.Latest = false;
+
+            Trace.WriteLine("Restore gamma1 as Latest");
+            var gamma2 = _manager.Get(gamma1.Id, VersionOptions.Published);
+            var publishedVersion = gamma2.Record.Versions.SingleOrDefault(x => x.Published);
+            if (publishedVersion != null)
+            {
+                publishedVersion.Latest = true;
+            }
+            Trace.WriteLine("flush");
+            _session.Flush();
+            _session.Clear();
+
+            Trace.WriteLine("gammaDraft3");
+            var gammaDraft3 = _manager.Get(gamma1.Id, VersionOptions.DraftRequired);
+            Assert.That(gammaDraft3.Version, Is.EqualTo(3));
+            Assert.That(gammaDraft3.Record, Is.Not.SameAs(gammaDraft2.Record));
+            Trace.WriteLine("flush");
+            _session.Flush();
+            _session.Clear();
+        }
+
+        [Test]
         public void UsingGetManyDraftRequiredShouldBuildNewVersionIfLatestIsAlreadyPublished() {
             Trace.WriteLine("gamma1");
             var gamma1 = _manager.Create(DefaultGammaName, VersionOptions.Published);

--- a/src/Orchard/ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard/ContentManagement/DefaultContentManager.cs
@@ -481,11 +481,13 @@ namespace Orchard.ContentManagement {
 
             if (latestVersion != null) {
                 latestVersion.Latest = false;
-                buildingItemVersionRecord.Number = latestVersion.Number + 1;
+                //buildingItemVersionRecord.Number = latestVersion.Number + 1;
             }
-            else {
-                buildingItemVersionRecord.Number = contentItemRecord.Versions.Max(x => x.Number) + 1;
-            }
+            //else {
+            //    buildingItemVersionRecord.Number = contentItemRecord.Versions.Max(x => x.Number) + 1;
+            //}
+            ////The new version should always be the next highest available number.
+            buildingItemVersionRecord.Number = contentItemRecord.Versions.Max(x => x.Number) + 1;
 
             contentItemRecord.Versions.Add(buildingItemVersionRecord);
             _contentItemVersionRepository.Create(buildingItemVersionRecord);

--- a/src/Orchard/ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard/ContentManagement/DefaultContentManager.cs
@@ -481,11 +481,7 @@ namespace Orchard.ContentManagement {
 
             if (latestVersion != null) {
                 latestVersion.Latest = false;
-                //buildingItemVersionRecord.Number = latestVersion.Number + 1;
             }
-            //else {
-            //    buildingItemVersionRecord.Number = contentItemRecord.Versions.Max(x => x.Number) + 1;
-            //}
             ////The new version should always be the next highest available number.
             buildingItemVersionRecord.Number = contentItemRecord.Versions.Max(x => x.Number) + 1;
 


### PR DESCRIPTION
The new version should always be contentItemRecord.Versions.Max(x => x.Number) + 1; not latestVersion.Number + 1;

I have a scenario where user can delete the draft content. In this scenario, I set the published version to have Latest=true and the draft version to have Latest=false. Now if I have to create again a new draft(by using ContentManager.Get(id, VersionOptions.DraftRequired);) out of the published content, I end up having two versions of the same content items with the same version number.