### PR TITLE
ContainerPart renders ContainableParts using customizable display-mode

### DIFF
--- a/src/Orchard.Web/Core/Containers/Settings/ContainerSettings.cs
+++ b/src/Orchard.Web/Core/Containers/Settings/ContainerSettings.cs
@@ -94,6 +94,9 @@ namespace Orchard.Core.Containers.Settings {
         public bool RestrictItemContentTypes { get; set; }
         public bool? EnablePositioning { get; set; }
         public string AdminListViewName { get; set; }
+        public string ItemsDisplayMode { get; set; }
+        public string ContainerTag { get; set; }
+        public string ItemTag { get; set; }
     }
 
     public class ContainerSettingsHooks : ContentDefinitionEditorEventsBase {
@@ -123,7 +126,26 @@ namespace Orchard.Core.Containers.Settings {
             if (model.PaginatedDefault == null)
                 model.PaginatedDefault = partModel.PaginatedDefault;
 
-            var viewModel = new ContainerTypePartSettingsViewModel {
+            if (string.IsNullOrEmpty(model.ItemsDisplayMode))
+            {
+                model.ItemsDisplayMode = partModel.ItemsDisplayMode;
+            }
+
+            if (string.IsNullOrEmpty(model.ContainerTag))
+            {
+                model.ContainerTag = partModel.ContainerTag;
+            }
+
+            if (string.IsNullOrEmpty(model.ItemTag))
+            {
+                model.ItemTag = partModel.ItemTag;
+            }
+            
+            var viewModel = new ContainerTypePartSettingsViewModel
+            {
+                ItemTag = model.ItemTag,
+                ContainerTag = model.ContainerTag,
+                ItemsDisplayMode = model.ItemsDisplayMode,
                 ItemsShownDefault = model.ItemsShownDefault,
                 PageSizeDefault = model.PageSizeDefault,
                 PaginatedDefault = model.PaginatedDefault,
@@ -161,6 +183,9 @@ namespace Orchard.Core.Containers.Settings {
             builder.WithSetting("ContainerTypePartSettings.RestrictItemContentTypes", viewModel.RestrictItemContentTypes.ToString());
             builder.WithSetting("ContainerTypePartSettings.EnablePositioning", viewModel.EnablePositioning.ToString());
             builder.WithSetting("ContainerTypePartSettings.AdminListViewName", viewModel.AdminListViewName);
+            builder.WithSetting("ContainerTypePartSettings.ItemsDisplayMode", viewModel.ItemsDisplayMode);
+            builder.WithSetting("ContainerTypePartSettings.ContainerTag", viewModel.ContainerTag);
+            builder.WithSetting("ContainerTypePartSettings.ItemTag", viewModel.ItemTag);
             yield return DefinitionTemplate(viewModel);
         }
 
@@ -173,6 +198,9 @@ namespace Orchard.Core.Containers.Settings {
             builder.WithSetting("ContainerPartSettings.ItemsShownDefault", model.ItemsShownDefault.ToString());
             builder.WithSetting("ContainerPartSettings.PageSizeDefault", model.PageSizeDefault.ToString());
             builder.WithSetting("ContainerPartSettings.PaginatedDefault", model.PaginatedDefault.ToString());
+            builder.WithSetting("ContainerPartSettings.ItemsDisplayMode", model.ItemsDisplayMode);
+            builder.WithSetting("ContainerPartSettings.ContainerTag", model.ContainerTag);
+            builder.WithSetting("ContainerPartSettings.ItemTag", model.ItemTag);
             yield return DefinitionTemplate(model);
         }
     }

--- a/src/Orchard.Web/Core/Containers/Settings/ContainerSettings.cs
+++ b/src/Orchard.Web/Core/Containers/Settings/ContainerSettings.cs
@@ -14,10 +14,49 @@ namespace Orchard.Core.Containers.Settings {
         public const bool ItemsShownDefaultDefault = true;
         public const int PageSizeDefaultDefault = 10;
         public const bool PaginatedDefaultDefault = true;
+        public const string ItemsDisplayModelDefault = "Summary";
+        public const string ItemTagDefault = "li";
+        public const string ContainerTagDefault = "ul";
 
         private bool? _itemsShownDefault;
         private int? _pageSizeDefault;
         private bool? _paginiatedDefault;
+        private string _itemsDisplayMode;
+        private string _itemTag = "li";
+        private string _containerTag = "ul";
+
+        public string ContainerTag
+        {
+            get
+            {
+                return !string.IsNullOrEmpty(_containerTag)
+                         ? _containerTag
+                         : ContainerTagDefault;
+            }
+            set { _containerTag = value; }
+        }
+        
+        public string ItemTag
+        {
+            get
+            {
+                return !string.IsNullOrEmpty(_itemTag)
+                         ? _itemTag
+                         : ItemTagDefault;
+            }
+            set { _itemTag = value; }
+        }
+        
+        public string ItemsDisplayMode
+        {
+            get
+            {
+                return !string.IsNullOrEmpty(_itemsDisplayMode)
+                         ? _itemsDisplayMode
+                         : ItemsDisplayModelDefault;
+            }
+            set { _itemsDisplayMode = value; }
+        }
 
         public bool ItemsShownDefault {
             get {

--- a/src/Orchard.Web/Core/Containers/ViewModels/ContainerTypePartSettingsViewModel.cs
+++ b/src/Orchard.Web/Core/Containers/ViewModels/ContainerTypePartSettingsViewModel.cs
@@ -5,6 +5,9 @@ using Orchard.Core.Containers.Services;
 
 namespace Orchard.Core.Containers.ViewModels {
     public class ContainerTypePartSettingsViewModel {
+        public string ItemsDisplayMode { get; set; }
+        public string ContainerTag { get; set; }
+        public string ItemTag { get; set; }
         public bool? ItemsShownDefault { get; set; }
         public int? PageSizeDefault { get; set; }
         public bool? PaginatedDefault { get; set; }

--- a/src/Orchard.Web/Core/Containers/Views/DefinitionTemplates/ContainerTypePartSettingsViewModel.cshtml
+++ b/src/Orchard.Web/Core/Containers/Views/DefinitionTemplates/ContainerTypePartSettingsViewModel.cshtml
@@ -3,6 +3,18 @@
     Script.Require("ShapesBase");
 }
 <fieldset>
+    <label for="@Html.FieldIdFor(m => m.ItemsDisplayMode)">@T("Default Item Display Mode")</label>
+    @Html.EditorFor(m => m.ItemsDisplayMode)
+</fieldset>
+<fieldset>
+    <label for="@Html.FieldIdFor(m => m.ContainerTag)">@T("Default Container Tag")</label>
+    @Html.EditorFor(m => m.ContainerTag)
+</fieldset>
+<fieldset>
+    <label for="@Html.FieldIdFor(m => m.ItemTag)">@T("Default Item Tag")</label>
+    @Html.EditorFor(m => m.ItemTag)
+</fieldset>
+<fieldset>
     <label for="@Html.FieldIdFor(m => m.ItemsShownDefault)">@T("Default Items Shown")</label>
     @Html.EditorFor(m => m.ItemsShownDefault)
 </fieldset>


### PR DESCRIPTION
Currently, ContainerPart renders its ContainableParts in "Summary" mode and it uses the default "ul", "li" tags to render them. In some scenarios, we need to render Containable items in Detail mode and also using other tags instead of ul-li. 

Using some new properties in the ContainerPartSettings , I make it customizable.

Summary of changes
1) It preserves default behavior (using Summary displayMode and 'ul-li' tags)

2) It adds three new properties (ContainerTag, ItemTag, ItemsDisplayMode) to the ContainerPartSettings and its related classes

3) If the ContainerPart is in detail mode, it tries to use the values in setting for display-mode of the items, and for rendering tags.

4) In case of empty values in the settings, it uses the default values ("Summary", ul, li)