### PR TITLE
Adjust the sorting method for taxonomy terms, so that the weight value is smaller in the front

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
@@ -71,7 +71,7 @@ namespace Orchard.Taxonomies.Models {
                 // if two nodes have the same parent, then compare by weight, then by path 
                 // /1/2/3 vs /1/2/4 => 3 vs 4
                 if (x.Path == y.Path) {
-                    var weight = y.Weight.CompareTo(x.Weight);
+                    var weight = x.Weight.CompareTo(y.Weight);
 
                     if (weight != 0) {
                         return weight;


### PR DESCRIPTION
Smaller in front is common, such as admin menu.
In the past, the bigger in the front is not convenient, also make trouble for people.