### PR TITLE
fixes #5031, fixes #5312, fixes #5394; Widget translation.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Widgets/Drivers/WidgetPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Drivers/WidgetPartDriver.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Orchard.ContentManagement;
+using Orchard.ContentManagement.Aspects;
 using Orchard.ContentManagement.Drivers;
 using Orchard.Localization;
 using Orchard.Utility.Extensions;
@@ -34,7 +35,7 @@ namespace Orchard.Widgets.Drivers {
             widgetPart.AvailableLayers = _widgetsService.GetLayers();
 
             if (widgetPart.LayerPart == null) {
-                Localization.Models.LocalizationPart localizationPart = widgetPart.ContentItem.Parts.Where(x => x.PartDefinition.Name == "LocalizationPart").FirstOrDefault() as Localization.Models.LocalizationPart;
+                var localizationPart = widgetPart.As<ILocalizableAspect>();
                 ContentItem masterContentItem = localizationPart.MasterContentItem as ContentItem;
                 WidgetPart masterWidgetPart = masterContentItem.Parts.Where(x => x.PartDefinition.Name == "WidgetPart").FirstOrDefault() as WidgetPart;
                 widgetPart.LayerPart = masterWidgetPart.LayerPart;

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
@@ -129,10 +129,6 @@
       <Name>Orchard.Framework</Name>
       <Private>True</Private>
     </ProjectReference>
-    <ProjectReference Include="..\Orchard.Localization\Orchard.Localization.csproj">
-      <Project>{fbc8b571-ed50-49d8-8d9d-64ab7454a0d6}</Project>
-      <Name>Orchard.Localization</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Orchard.Scripting\Orchard.Scripting.csproj">
       <Project>{99002B65-86F7-415E-BF4A-381AA8AB9CCC}</Project>
       <Name>Orchard.Scripting</Name>

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
@@ -26,6 +26,7 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <TargetFrameworkProfile />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -127,6 +128,10 @@
       <Project>{2D1D92BB-4555-4CBE-8D0E-63563D6CE4C6}</Project>
       <Name>Orchard.Framework</Name>
       <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Orchard.Localization\Orchard.Localization.csproj">
+      <Project>{fbc8b571-ed50-49d8-8d9d-64ab7454a0d6}</Project>
+      <Name>Orchard.Localization</Name>
     </ProjectReference>
     <ProjectReference Include="..\Orchard.Scripting\Orchard.Scripting.csproj">
       <Project>{99002B65-86F7-415E-BF4A-381AA8AB9CCC}</Project>

--- a/src/Orchard/ContentManagement/Aspects/ILocalizableAspect.cs
+++ b/src/Orchard/ContentManagement/Aspects/ILocalizableAspect.cs
@@ -1,5 +1,6 @@
 ﻿namespace Orchard.ContentManagement.Aspects {
     public interface ILocalizableAspect : IContent {
         string Culture { get ; }
+        IContent MasterContentItem { get; }
     }
 }


### PR DESCRIPTION
This is for fixing the bug that happens when trying to translate a widget. It seems that the MasterContentItem values we're not passed to the Widget that we want to translate. So this, adds the same LayerId and Zone values of the MasterContentItem to the Widget we are translating.