### PR TITLE
Correct CSS class name of MediaLibraryPickerField field

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.Summary.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.Summary.cshtml
@@ -5,11 +5,12 @@
 @{
     var field = (MediaLibraryPickerField) Model.ContentField;
     string name = field.DisplayName;
+    string techName = field.Name;
     var mediaParts = field.MediaParts;
 }
 @if (mediaParts.Any()) {
 <span class="name">@name:</span>
-<p class="media-@name.HtmlClassify()">    
+<p class="media-@techName.HtmlClassify()">    
         @foreach (var contentItem in mediaParts) {
                 @Display(BuildDisplay(contentItem, "Thumbnail"))
         }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.Summary.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.Summary.cshtml
@@ -4,13 +4,13 @@
 
 @{
     var field = (MediaLibraryPickerField) Model.ContentField;
-    string name = field.DisplayName;
-    string techName = field.Name;
+    string displayName = field.DisplayName;
+    string name = field.Name;
     var mediaParts = field.MediaParts;
 }
 @if (mediaParts.Any()) {
-<span class="name">@name:</span>
-<p class="media-@techName.HtmlClassify()">    
+<span class="name">@displayName:</span>
+<p class="media-@name.HtmlClassify()">    
         @foreach (var contentItem in mediaParts) {
                 @Display(BuildDisplay(contentItem, "Thumbnail"))
         }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.SummaryAdmin.cshtml
@@ -4,14 +4,14 @@
 
 @{
     var field = (MediaLibraryPickerField) Model.ContentField;
-    string name = field.DisplayName;
-    string techName = field.Name;
+    string displayName = field.DisplayName;
+    string name = field.Name;
     var mediaParts = field.MediaParts;
 
     var returnUrl = ViewContext.RequestContext.HttpContext.Request.ToUrlString();
 }
-<span class="name">@name:</span>
-<p class="media-library-picker-field media-library-picker-field-@techName.HtmlClassify()">
+<span class="name">@displayName:</span>
+<p class="media-library-picker-field media-library-picker-field-@name.HtmlClassify()">
     
     @if (mediaParts.Any()) {
         foreach (var contentItem in mediaParts) {

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.SummaryAdmin.cshtml
@@ -5,12 +5,13 @@
 @{
     var field = (MediaLibraryPickerField) Model.ContentField;
     string name = field.DisplayName;
+    string techName = field.Name;
     var mediaParts = field.MediaParts;
 
     var returnUrl = ViewContext.RequestContext.HttpContext.Request.ToUrlString();
 }
 <span class="name">@name:</span>
-<p class="media-library-picker-field media-library-picker-field-@name.HtmlClassify()">
+<p class="media-library-picker-field media-library-picker-field-@techName.HtmlClassify()">
     
     @if (mediaParts.Any()) {
         foreach (var contentItem in mediaParts) {

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.cshtml
@@ -4,12 +4,12 @@
 
 @{
     var field = (MediaLibraryPickerField) Model.ContentField;
-    string name = field.DisplayName;
-    string techName = field.Name;
+    string displayName = field.DisplayName;
+    string name = field.Name;
     var contents = field.MediaParts;
 }
-<section class="media-library-picker-field media-library-picker-field-@techName.HtmlClassify()">
-    <h3>@name</h3>
+<section class="media-library-picker-field media-library-picker-field-@name.HtmlClassify()">
+    <h3>@displayName</h3>
     @foreach(var content in contents) {
     <div>
         @Display(BuildDisplay(content, "Summary"))

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Fields/MediaLibraryPicker.cshtml
@@ -5,9 +5,10 @@
 @{
     var field = (MediaLibraryPickerField) Model.ContentField;
     string name = field.DisplayName;
+    string techName = field.Name;
     var contents = field.MediaParts;
 }
-<section class="media-library-picker-field media-library-picker-field-@name.HtmlClassify()">
+<section class="media-library-picker-field media-library-picker-field-@techName.HtmlClassify()">
     <h3>@name</h3>
     @foreach(var content in contents) {
     <div>


### PR DESCRIPTION
Field CSS class name should use the technical name, rather than the display name.