### PR TITLE
Hint correction for trailing '/' in url prefix

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MultiTenancy/Views/Admin/Add.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MultiTenancy/Views/Admin/Add.cshtml
@@ -25,7 +25,7 @@
         <div>
             <label for="@Html.FieldIdFor(m => m.RequestUrlPrefix)">@T("URL prefix")</label>
             @Html.TextBoxFor(m => m.RequestUrlPrefix, new { @class = "text medium" })
-            <span class="hint">@T("(Optional) Example: If prefix is \"site1\", the tenant URL prefix is \"http://orchardproject.net/site1\"")</span>
+            <span class="hint">@T("(Optional) Example: If prefix is \"site1\", the tenant URL prefix is \"http://orchardproject.net/site1/\"")</span>
         </div>
     </fieldset>
     <fieldset>


### PR DESCRIPTION
The url prefix actually needs a trailing '/' for the tenant to get loaded.  Not including that slash in the url ends up causing a 404.  May alleviate some brief confusion.