### PR TITLE
Redis Module: Added connection string warning to description

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MultiTenancy/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MultiTenancy/Views/Admin/Edit.cshtml
@@ -23,7 +23,7 @@
         <div>
             <label for="@Html.FieldIdFor(m => m.RequestUrlPrefix)">@T("URL prefix")</label>
             @Html.TextBoxFor(m => m.RequestUrlPrefix, new { @class = "text medium" })
-            <span class="hint">@T("(Optional) Example: If prefix is \"site1\", the tenant URL prefix is \"http://orchardproject.net/site1\"")</span>
+            <span class="hint">@T("(Optional) Example: If prefix is \"site1\", the tenant URL prefix is \"http://orchardproject.net/site1/\"")</span>
         </div>    
     </fieldset>
     <fieldset>

--- a/src/Orchard.Web/Modules/Orchard.Redis/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.Redis/Module.txt
@@ -12,12 +12,12 @@ Features:
         Category: Hosting
     Orchard.Redis.MessageBus:
         Name: Redis Message Bus
-        Description: A message bus implementation using Redis pub/sub.
+        Description: A message bus implementation using Redis pub/sub. Requires a connection string for key "Orchard.Redis.MessageBus".
         Category: Hosting
         Dependencies: Orchard.MessageBus, Orchard.Redis
     Orchard.Redis.OutputCache:
         Name: Redis Output Cache
-        Description: An output cache storage provider using Redis.
+        Description: An output cache storage provider using Redis. Requires a connection string for key "Orchard.Redis.OutputCache".
         Category: Performance
         Dependencies: Orchard.OutputCache, Orchard.Redis
     Orchard.Redis.Caching:


### PR DESCRIPTION
Without the connection string, enabling this module can crash the site.  Added a statement to the description regarding this.