### PR TITLE
Fixes #5398 - ShellDescriptorCache in HostComponents

### DIFF
--- a/src/Orchard.Web/Config/HostComponents.config
+++ b/src/Orchard.Web/Config/HostComponents.config
@@ -87,6 +87,13 @@
                 <Property Name="Disabled" Value="false"/>
             </Properties>
         </Component>
+        
+        <Component Type="Orchard.Environment.Descriptor.ShellDescriptorCache">
+            <Properties>
+                <!-- Set Value="true" to disable shell descriptors cache (cache.dat). Recommended when using multiple instances. -->
+                <Property Name="Disabled" Value="false"/>
+            </Properties>
+        </Component>
 
         <Component Type="Orchard.Services.ClientAddressAccessor">
             <Properties>


### PR DESCRIPTION
Added Orchard.Environment.Descriptor.ShellDescriptorCache setting back to HostComponents.config. For some reason, this was removed at some point but I believe it needs to be there for Azure Web Apps deployments (when running with a shared file system and multiple instances).  We were getting instances that would crash when trying to access the locked cache.dat file.

Original commit by @sebastienros
https://github.com/OrchardCMS/Orchard/commit/a2d91796d14b9aa0b7fb1ae97037c9d843680acd

Commit that removed this setting:
https://github.com/OrchardCMS/Orchard/commit/e5d89ea1fbd4bedf574c85ff8d7a8c21513b5d5e
