### PR TITLE
Remove the blank line at the bottom of every page after the default theme rendering.

### DIFF
--- a/src/Orchard.Web/Themes/TheThemeMachine/Styles/Site.css
+++ b/src/Orchard.Web/Themes/TheThemeMachine/Styles/Site.css
@@ -66,6 +66,7 @@ header, footer, aside, nav, article { display: block; }
     content: ".";
     display: block;
     height: 0;
+    font-size: 0;
     clear: both;
     visibility: hidden;
 }
@@ -75,6 +76,7 @@ header, footer, aside, nav, article { display: block; }
     content: ".";
     display: block;
     height: 0;
+    font-size: 0;
     clear: both;
     visibility: hidden;
 }


### PR DESCRIPTION
Set a background color to #layout-footer in Site.css, you can clearly see the blank line at the bottom.