### PR TITLE
Delete the CamelFriendly function call to DisplayName.

### DIFF
--- a/src/Orchard.Web/Core/Navigation/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Core/Navigation/Views/Admin/Index.cshtml
@@ -59,7 +59,7 @@
             <ul class="menu-items-zone">
                 @foreach (var descriptor in Model.MenuItemDescriptors.OrderBy(x => x.DisplayName)) {
                     <li>
-                        <div class="menu-item-description"><h2>@T(descriptor.DisplayName.CamelFriendly())</h2>
+                        <div class="menu-item-description"><h2>@T(descriptor.DisplayName)</h2>
                             @if (!string.IsNullOrWhiteSpace(descriptor.Description)) {
                                 <span class="hint">@T(descriptor.Description)</span>
                             }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.Autocomplete.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.Autocomplete.cshtml
@@ -30,7 +30,7 @@
     var selectedTerms = Newtonsoft.Json.JsonConvert.SerializeObject(Model.Terms.Where(x => x.IsChecked).Select(x => new { label = x.Name, value = x.Id, levels = 0, disabled = true }));
 }
 <fieldset class="taxonomy-wrapper" data-name-prefix="@Html.FieldNameFor(m => m)" data-id-prefix="@Html.FieldIdFor(m => m)">
-    <legend @if(Model.Settings.Required) { <text>class="required"</text> }>@Model.DisplayName.CamelFriendly()</legend>
+    <legend @if(Model.Settings.Required) { <text>class="required"</text> }>@Model.DisplayName</legend>
     @if (Model.Settings.Autocomplete) {
     <div class="terms-editor" data-all-terms="@allTerms" data-selected-terms="@selectedTerms" data-allow-new-terms="@Model.Settings.AllowCustomTerms.ToString().ToLower()" data-singlechoice="@Model.Settings.SingleChoice.ToString().ToLower()">
         <ul></ul>
@@ -69,7 +69,7 @@
             
     @if (!Model.Terms.Any()) {
     <div class="no-terms">
-        @T("There are no terms defined for {0} yet.", Model.DisplayName.CamelFriendly())
+        @T("There are no terms defined for {0} yet.", Model.DisplayName)
         <a href="@Url.Action("Index", "TermAdmin", new { taxonomyId = Model.TaxonomyId, area = "Orchard.Taxonomies" })">@T("Create some terms")</a>
     </div>        
     }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.cshtml
@@ -14,7 +14,7 @@
 }
 
 <fieldset class="taxonomy-wrapper" data-name-prefix="@Html.FieldNameFor(m => m)" data-id-prefix="@Html.FieldIdFor(m => m)">
-    <legend @if(settings.Required) { <text>class="required"</text> }>@Model.DisplayName.CamelFriendly()</legend>
+    <legend @if(settings.Required) { <text>class="required"</text> }>@Model.DisplayName</legend>
     
     <div class="expando">
         @if (!String.IsNullOrWhiteSpace(Model.Settings.Hint))
@@ -45,7 +45,7 @@
             
         @if (!Model.Terms.Any()) {
             <div class="no-terms">
-                @T("There are no terms defined for {0} yet.", Model.DisplayName.CamelFriendly())
+                @T("There are no terms defined for {0} yet.", Model.DisplayName)
                 <a href="@Url.Action("Index", "TermAdmin", new { taxonomyId = Model.TaxonomyId, area = "Orchard.Taxonomies" })">@T("Create some terms")</a>
             </div>        
         }


### PR DESCRIPTION
The CamelFriendly function is designed for Technical Name. The
DisplayName needs to be displayed as it is.