### PR TITLE
#5512: Incorrect message of DynamicForms StringLength rule if only Maximum is specified

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/ValidationRules/StringLength.cs
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/ValidationRules/StringLength.cs
@@ -45,8 +45,10 @@ namespace Orchard.DynamicForms.ValidationRules {
 
             if(Minimum != null && Maximum != null)
                 return T("{0} must be between {1} and {2} characters long.", context.FieldName, Minimum, Maximum);
+            else if (Minimum != null)
+                return T("{0} must be at least {1} characters long.", context.FieldName, Minimum);
             
-            return T("{0} must be at least {1} characters long.", context.FieldName, Minimum);
+            return T("{0} must be at most {1} characters long.", context.FieldName, Maximum);
         }
     }
 }


### PR DESCRIPTION
Fixes #5512