### PR TITLE
Added mimetype declarations to root web.config

### DIFF
--- a/src/Orchard.Web/Web.config
+++ b/src/Orchard.Web/Web.config
@@ -119,6 +119,14 @@
                 <requestLimits maxAllowedContentLength="67108864"/>
             </requestFiltering>
         </security>
+		<staticContent>
+			<remove fileExtension=".woff" />
+			<mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+			<remove fileExtension=".js" />
+			<mimeMap fileExtension=".js" mimeType="text/javascript" />
+			<remove fileExtension=".svg" />
+			<mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+		</staticContent>
     </system.webServer>
     
     <runtime>


### PR DESCRIPTION
I'm not sure that this is something that we want to include globally, but I have had some issues with the following mime maps on Azure.
Specifically, SVG files getting returned as binary, breaking embeds in media library, editors and UI (front and admin).

This may also be directly related to storing media files in azure blob storage (and setting the mimetype when uploading files to blob storage)