### PR TITLE
#5369: Allows simple properties null checking on a dynamic ContentItem or ContentPart

### DIFF
--- a/src/Orchard.Tests/ContentManagement/DynamicContentItemTests.cs
+++ b/src/Orchard.Tests/ContentManagement/DynamicContentItemTests.cs
@@ -76,5 +76,39 @@ namespace Orchard.Tests.ContentManagement {
 
             Assert.That((object)testingPartDynamic, Is.AssignableTo<IEnumerable<ContentPart>>());
         }
+
+
+        [Test]
+        public void NullCheckingCanBeDoneOnProperties() {
+            var contentItem = new ContentItem();
+            var contentPart = new ContentPart { TypePartDefinition = new ContentTypePartDefinition(new ContentPartDefinition("FooPart"), new SettingsDictionary()) };
+            var contentField = new ContentField { PartFieldDefinition = new ContentPartFieldDefinition(new ContentFieldDefinition("FooType"), "FooField", new SettingsDictionary()) };
+
+            dynamic item = contentItem;
+            dynamic part = contentPart;
+
+            Assert.That(item.FooPart == null, Is.True);
+            Assert.That(item.FooPart != null, Is.False);
+
+            contentItem.Weld(contentPart);
+
+            Assert.That(item.FooPart == null, Is.False);
+            Assert.That(item.FooPart != null, Is.True);
+            Assert.That(item.FooPart, Is.SameAs(contentPart));
+
+            Assert.That(part.FooField == null, Is.True);
+            Assert.That(part.FooField != null, Is.False);
+            Assert.That(item.FooPart.FooField == null, Is.True);
+            Assert.That(item.FooPart.FooField != null, Is.False);
+
+            contentPart.Weld(contentField);
+
+            Assert.That(part.FooField == null, Is.False);
+            Assert.That(part.FooField != null, Is.True);
+            Assert.That(item.FooPart.FooField == null, Is.False);
+            Assert.That(item.FooPart.FooField != null, Is.True);
+            Assert.That(part.FooField, Is.SameAs(contentField));
+            Assert.That(item.FooPart.FooField, Is.SameAs(contentField));
+        }
     }
 }

--- a/src/Orchard/ContentManagement/ContentItem.cs
+++ b/src/Orchard/ContentManagement/ContentItem.cs
@@ -52,7 +52,8 @@ namespace Orchard.ContentManagement {
                         return true;
                     }
                 }
-                return false;
+                result = null;
+                return true;
             }
 
             return true;

--- a/src/Orchard/ContentManagement/ContentPart.cs
+++ b/src/Orchard/ContentManagement/ContentPart.cs
@@ -74,7 +74,8 @@ namespace Orchard.ContentManagement {
                         return true;
                     }
                 }
-                return false;
+                result = null;
+                return true;
             }
 
             return true;


### PR DESCRIPTION
Fixes #5369

Not sure we can do this, but with this changes, with a dynamic ContentItem / ContentPart (e.g got from the Model in a razor view, and not casted to the ContentItem / ContentPart types) I can use the following without throwing an exception

    if (contentItem.SomePart != null)
    if (part.SomeField != null)

Best