### PR TITLE
Issue/autoroute identity

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Drivers/AutoroutePartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Drivers/AutoroutePartDriver.cs
@@ -110,26 +110,17 @@ namespace Orchard.Autoroute.Drivers {
         }
 
         protected override void Importing(AutoroutePart part, ContentManagement.Handlers.ImportContentContext context) {
-            var displayAlias = context.Attribute(part.PartDefinition.Name, "Alias");
-            if (displayAlias != null) {
-                part.DisplayAlias = displayAlias;
-            }
-
-            var customPattern = context.Attribute(part.PartDefinition.Name, "CustomPattern");
-            if (customPattern != null) {
-                part.CustomPattern = customPattern;
-            }
-
-            var useCustomPattern = context.Attribute(part.PartDefinition.Name, "UseCustomPattern");
-            if (useCustomPattern != null) {
-                part.UseCustomPattern = bool.Parse(useCustomPattern);
-            }
+            context.ImportAttribute(part.PartDefinition.Name, "Alias", x => part.DisplayAlias = x);
+            context.ImportAttribute(part.PartDefinition.Name, "CustomPattern", x => part.CustomPattern = x);
+            context.ImportAttribute(part.PartDefinition.Name, "UseCustomPattern", x => part.UseCustomPattern = XmlHelper.Parse<bool>(x));
+            context.ImportAttribute(part.PartDefinition.Name, "Identifier", x => part.Identifier = x);
         }
 
         protected override void Exporting(AutoroutePart part, ContentManagement.Handlers.ExportContentContext context) {
             context.Element(part.PartDefinition.Name).SetAttributeValue("Alias", String.IsNullOrEmpty(part.Record.DisplayAlias) ? "/" : part.Record.DisplayAlias);
             context.Element(part.PartDefinition.Name).SetAttributeValue("CustomPattern", part.Record.CustomPattern);
             context.Element(part.PartDefinition.Name).SetAttributeValue("UseCustomPattern", part.Record.UseCustomPattern);
+            context.Element(part.PartDefinition.Name).SetAttributeValue("Identifier", part.Record.Identifier);
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Migrations.cs
@@ -8,19 +8,21 @@ namespace Orchard.Autoroute {
             SchemaBuilder.CreateTable("AutoroutePartRecord",
                 table => table
                     .ContentPartVersionRecord()
-                            .Column<string>("CustomPattern", c => c.WithLength(2048))
-                            .Column<bool>("UseCustomPattern", c=> c.WithDefault(false))
-                            .Column<string>("DisplayAlias", c => c.WithLength(2048)));
+                    .Column<string>("CustomPattern", c => c.WithLength(2048))
+                    .Column<bool>("UseCustomPattern", c=> c.WithDefault(false))
+                    .Column<string>("DisplayAlias", c => c.WithLength(2048))
+                    .Column<string>("Identifier", c => c.WithLength(256)));
 
             ContentDefinitionManager.AlterPartDefinition("AutoroutePart", part => part
                 .Attachable()
                 .WithDescription("Adds advanced url configuration options to your content type to completely customize the url pattern for a content item."));
 
-            SchemaBuilder.AlterTable("AutoroutePartRecord", table => table
-                .CreateIndex("IDX_AutoroutePartRecord_DisplayAlias", "DisplayAlias")
-            );
+            SchemaBuilder.AlterTable("AutoroutePartRecord", table => {
+                table.CreateIndex("IDX_AutoroutePartRecord_DisplayAlias", "DisplayAlias");
+                table.CreateIndex("IDX_AutoroutePartRecord_Identity", "Identity");
+            });
 
-            return 3;
+            return 4;
         }
 
         public int UpdateFrom1() {
@@ -36,6 +38,15 @@ namespace Orchard.Autoroute {
             );
 
             return 3;
+        }
+
+        public int UpdateFrom3() {
+            SchemaBuilder.AlterTable("AutoroutePartRecord", table => {
+                table.AddColumn<string>("Identifier", c => c.WithLength(256));
+                table.CreateIndex("IDX_AutoroutePartRecord_Identity", "Identifier");
+            });
+
+            return 4;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Models/AutoroutePart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Models/AutoroutePart.cs
@@ -16,6 +16,10 @@ namespace Orchard.Autoroute.Models {
             get { return Retrieve(x => x.DisplayAlias); }
             set { Store(x => x.DisplayAlias, value); }
         }
+        public string Identifier {
+            get { return Retrieve(x => x.Identifier); }
+            set { Store(x => x.Identifier, value); }
+        }
 
         public string Path {
             get { return DisplayAlias; }

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Models/AutoroutePartRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Models/AutoroutePartRecord.cs
@@ -11,5 +11,8 @@ namespace Orchard.Autoroute.Models {
         
         [StringLength(2048)]
         public virtual string DisplayAlias { get; set; }
+
+        [StringLength(256)]
+        public virtual string Identifier { get; set; }
     }
 }


### PR DESCRIPTION
This ensures a non-changing identifier for content items since it's based on a one-time generated value (GUID) rather than a changing alias.

This fixes an issue where content items seem to be duplicated when imported if the have the "/" alias.