### PR TITLE
Add: Multiple BlogPost ContentTypes support (http://orchard.uservoice…

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Blogs/AdminMenu.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/AdminMenu.cs
@@ -1,16 +1,20 @@
 ﻿using System.Linq;
 using Orchard.Blogs.Services;
+using Orchard.ContentManagement.MetaData.Models;
 using Orchard.Localization;
 using Orchard.Security;
 using Orchard.UI.Navigation;
 
-namespace Orchard.Blogs {
-    public class AdminMenu : INavigationProvider {
+namespace Orchard.Blogs
+{
+    public class AdminMenu : INavigationProvider
+    {
         private readonly IBlogService _blogService;
         private readonly IAuthorizationService _authorizationService;
         private readonly IWorkContextAccessor _workContextAccessor;
 
-        public AdminMenu(IBlogService blogService, IAuthorizationService authorizationService, IWorkContextAccessor workContextAccessor) {
+        public AdminMenu(IBlogService blogService, IAuthorizationService authorizationService, IWorkContextAccessor workContextAccessor)
+        {
             _blogService = blogService;
             _authorizationService = authorizationService;
             _workContextAccessor = workContextAccessor;
@@ -20,17 +24,20 @@ namespace Orchard.Blogs {
 
         public string MenuName { get { return "admin"; } }
 
-        public void GetNavigation(NavigationBuilder builder) {
+        public void GetNavigation(NavigationBuilder builder)
+        {
             builder.AddImageSet("blog")
                 .Add(T("Blog"), "1.5", BuildMenu);
         }
 
-        private void BuildMenu(NavigationItemBuilder menu) {
+        private void BuildMenu(NavigationItemBuilder menu)
+        {
             var blogs = _blogService.Get().Where(x => _authorizationService.TryCheckAccess(Permissions.MetaListBlogs, _workContextAccessor.GetContext().CurrentUser, x)).ToArray();
             var blogCount = blogs.Count();
             var singleBlog = blogCount == 1 ? blogs.ElementAt(0) : null;
 
-            if (blogCount > 0 && singleBlog == null) {
+            if (blogCount > 0 && singleBlog == null)
+            {
                 menu.Add(T("Manage Blogs"), "3",
                          item => item.Action("List", "BlogAdmin", new { area = "Orchard.Blogs" }).Permission(Permissions.MetaListOwnBlogs));
             }
@@ -39,9 +46,16 @@ namespace Orchard.Blogs {
                     item => item.Action("Item", "BlogAdmin", new { area = "Orchard.Blogs", blogId = singleBlog.Id }).Permission(Permissions.MetaListOwnBlogs));
 
             if (singleBlog != null)
-                menu.Add(T("New Post"), "1.1",
+            {
+                foreach (var definition in _blogService.GetBlogPostContentTypes())
+                {
+                    string blogPostType = definition.Name;
+                    menu.Add(T("New {0}", definition.DisplayName), "1.1",
                          item =>
-                         item.Action("Create", "BlogPostAdmin", new {area = "Orchard.Blogs", blogId = singleBlog.Id}).Permission(Permissions.MetaListOwnBlogs));
+                         item.Action("Create", "BlogPostAdmin", new { area = "Orchard.Blogs", blogId = singleBlog.Id, contentType = blogPostType }).Permission(Permissions.MetaListOwnBlogs));
+                }
+            }
+
 
             menu.Add(T("New Blog"), "1.2",
                      item =>

--- a/src/Orchard.Web/Modules/Orchard.Blogs/AdminMenu.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/AdminMenu.cs
@@ -7,14 +7,12 @@ using Orchard.UI.Navigation;
 
 namespace Orchard.Blogs
 {
-    public class AdminMenu : INavigationProvider
-    {
+    public class AdminMenu : INavigationProvider {
         private readonly IBlogService _blogService;
         private readonly IAuthorizationService _authorizationService;
         private readonly IWorkContextAccessor _workContextAccessor;
 
-        public AdminMenu(IBlogService blogService, IAuthorizationService authorizationService, IWorkContextAccessor workContextAccessor)
-        {
+        public AdminMenu(IBlogService blogService, IAuthorizationService authorizationService, IWorkContextAccessor workContextAccessor) {
             _blogService = blogService;
             _authorizationService = authorizationService;
             _workContextAccessor = workContextAccessor;
@@ -24,14 +22,12 @@ namespace Orchard.Blogs
 
         public string MenuName { get { return "admin"; } }
 
-        public void GetNavigation(NavigationBuilder builder)
-        {
+        public void GetNavigation(NavigationBuilder builder) {
             builder.AddImageSet("blog")
                 .Add(T("Blog"), "1.5", BuildMenu);
         }
 
-        private void BuildMenu(NavigationItemBuilder menu)
-        {
+        private void BuildMenu(NavigationItemBuilder menu) {
             var blogs = _blogService.Get().Where(x => _authorizationService.TryCheckAccess(Permissions.MetaListBlogs, _workContextAccessor.GetContext().CurrentUser, x)).ToArray();
             var blogCount = blogs.Count();
             var singleBlog = blogCount == 1 ? blogs.ElementAt(0) : null;

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Commands/BlogCommands.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Commands/BlogCommands.cs
@@ -17,8 +17,7 @@ using Orchard.UI.Navigation;
 
 namespace Orchard.Blogs.Commands
 {
-    public class BlogCommands : DefaultOrchardCommandHandler
-    {
+    public class BlogCommands : DefaultOrchardCommandHandler {
         private readonly IContentManager _contentManager;
         private readonly IMembershipService _membershipService;
         private readonly IBlogService _blogService;
@@ -34,8 +33,7 @@ namespace Orchard.Blogs.Commands
             IMenuService menuService,
             ISiteService siteService,
             INavigationManager navigationManager,
-            IArchiveService archiveService)
-        {
+            IArchiveService archiveService) {
             _contentManager = contentManager;
             _membershipService = membershipService;
             _blogService = blogService;
@@ -78,8 +76,7 @@ namespace Orchard.Blogs.Commands
         [CommandName("blog create")]
         [CommandHelp("blog create [/Slug:<slug>] /Title:<title> [/Owner:<username>] [/Description:<description>] [/MenuName:<name>] [/MenuText:<menu text>] [/Homepage:true|false]\r\n\t" + "Creates a new Blog")]
         [OrchardSwitches("Slug,Title,Owner,Description,MenuText,Homepage,MenuName")]
-        public void Create()
-        {
+        public void Create() {
             if (String.IsNullOrEmpty(Owner))
             {
                 Owner = _siteService.GetSiteSettings().SuperUser;
@@ -132,8 +129,7 @@ namespace Orchard.Blogs.Commands
         [CommandName("blog import")]
         [CommandHelp("blog import /BlogId:<id> /FeedUrl:<feed url> /Owner:<username> [/ContentType:<contenttype>]\r\n\t" + "Import all items from <feed url> into the blog specified by <id>")]
         [OrchardSwitches("FeedUrl,BlogId,Owner,ContentType")]
-        public void Import()
-        {
+        public void Import() {
             var owner = _membershipService.GetUser(Owner);
 
             if (owner == null)
@@ -190,8 +186,7 @@ namespace Orchard.Blogs.Commands
         [CommandName("blog build archive")]
         [CommandHelp("blog build archive /BlogId:<id> \r\n\t" + "Rebuild the archive information for the blog specified by <id>")]
         [OrchardSwitches("BlogId")]
-        public void BuildArchive()
-        {
+        public void BuildArchive() {
 
             var blog = _blogService.Get(BlogId, VersionOptions.Latest);
 

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Commands/BlogCommands.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Commands/BlogCommands.cs
@@ -15,8 +15,10 @@ using Orchard.Settings;
 using Orchard.Core.Title.Models;
 using Orchard.UI.Navigation;
 
-namespace Orchard.Blogs.Commands {
-    public class BlogCommands : DefaultOrchardCommandHandler {
+namespace Orchard.Blogs.Commands
+{
+    public class BlogCommands : DefaultOrchardCommandHandler
+    {
         private readonly IContentManager _contentManager;
         private readonly IMembershipService _membershipService;
         private readonly IBlogService _blogService;
@@ -32,7 +34,8 @@ namespace Orchard.Blogs.Commands {
             IMenuService menuService,
             ISiteService siteService,
             INavigationManager navigationManager,
-            IArchiveService archiveService) {
+            IArchiveService archiveService)
+        {
             _contentManager = contentManager;
             _membershipService = membershipService;
             _blogService = blogService;
@@ -69,16 +72,22 @@ namespace Orchard.Blogs.Commands {
         [OrchardSwitch]
         public bool Homepage { get; set; }
 
+        [OrchardSwitch]
+        public string ContentType { get; set; }
+
         [CommandName("blog create")]
         [CommandHelp("blog create [/Slug:<slug>] /Title:<title> [/Owner:<username>] [/Description:<description>] [/MenuName:<name>] [/MenuText:<menu text>] [/Homepage:true|false]\r\n\t" + "Creates a new Blog")]
         [OrchardSwitches("Slug,Title,Owner,Description,MenuText,Homepage,MenuName")]
-        public void Create() {
-            if (String.IsNullOrEmpty(Owner)) {
+        public void Create()
+        {
+            if (String.IsNullOrEmpty(Owner))
+            {
                 Owner = _siteService.GetSiteSettings().SuperUser;
             }
             var owner = _membershipService.GetUser(Owner);
 
-            if (owner == null) {
+            if (owner == null)
+            {
                 Context.Output.WriteLine(T("Invalid username: {0}", Owner));
                 return;
             }
@@ -86,24 +95,29 @@ namespace Orchard.Blogs.Commands {
             var blog = _contentManager.New("Blog");
             blog.As<ICommonPart>().Owner = owner;
             blog.As<TitlePart>().Title = Title;
-            if (!String.IsNullOrEmpty(Description)) {
+            if (!String.IsNullOrEmpty(Description))
+            {
                 blog.As<BlogPart>().Description = Description;
             }
 
-            if (Homepage || !String.IsNullOrWhiteSpace(Slug)) {
+            if (Homepage || !String.IsNullOrWhiteSpace(Slug))
+            {
                 dynamic dblog = blog;
-                if (dblog.AutoroutePart != null) {
+                if (dblog.AutoroutePart != null)
+                {
                     dblog.AutoroutePart.UseCustomPattern = true;
                     dblog.AutoroutePart.CustomPattern = Homepage ? "/" : Slug;
                 }
             }
-            
+
             _contentManager.Create(blog);
 
-            if (!String.IsNullOrWhiteSpace(MenuText)) {
+            if (!String.IsNullOrWhiteSpace(MenuText))
+            {
                 var menu = _menuService.GetMenu(MenuName);
 
-                if (menu != null) {
+                if (menu != null)
+                {
                     var menuItem = _contentManager.Create<ContentMenuItemPart>("ContentMenuItem");
                     menuItem.Content = blog;
                     menuItem.As<MenuPart>().MenuPosition = _navigationManager.GetNextPosition(menu);
@@ -116,40 +130,52 @@ namespace Orchard.Blogs.Commands {
         }
 
         [CommandName("blog import")]
-        [CommandHelp("blog import /BlogId:<id> /FeedUrl:<feed url> /Owner:<username>\r\n\t" + "Import all items from <feed url> into the blog specified by <id>")]
-        [OrchardSwitches("FeedUrl,BlogId,Owner")]
-        public void Import() {
+        [CommandHelp("blog import /BlogId:<id> /FeedUrl:<feed url> /Owner:<username> [/ContentType:<contenttype>]\r\n\t" + "Import all items from <feed url> into the blog specified by <id>")]
+        [OrchardSwitches("FeedUrl,BlogId,Owner,ContentType")]
+        public void Import()
+        {
             var owner = _membershipService.GetUser(Owner);
 
-            if(owner == null) {
+            if (owner == null)
+            {
                 Context.Output.WriteLine(T("Invalid username: {0}", Owner));
                 return;
             }
 
+            if (string.IsNullOrWhiteSpace(ContentType))
+            {
+                ContentType = "BlogPost";
+            }
+
             XDocument doc;
 
-            try {
+            try
+            {
                 Context.Output.WriteLine(T("Loading feed..."));
                 doc = XDocument.Load(FeedUrl);
                 Context.Output.WriteLine(T("Found {0} items", doc.Descendants("item").Count()));
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 throw new OrchardException(T("An error occured while loading the feed at {0}.", FeedUrl), ex);
             }
 
             var blog = _blogService.Get(BlogId, VersionOptions.Latest);
 
-            if ( blog == null ) {
+            if (blog == null)
+            {
                 Context.Output.WriteLine(T("Blog not found with specified Id: {0}", BlogId));
                 return;
             }
 
-            foreach ( var item in doc.Descendants("item") ) {
-                if (item != null) {
+            foreach (var item in doc.Descendants("item"))
+            {
+                if (item != null)
+                {
                     var postName = item.Element("title").Value;
 
                     Context.Output.WriteLine(T("Adding post: {0}...", postName.Substring(0, Math.Min(postName.Length, 40))));
-                    var post = _contentManager.New("BlogPost");
+                    var post = _contentManager.New(ContentType);
                     post.As<ICommonPart>().Owner = owner;
                     post.As<ICommonPart>().Container = blog;
                     post.As<TitlePart>().Title = postName;
@@ -164,11 +190,13 @@ namespace Orchard.Blogs.Commands {
         [CommandName("blog build archive")]
         [CommandHelp("blog build archive /BlogId:<id> \r\n\t" + "Rebuild the archive information for the blog specified by <id>")]
         [OrchardSwitches("BlogId")]
-        public void BuildArchive() {
+        public void BuildArchive()
+        {
 
             var blog = _blogService.Get(BlogId, VersionOptions.Latest);
 
-            if (blog == null) {
+            if (blog == null)
+            {
                 Context.Output.WriteLine(T("Blog not found with specified Id: {0}", BlogId));
                 return;
             }

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Controllers/BlogPostAdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Controllers/BlogPostAdminController.cs
@@ -22,13 +22,11 @@ namespace Orchard.Blogs.Controllers
     /// helper extensions from UrlHelperExtensions.
     /// </summary>
     [ValidateInput(false), Admin]
-    public class BlogPostAdminController : Controller, IUpdateModel
-    {
+    public class BlogPostAdminController : Controller, IUpdateModel {
         private readonly IBlogService _blogService;
         private readonly IBlogPostService _blogPostService;
 
-        public BlogPostAdminController(IOrchardServices services, IBlogService blogService, IBlogPostService blogPostService)
-        {
+        public BlogPostAdminController(IOrchardServices services, IBlogService blogService, IBlogPostService blogPostService) {
             Services = services;
             _blogService = blogService;
             _blogPostService = blogPostService;
@@ -38,8 +36,7 @@ namespace Orchard.Blogs.Controllers
         public IOrchardServices Services { get; set; }
         public Localizer T { get; set; }
 
-        public ActionResult Create(int blogId, string contentType)
-        {
+        public ActionResult Create(int blogId, string contentType) {
 
             var blog = _blogService.Get(blogId, VersionOptions.Latest).As<BlogPart>();
             if (blog == null)
@@ -58,23 +55,20 @@ namespace Orchard.Blogs.Controllers
 
         [HttpPost, ActionName("Create")]
         [FormValueRequired("submit.Save")]
-        public ActionResult CreatePOST(int blogId, string contentType)
-        {
+        public ActionResult CreatePOST(int blogId, string contentType) {
             return CreatePOST(blogId, contentType, false);
         }
 
         [HttpPost, ActionName("Create")]
         [FormValueRequired("submit.Publish")]
-        public ActionResult CreateAndPublishPOST(int blogId, string contentType)
-        {
+        public ActionResult CreateAndPublishPOST(int blogId, string contentType) {
             if (!Services.Authorizer.Authorize(Permissions.PublishOwnBlogPost, T("Couldn't create content")))
                 return new HttpUnauthorizedResult();
 
             return CreatePOST(blogId, contentType, true);
         }
 
-        private ActionResult CreatePOST(int blogId, string contentType, bool publish = false)
-        {
+        private ActionResult CreatePOST(int blogId, string contentType, bool publish = false) {
             var blog = _blogService.Get(blogId, VersionOptions.Latest).As<BlogPart>();
 
             if (blog == null)
@@ -109,8 +103,7 @@ namespace Orchard.Blogs.Controllers
 
         //todo: the content shape template has extra bits that the core contents module does not (remove draft functionality)
         //todo: - move this extra functionality there or somewhere else that's appropriate?
-        public ActionResult Edit(int blogId, int postId)
-        {
+        public ActionResult Edit(int blogId, int postId) {
             var blog = _blogService.Get(blogId, VersionOptions.Latest);
             if (blog == null)
                 return HttpNotFound();
@@ -128,8 +121,7 @@ namespace Orchard.Blogs.Controllers
 
         [HttpPost, ActionName("Edit")]
         [FormValueRequired("submit.Save")]
-        public ActionResult EditPOST(int blogId, int postId, string returnUrl)
-        {
+        public ActionResult EditPOST(int blogId, int postId, string returnUrl) {
             return EditPOST(blogId, postId, returnUrl, contentItem =>
             {
                 if (!contentItem.Has<IPublishingControlAspect>() && !contentItem.TypeDefinition.Settings.GetModel<ContentTypeSettings>().Draftable)
@@ -139,8 +131,7 @@ namespace Orchard.Blogs.Controllers
 
         [HttpPost, ActionName("Edit")]
         [FormValueRequired("submit.Publish")]
-        public ActionResult EditAndPublishPOST(int blogId, int postId, string returnUrl)
-        {
+        public ActionResult EditAndPublishPOST(int blogId, int postId, string returnUrl) {
             var blog = _blogService.Get(blogId, VersionOptions.Latest);
             if (blog == null)
                 return HttpNotFound();
@@ -156,8 +147,7 @@ namespace Orchard.Blogs.Controllers
             return EditPOST(blogId, postId, returnUrl, contentItem => Services.ContentManager.Publish(contentItem));
         }
 
-        public ActionResult EditPOST(int blogId, int postId, string returnUrl, Action<ContentItem> conditionallyPublish)
-        {
+        public ActionResult EditPOST(int blogId, int postId, string returnUrl, Action<ContentItem> conditionallyPublish) {
             var blog = _blogService.Get(blogId, VersionOptions.Latest);
             if (blog == null)
                 return HttpNotFound();
@@ -186,8 +176,7 @@ namespace Orchard.Blogs.Controllers
         }
 
         [ValidateAntiForgeryTokenOrchard]
-        public ActionResult DiscardDraft(int id)
-        {
+        public ActionResult DiscardDraft(int id) {
             // get the current draft version
             var draft = Services.ContentManager.Get(id, VersionOptions.Draft);
             if (draft == null)
@@ -217,21 +206,18 @@ namespace Orchard.Blogs.Controllers
             return RedirectToEdit(published);
         }
 
-        ActionResult RedirectToEdit(int id)
-        {
+        ActionResult RedirectToEdit(int id) {
             return RedirectToEdit(Services.ContentManager.GetLatest<BlogPostPart>(id));
         }
 
-        ActionResult RedirectToEdit(IContent item)
-        {
+        ActionResult RedirectToEdit(IContent item) {
             if (item == null || item.As<BlogPostPart>() == null)
                 return HttpNotFound();
             return RedirectToAction("Edit", new { BlogId = item.As<BlogPostPart>().BlogPart.Id, PostId = item.ContentItem.Id });
         }
 
         [ValidateAntiForgeryTokenOrchard]
-        public ActionResult Delete(int blogId, int postId)
-        {
+        public ActionResult Delete(int blogId, int postId) {
             //refactoring: test PublishBlogPost/PublishBlogPost in addition if published
 
             var blog = _blogService.Get(blogId, VersionOptions.Latest);
@@ -252,8 +238,7 @@ namespace Orchard.Blogs.Controllers
         }
 
         [ValidateAntiForgeryTokenOrchard]
-        public ActionResult Publish(int blogId, int postId)
-        {
+        public ActionResult Publish(int blogId, int postId) {
             var blog = _blogService.Get(blogId, VersionOptions.Latest);
             if (blog == null)
                 return HttpNotFound();
@@ -272,8 +257,7 @@ namespace Orchard.Blogs.Controllers
         }
 
         [ValidateAntiForgeryTokenOrchard]
-        public ActionResult Unpublish(int blogId, int postId)
-        {
+        public ActionResult Unpublish(int blogId, int postId) {
             var blog = _blogService.Get(blogId, VersionOptions.Latest);
             if (blog == null)
                 return HttpNotFound();
@@ -291,13 +275,11 @@ namespace Orchard.Blogs.Controllers
             return Redirect(Url.BlogForAdmin(blog.As<BlogPart>()));
         }
 
-        bool IUpdateModel.TryUpdateModel<TModel>(TModel model, string prefix, string[] includeProperties, string[] excludeProperties)
-        {
+        bool IUpdateModel.TryUpdateModel<TModel>(TModel model, string prefix, string[] includeProperties, string[] excludeProperties) {
             return TryUpdateModel(model, prefix, includeProperties, excludeProperties);
         }
 
-        void IUpdateModel.AddModelError(string key, LocalizedString errorMessage)
-        {
+        void IUpdateModel.AddModelError(string key, LocalizedString errorMessage) {
             ModelState.AddModelError(key, errorMessage.ToString());
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Drivers/BlogPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Drivers/BlogPartDriver.cs
@@ -1,35 +1,54 @@
 ﻿using System;
 using System.Collections.Generic;
 using Orchard.Blogs.Models;
+using Orchard.Blogs.Services;
 using Orchard.ContentManagement;
 using Orchard.ContentManagement.Drivers;
 
-namespace Orchard.Blogs.Drivers {
-    public class BlogPartDriver : ContentPartDriver<BlogPart> {
-        protected override string Prefix {
+namespace Orchard.Blogs.Drivers
+{
+    public class BlogPartDriver : ContentPartDriver<BlogPart>
+    {
+        private readonly IOrchardServices _orchardService;
+        private readonly IBlogService _blogService;
+
+        protected override string Prefix
+        {
             get { return "BlogPart"; }
         }
 
-        protected override DriverResult Display(BlogPart part, string displayType, dynamic shapeHelper) {
+        public BlogPartDriver(IOrchardServices orchardService, IBlogService blogService)
+        {
+            _orchardService = orchardService;
+            _blogService = blogService;
+        }
+
+        protected override DriverResult Display(BlogPart part, string displayType, dynamic shapeHelper)
+        {
             return Combined(
                 ContentShape("Parts_Blogs_Blog_Manage",
                     () => shapeHelper.Parts_Blogs_Blog_Manage()),
                 ContentShape("Parts_Blogs_Blog_Description",
                     () => shapeHelper.Parts_Blogs_Blog_Description(Description: part.Description)),
                 ContentShape("Parts_Blogs_Blog_SummaryAdmin",
-                    () => shapeHelper.Parts_Blogs_Blog_SummaryAdmin()),
+                    () =>
+                    {
+                        _orchardService.WorkContext.Layout.BlogPostContentTypes = _blogService.GetBlogPostContentTypes();
+                        return shapeHelper.Parts_Blogs_Blog_SummaryAdmin();
+                    }),
                 ContentShape("Parts_Blogs_Blog_BlogPostCount",
                     () => shapeHelper.Parts_Blogs_Blog_BlogPostCount(PostCount: part.PostCount))
                 );
         }
 
-        protected override DriverResult Editor(BlogPart blogPart, dynamic shapeHelper) {
+        protected override DriverResult Editor(BlogPart blogPart, dynamic shapeHelper)
+        {
             var results = new List<DriverResult> {
                 ContentShape("Parts_Blogs_Blog_Fields",
                              () => shapeHelper.EditorTemplate(TemplateName: "Parts.Blogs.Blog.Fields", Model: blogPart, Prefix: Prefix))
             };
 
-            
+
             if (blogPart.Id > 0)
                 results.Add(ContentShape("Blog_DeleteButton",
                     deleteButton => deleteButton));
@@ -37,29 +56,35 @@ namespace Orchard.Blogs.Drivers {
             return Combined(results.ToArray());
         }
 
-        protected override DriverResult Editor(BlogPart blogPart, IUpdateModel updater, dynamic shapeHelper) {
+        protected override DriverResult Editor(BlogPart blogPart, IUpdateModel updater, dynamic shapeHelper)
+        {
             updater.TryUpdateModel(blogPart, Prefix, null, null);
             return Editor(blogPart, shapeHelper);
         }
 
-        protected override void Importing(BlogPart part, ContentManagement.Handlers.ImportContentContext context) {
+        protected override void Importing(BlogPart part, ContentManagement.Handlers.ImportContentContext context)
+        {
             var description = context.Attribute(part.PartDefinition.Name, "Description");
-            if (description != null) {
+            if (description != null)
+            {
                 part.Description = description;
             }
 
             var postCount = context.Attribute(part.PartDefinition.Name, "PostCount");
-            if (postCount != null) {
+            if (postCount != null)
+            {
                 part.PostCount = Convert.ToInt32(postCount);
             }
 
             var feedProxyUrl = context.Attribute(part.PartDefinition.Name, "FeedProxyUrl");
-            if (feedProxyUrl != null) {
+            if (feedProxyUrl != null)
+            {
                 part.FeedProxyUrl = feedProxyUrl;
             }
         }
 
-        protected override void Exporting(BlogPart part, ContentManagement.Handlers.ExportContentContext context) {
+        protected override void Exporting(BlogPart part, ContentManagement.Handlers.ExportContentContext context)
+        {
             context.Element(part.PartDefinition.Name).SetAttributeValue("Description", part.Description);
             context.Element(part.PartDefinition.Name).SetAttributeValue("PostCount", part.PostCount);
             context.Element(part.PartDefinition.Name).SetAttributeValue("FeedProxyUrl", part.FeedProxyUrl);

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Drivers/BlogPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Drivers/BlogPartDriver.cs
@@ -7,24 +7,20 @@ using Orchard.ContentManagement.Drivers;
 
 namespace Orchard.Blogs.Drivers
 {
-    public class BlogPartDriver : ContentPartDriver<BlogPart>
-    {
+    public class BlogPartDriver : ContentPartDriver<BlogPart> {
         private readonly IOrchardServices _orchardService;
         private readonly IBlogService _blogService;
 
-        protected override string Prefix
-        {
+        protected override string Prefix {
             get { return "BlogPart"; }
         }
 
-        public BlogPartDriver(IOrchardServices orchardService, IBlogService blogService)
-        {
+        public BlogPartDriver(IOrchardServices orchardService, IBlogService blogService) {
             _orchardService = orchardService;
             _blogService = blogService;
         }
 
-        protected override DriverResult Display(BlogPart part, string displayType, dynamic shapeHelper)
-        {
+        protected override DriverResult Display(BlogPart part, string displayType, dynamic shapeHelper) {
             return Combined(
                 ContentShape("Parts_Blogs_Blog_Manage",
                     () => shapeHelper.Parts_Blogs_Blog_Manage()),
@@ -41,8 +37,7 @@ namespace Orchard.Blogs.Drivers
                 );
         }
 
-        protected override DriverResult Editor(BlogPart blogPart, dynamic shapeHelper)
-        {
+        protected override DriverResult Editor(BlogPart blogPart, dynamic shapeHelper) {
             var results = new List<DriverResult> {
                 ContentShape("Parts_Blogs_Blog_Fields",
                              () => shapeHelper.EditorTemplate(TemplateName: "Parts.Blogs.Blog.Fields", Model: blogPart, Prefix: Prefix))
@@ -56,14 +51,12 @@ namespace Orchard.Blogs.Drivers
             return Combined(results.ToArray());
         }
 
-        protected override DriverResult Editor(BlogPart blogPart, IUpdateModel updater, dynamic shapeHelper)
-        {
+        protected override DriverResult Editor(BlogPart blogPart, IUpdateModel updater, dynamic shapeHelper) {
             updater.TryUpdateModel(blogPart, Prefix, null, null);
             return Editor(blogPart, shapeHelper);
         }
 
-        protected override void Importing(BlogPart part, ContentManagement.Handlers.ImportContentContext context)
-        {
+        protected override void Importing(BlogPart part, ContentManagement.Handlers.ImportContentContext context) {
             var description = context.Attribute(part.PartDefinition.Name, "Description");
             if (description != null)
             {
@@ -83,8 +76,7 @@ namespace Orchard.Blogs.Drivers
             }
         }
 
-        protected override void Exporting(BlogPart part, ContentManagement.Handlers.ExportContentContext context)
-        {
+        protected override void Exporting(BlogPart part, ContentManagement.Handlers.ExportContentContext context) {
             context.Element(part.PartDefinition.Name).SetAttributeValue("Description", part.Description);
             context.Element(part.PartDefinition.Name).SetAttributeValue("PostCount", part.PostCount);
             context.Element(part.PartDefinition.Name).SetAttributeValue("FeedProxyUrl", part.FeedProxyUrl);

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Drivers/RecentBlogPostsPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Drivers/RecentBlogPostsPartDriver.cs
@@ -8,27 +8,33 @@ using Orchard.ContentManagement.Drivers;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Core.Common.Models;
 
-namespace Orchard.Blogs.Drivers {
-    public class RecentBlogPostsPartDriver : ContentPartDriver<RecentBlogPostsPart> {
+namespace Orchard.Blogs.Drivers
+{
+    public class RecentBlogPostsPartDriver : ContentPartDriver<RecentBlogPostsPart>
+    {
         private readonly IBlogService _blogService;
         private readonly IContentManager _contentManager;
 
         public RecentBlogPostsPartDriver(
-            IBlogService blogService, 
-            IContentManager contentManager) {
+            IBlogService blogService,
+            IContentManager contentManager)
+        {
             _blogService = blogService;
             _contentManager = contentManager;
         }
 
-        protected override DriverResult Display(RecentBlogPostsPart part, string displayType, dynamic shapeHelper) {
-            return ContentShape("Parts_Blogs_RecentBlogPosts", () => {
-            var blog = _contentManager.Get<BlogPart>(part.BlogId);
+        protected override DriverResult Display(RecentBlogPostsPart part, string displayType, dynamic shapeHelper)
+        {
+            return ContentShape("Parts_Blogs_RecentBlogPosts", () =>
+            {
+                var blog = _contentManager.Get<BlogPart>(part.BlogId);
 
-                if (blog == null) {
+                if (blog == null)
+                {
                     return null;
                 }
 
-                var blogPosts = _contentManager.Query(VersionOptions.Published, "BlogPost")
+                var blogPosts = _contentManager.Query(VersionOptions.Published)
                     .Join<CommonPartRecord>().Where(cr => cr.Container.Id == blog.Id)
                     .OrderByDescending(cr => cr.CreatedUtc)
                     .Slice(0, part.Count)
@@ -43,8 +49,10 @@ namespace Orchard.Blogs.Drivers {
             });
         }
 
-        protected override DriverResult Editor(RecentBlogPostsPart part, dynamic shapeHelper) {
-            var viewModel = new RecentBlogPostsViewModel {
+        protected override DriverResult Editor(RecentBlogPostsPart part, dynamic shapeHelper)
+        {
+            var viewModel = new RecentBlogPostsViewModel
+            {
                 Count = part.Count,
                 BlogId = part.BlogId,
                 Blogs = _blogService.Get().ToList().OrderBy(b => _contentManager.GetItemMetadata(b).DisplayText)
@@ -54,10 +62,12 @@ namespace Orchard.Blogs.Drivers {
                                 () => shapeHelper.EditorTemplate(TemplateName: "Parts.Blogs.RecentBlogPosts", Model: viewModel, Prefix: Prefix));
         }
 
-        protected override DriverResult Editor(RecentBlogPostsPart part, IUpdateModel updater, dynamic shapeHelper) {
+        protected override DriverResult Editor(RecentBlogPostsPart part, IUpdateModel updater, dynamic shapeHelper)
+        {
             var viewModel = new RecentBlogPostsViewModel();
 
-            if (updater.TryUpdateModel(viewModel, Prefix, null, null)) {
+            if (updater.TryUpdateModel(viewModel, Prefix, null, null))
+            {
                 part.BlogId = viewModel.BlogId;
                 part.Count = viewModel.Count;
             }
@@ -65,19 +75,23 @@ namespace Orchard.Blogs.Drivers {
             return Editor(part, shapeHelper);
         }
 
-        protected override void Importing(RecentBlogPostsPart part, ImportContentContext context) {
+        protected override void Importing(RecentBlogPostsPart part, ImportContentContext context)
+        {
             var blog = context.Attribute(part.PartDefinition.Name, "Blog");
-            if (blog != null) {
+            if (blog != null)
+            {
                 part.BlogId = context.GetItemFromSession(blog).Id;
             }
 
             var count = context.Attribute(part.PartDefinition.Name, "Count");
-            if (count != null) {
+            if (count != null)
+            {
                 part.Count = Convert.ToInt32(count);
             }
         }
 
-        protected override void Exporting(RecentBlogPostsPart part, ExportContentContext context) {
+        protected override void Exporting(RecentBlogPostsPart part, ExportContentContext context)
+        {
             var blog = _contentManager.Get(part.BlogId);
             var blogIdentity = _contentManager.GetItemMetadata(blog).Identity;
             context.Element(part.PartDefinition.Name).SetAttributeValue("Blog", blogIdentity);

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Drivers/RecentBlogPostsPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Drivers/RecentBlogPostsPartDriver.cs
@@ -10,21 +10,18 @@ using Orchard.Core.Common.Models;
 
 namespace Orchard.Blogs.Drivers
 {
-    public class RecentBlogPostsPartDriver : ContentPartDriver<RecentBlogPostsPart>
-    {
+    public class RecentBlogPostsPartDriver : ContentPartDriver<RecentBlogPostsPart> {
         private readonly IBlogService _blogService;
         private readonly IContentManager _contentManager;
 
         public RecentBlogPostsPartDriver(
             IBlogService blogService,
-            IContentManager contentManager)
-        {
+            IContentManager contentManager) {
             _blogService = blogService;
             _contentManager = contentManager;
         }
 
-        protected override DriverResult Display(RecentBlogPostsPart part, string displayType, dynamic shapeHelper)
-        {
+        protected override DriverResult Display(RecentBlogPostsPart part, string displayType, dynamic shapeHelper) {
             return ContentShape("Parts_Blogs_RecentBlogPosts", () =>
             {
                 var blog = _contentManager.Get<BlogPart>(part.BlogId);
@@ -49,8 +46,7 @@ namespace Orchard.Blogs.Drivers
             });
         }
 
-        protected override DriverResult Editor(RecentBlogPostsPart part, dynamic shapeHelper)
-        {
+        protected override DriverResult Editor(RecentBlogPostsPart part, dynamic shapeHelper) {
             var viewModel = new RecentBlogPostsViewModel
             {
                 Count = part.Count,
@@ -62,8 +58,7 @@ namespace Orchard.Blogs.Drivers
                                 () => shapeHelper.EditorTemplate(TemplateName: "Parts.Blogs.RecentBlogPosts", Model: viewModel, Prefix: Prefix));
         }
 
-        protected override DriverResult Editor(RecentBlogPostsPart part, IUpdateModel updater, dynamic shapeHelper)
-        {
+        protected override DriverResult Editor(RecentBlogPostsPart part, IUpdateModel updater, dynamic shapeHelper) {
             var viewModel = new RecentBlogPostsViewModel();
 
             if (updater.TryUpdateModel(viewModel, Prefix, null, null))
@@ -75,8 +70,7 @@ namespace Orchard.Blogs.Drivers
             return Editor(part, shapeHelper);
         }
 
-        protected override void Importing(RecentBlogPostsPart part, ImportContentContext context)
-        {
+        protected override void Importing(RecentBlogPostsPart part, ImportContentContext context) {
             var blog = context.Attribute(part.PartDefinition.Name, "Blog");
             if (blog != null)
             {
@@ -90,8 +84,7 @@ namespace Orchard.Blogs.Drivers
             }
         }
 
-        protected override void Exporting(RecentBlogPostsPart part, ExportContentContext context)
-        {
+        protected override void Exporting(RecentBlogPostsPart part, ExportContentContext context) {
             var blog = _contentManager.Get(part.BlogId);
             var blogIdentity = _contentManager.GetItemMetadata(blog).Identity;
             context.Element(part.PartDefinition.Name).SetAttributeValue("Blog", blogIdentity);

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Extensions/UrlHelperExtensions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Extensions/UrlHelperExtensions.cs
@@ -10,98 +10,79 @@ namespace Orchard.Blogs.Extensions
     /// <summary>
     /// TODO: (PH:Autoroute) Many of these are or could be redundant (see controllers)
     /// </summary>
-    public static class UrlHelperExtensions
-    {
-        public static string Blogs(this UrlHelper urlHelper)
-        {
+    public static class UrlHelperExtensions {
+        public static string Blogs(this UrlHelper urlHelper) {
             return urlHelper.Action("List", "Blog", new { area = "Orchard.Blogs" });
         }
 
-        public static string BlogsForAdmin(this UrlHelper urlHelper)
-        {
+        public static string BlogsForAdmin(this UrlHelper urlHelper) {
             return urlHelper.Action("List", "BlogAdmin", new { area = "Orchard.Blogs" });
         }
 
-        public static string Blog(this UrlHelper urlHelper, BlogPart blogPart)
-        {
+        public static string Blog(this UrlHelper urlHelper, BlogPart blogPart) {
             return urlHelper.Action("Item", "Blog", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogLiveWriterManifest(this UrlHelper urlHelper, BlogPart blogPart)
-        {
+        public static string BlogLiveWriterManifest(this UrlHelper urlHelper, BlogPart blogPart) {
             return urlHelper.AbsoluteAction(() => urlHelper.Action("Manifest", "LiveWriter", new { area = "XmlRpc" }));
         }
 
-        public static string BlogRsd(this UrlHelper urlHelper, BlogPart blogPart)
-        {
+        public static string BlogRsd(this UrlHelper urlHelper, BlogPart blogPart) {
             return urlHelper.AbsoluteAction(() => urlHelper.Action("Rsd", "RemoteBlogPublishing", new { path = blogPart.As<IAliasAspect>().Path + "/rsd", area = "Orchard.Blogs" }));
         }
 
-        public static string BlogArchiveYear(this UrlHelper urlHelper, BlogPart blogPart, int year)
-        {
+        public static string BlogArchiveYear(this UrlHelper urlHelper, BlogPart blogPart, int year) {
             var blogPath = blogPart.As<IAliasAspect>().Path;
             return urlHelper.Action("ListByArchive", "BlogPost", new { path = (string.IsNullOrWhiteSpace(blogPath) ? "archive/" : blogPath + "/archive/") + year.ToString(), area = "Orchard.Blogs" });
         }
 
-        public static string BlogArchiveMonth(this UrlHelper urlHelper, BlogPart blogPart, int year, int month)
-        {
+        public static string BlogArchiveMonth(this UrlHelper urlHelper, BlogPart blogPart, int year, int month) {
             var blogPath = blogPart.As<IAliasAspect>().Path;
             return urlHelper.Action("ListByArchive", "BlogPost", new { path = (string.IsNullOrWhiteSpace(blogPath) ? "archive/" : blogPath + "/archive/") + string.Format("{0}/{1}", year, month), area = "Orchard.Blogs" });
         }
 
-        public static string BlogArchiveDay(this UrlHelper urlHelper, BlogPart blogPart, int year, int month, int day)
-        {
+        public static string BlogArchiveDay(this UrlHelper urlHelper, BlogPart blogPart, int year, int month, int day) {
             var blogPath = blogPart.As<IAliasAspect>().Path;
             return urlHelper.Action("ListByArchive", "BlogPost", new { path = (string.IsNullOrWhiteSpace(blogPath) ? "archive/" : blogPath + "/archive/") + string.Format("{0}/{1}/{2}", year, month, day), area = "Orchard.Blogs" });
         }
 
-        public static string BlogForAdmin(this UrlHelper urlHelper, BlogPart blogPart)
-        {
+        public static string BlogForAdmin(this UrlHelper urlHelper, BlogPart blogPart) {
             return urlHelper.Action("Item", "BlogAdmin", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogCreate(this UrlHelper urlHelper)
-        {
+        public static string BlogCreate(this UrlHelper urlHelper) {
             return urlHelper.Action("Create", "BlogAdmin", new { area = "Orchard.Blogs" });
         }
 
-        public static string BlogEdit(this UrlHelper urlHelper, BlogPart blogPart)
-        {
+        public static string BlogEdit(this UrlHelper urlHelper, BlogPart blogPart) {
             return urlHelper.Action("Edit", "BlogAdmin", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogRemove(this UrlHelper urlHelper, BlogPart blogPart)
-        {
+        public static string BlogRemove(this UrlHelper urlHelper, BlogPart blogPart) {
             return urlHelper.Action("Remove", "BlogAdmin", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostCreate(this UrlHelper urlHelper, BlogPart blogPart)
-        {
+        public static string BlogPostCreate(this UrlHelper urlHelper, BlogPart blogPart) {
             return urlHelper.Action("Create", "BlogPostAdmin", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostCreate(this UrlHelper urlHelper, BlogPart blogPart, string contentType)
-        {
+        public static string BlogPostCreate(this UrlHelper urlHelper, BlogPart blogPart, string contentType) {
             return urlHelper.Action("Create", "BlogPostAdmin", new { blogId = blogPart.Id, contentType = contentType, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostEdit(this UrlHelper urlHelper, BlogPostPart blogPostPart)
-        {
+        public static string BlogPostEdit(this UrlHelper urlHelper, BlogPostPart blogPostPart) {
             return urlHelper.Action("Edit", "BlogPostAdmin", new { blogId = blogPostPart.BlogPart.Id, postId = blogPostPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostDelete(this UrlHelper urlHelper, BlogPostPart blogPostPart)
-        {
+        public static string BlogPostDelete(this UrlHelper urlHelper, BlogPostPart blogPostPart) {
             return urlHelper.Action("Delete", "BlogPostAdmin", new { blogId = blogPostPart.BlogPart.Id, postId = blogPostPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostPublish(this UrlHelper urlHelper, BlogPostPart blogPostPart)
-        {
+        public static string BlogPostPublish(this UrlHelper urlHelper, BlogPostPart blogPostPart) {
             return urlHelper.Action("Publish", "BlogPostAdmin", new { blogId = blogPostPart.BlogPart.Id, postId = blogPostPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostUnpublish(this UrlHelper urlHelper, BlogPostPart blogPostPart)
-        {
+        public static string BlogPostUnpublish(this UrlHelper urlHelper, BlogPostPart blogPostPart) {
             return urlHelper.Action("Unpublish", "BlogPostAdmin", new { blogId = blogPostPart.BlogPart.Id, postId = blogPostPart.Id, area = "Orchard.Blogs" });
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Extensions/UrlHelperExtensions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Extensions/UrlHelperExtensions.cs
@@ -5,79 +5,103 @@ using Orchard.ContentManagement;
 using Orchard.ContentManagement.Aspects;
 using Orchard.Mvc.Extensions;
 
-namespace Orchard.Blogs.Extensions {
+namespace Orchard.Blogs.Extensions
+{
     /// <summary>
     /// TODO: (PH:Autoroute) Many of these are or could be redundant (see controllers)
     /// </summary>
-    public static class UrlHelperExtensions {
-        public static string Blogs(this UrlHelper urlHelper) {
-            return urlHelper.Action("List", "Blog", new {area = "Orchard.Blogs"});
+    public static class UrlHelperExtensions
+    {
+        public static string Blogs(this UrlHelper urlHelper)
+        {
+            return urlHelper.Action("List", "Blog", new { area = "Orchard.Blogs" });
         }
 
-        public static string BlogsForAdmin(this UrlHelper urlHelper) {
-            return urlHelper.Action("List", "BlogAdmin", new {area = "Orchard.Blogs"});
+        public static string BlogsForAdmin(this UrlHelper urlHelper)
+        {
+            return urlHelper.Action("List", "BlogAdmin", new { area = "Orchard.Blogs" });
         }
 
-        public static string Blog(this UrlHelper urlHelper, BlogPart blogPart) {
+        public static string Blog(this UrlHelper urlHelper, BlogPart blogPart)
+        {
             return urlHelper.Action("Item", "Blog", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogLiveWriterManifest(this UrlHelper urlHelper, BlogPart blogPart) {
+        public static string BlogLiveWriterManifest(this UrlHelper urlHelper, BlogPart blogPart)
+        {
             return urlHelper.AbsoluteAction(() => urlHelper.Action("Manifest", "LiveWriter", new { area = "XmlRpc" }));
         }
 
-        public static string BlogRsd(this UrlHelper urlHelper, BlogPart blogPart) {
+        public static string BlogRsd(this UrlHelper urlHelper, BlogPart blogPart)
+        {
             return urlHelper.AbsoluteAction(() => urlHelper.Action("Rsd", "RemoteBlogPublishing", new { path = blogPart.As<IAliasAspect>().Path + "/rsd", area = "Orchard.Blogs" }));
         }
 
-        public static string BlogArchiveYear(this UrlHelper urlHelper, BlogPart blogPart, int year) {
+        public static string BlogArchiveYear(this UrlHelper urlHelper, BlogPart blogPart, int year)
+        {
             var blogPath = blogPart.As<IAliasAspect>().Path;
             return urlHelper.Action("ListByArchive", "BlogPost", new { path = (string.IsNullOrWhiteSpace(blogPath) ? "archive/" : blogPath + "/archive/") + year.ToString(), area = "Orchard.Blogs" });
         }
 
-        public static string BlogArchiveMonth(this UrlHelper urlHelper, BlogPart blogPart, int year, int month) {
+        public static string BlogArchiveMonth(this UrlHelper urlHelper, BlogPart blogPart, int year, int month)
+        {
             var blogPath = blogPart.As<IAliasAspect>().Path;
             return urlHelper.Action("ListByArchive", "BlogPost", new { path = (string.IsNullOrWhiteSpace(blogPath) ? "archive/" : blogPath + "/archive/") + string.Format("{0}/{1}", year, month), area = "Orchard.Blogs" });
         }
 
-        public static string BlogArchiveDay(this UrlHelper urlHelper, BlogPart blogPart, int year, int month, int day) {
+        public static string BlogArchiveDay(this UrlHelper urlHelper, BlogPart blogPart, int year, int month, int day)
+        {
             var blogPath = blogPart.As<IAliasAspect>().Path;
             return urlHelper.Action("ListByArchive", "BlogPost", new { path = (string.IsNullOrWhiteSpace(blogPath) ? "archive/" : blogPath + "/archive/") + string.Format("{0}/{1}/{2}", year, month, day), area = "Orchard.Blogs" });
         }
 
-        public static string BlogForAdmin(this UrlHelper urlHelper, BlogPart blogPart) {
+        public static string BlogForAdmin(this UrlHelper urlHelper, BlogPart blogPart)
+        {
             return urlHelper.Action("Item", "BlogAdmin", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogCreate(this UrlHelper urlHelper) {
+        public static string BlogCreate(this UrlHelper urlHelper)
+        {
             return urlHelper.Action("Create", "BlogAdmin", new { area = "Orchard.Blogs" });
         }
 
-        public static string BlogEdit(this UrlHelper urlHelper, BlogPart blogPart) {
+        public static string BlogEdit(this UrlHelper urlHelper, BlogPart blogPart)
+        {
             return urlHelper.Action("Edit", "BlogAdmin", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogRemove(this UrlHelper urlHelper, BlogPart blogPart) {
+        public static string BlogRemove(this UrlHelper urlHelper, BlogPart blogPart)
+        {
             return urlHelper.Action("Remove", "BlogAdmin", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostCreate(this UrlHelper urlHelper, BlogPart blogPart) {
+        public static string BlogPostCreate(this UrlHelper urlHelper, BlogPart blogPart)
+        {
             return urlHelper.Action("Create", "BlogPostAdmin", new { blogId = blogPart.Id, area = "Orchard.Blogs" });
         }
-        
-        public static string BlogPostEdit(this UrlHelper urlHelper, BlogPostPart blogPostPart) {
+
+        public static string BlogPostCreate(this UrlHelper urlHelper, BlogPart blogPart, string contentType)
+        {
+            return urlHelper.Action("Create", "BlogPostAdmin", new { blogId = blogPart.Id, contentType = contentType, area = "Orchard.Blogs" });
+        }
+
+        public static string BlogPostEdit(this UrlHelper urlHelper, BlogPostPart blogPostPart)
+        {
             return urlHelper.Action("Edit", "BlogPostAdmin", new { blogId = blogPostPart.BlogPart.Id, postId = blogPostPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostDelete(this UrlHelper urlHelper, BlogPostPart blogPostPart) {
+        public static string BlogPostDelete(this UrlHelper urlHelper, BlogPostPart blogPostPart)
+        {
             return urlHelper.Action("Delete", "BlogPostAdmin", new { blogId = blogPostPart.BlogPart.Id, postId = blogPostPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostPublish(this UrlHelper urlHelper, BlogPostPart blogPostPart) {
+        public static string BlogPostPublish(this UrlHelper urlHelper, BlogPostPart blogPostPart)
+        {
             return urlHelper.Action("Publish", "BlogPostAdmin", new { blogId = blogPostPart.BlogPart.Id, postId = blogPostPart.Id, area = "Orchard.Blogs" });
         }
 
-        public static string BlogPostUnpublish(this UrlHelper urlHelper, BlogPostPart blogPostPart) {
+        public static string BlogPostUnpublish(this UrlHelper urlHelper, BlogPostPart blogPostPart)
+        {
             return urlHelper.Action("Unpublish", "BlogPostAdmin", new { blogId = blogPostPart.BlogPart.Id, postId = blogPostPart.Id, area = "Orchard.Blogs" });
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Handlers/BlogPostPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Handlers/BlogPostPartHandler.cs
@@ -6,11 +6,14 @@ using Orchard.ContentManagement;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Core.Common.Models;
 
-namespace Orchard.Blogs.Handlers {
-    public class BlogPostPartHandler : ContentHandler {
+namespace Orchard.Blogs.Handlers
+{
+    public class BlogPostPartHandler : ContentHandler
+    {
         private readonly IBlogService _blogService;
 
-        public BlogPostPartHandler(IBlogService blogService, IBlogPostService blogPostService, RequestContext requestContext) {
+        public BlogPostPartHandler(IBlogService blogService, IBlogPostService blogPostService, RequestContext requestContext)
+        {
             _blogService = blogService;
 
             OnGetDisplayShape<BlogPostPart>(SetModelProperties);
@@ -29,24 +32,29 @@ namespace Orchard.Blogs.Handlers {
                     blogPost => context.ContentManager.Remove(blogPost.ContentItem)));
         }
 
-        private void ProcessBlogPostsCount(BlogPostPart blogPostPart) {
+        private void ProcessBlogPostsCount(BlogPostPart blogPostPart)
+        {
             CommonPart commonPart = blogPostPart.As<CommonPart>();
             if (commonPart != null &&
-                commonPart.Record.Container != null) {
+                commonPart.Record.Container != null)
+            {
 
                 _blogService.ProcessBlogPostsCount(commonPart.Container.Id);
             }
         }
 
-        private static void SetModelProperties(BuildShapeContext context, BlogPostPart blogPost) {
+        private static void SetModelProperties(BuildShapeContext context, BlogPostPart blogPost)
+        {
             context.Shape.Blog = blogPost.BlogPart;
         }
 
-        protected override void GetItemMetadata(GetContentItemMetadataContext context) {
+        protected override void GetItemMetadata(GetContentItemMetadataContext context)
+        {
             var blogPost = context.ContentItem.As<BlogPostPart>();
 
             // BlogPart can be null if this is a new Blog Post item.
-            if (blogPost == null || blogPost.BlogPart == null) {
+            if (blogPost == null || blogPost.BlogPart == null)
+            {
                 return;
             }
 
@@ -54,7 +62,8 @@ namespace Orchard.Blogs.Handlers {
                 {"Area", "Orchard.Blogs"},
                 {"Controller", "BlogPostAdmin"},
                 {"Action", "Create"},
-                {"blogId", blogPost.BlogPart.Id}
+                {"blogId", blogPost.BlogPart.Id},
+                {"contentType", "BlogPost"}
             };
             context.Metadata.EditorRouteValues = new RouteValueDictionary {
                 {"Area", "Orchard.Blogs"},

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Handlers/BlogPostPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Handlers/BlogPostPartHandler.cs
@@ -8,12 +8,10 @@ using Orchard.Core.Common.Models;
 
 namespace Orchard.Blogs.Handlers
 {
-    public class BlogPostPartHandler : ContentHandler
-    {
+    public class BlogPostPartHandler : ContentHandler {
         private readonly IBlogService _blogService;
 
-        public BlogPostPartHandler(IBlogService blogService, IBlogPostService blogPostService, RequestContext requestContext)
-        {
+        public BlogPostPartHandler(IBlogService blogService, IBlogPostService blogPostService, RequestContext requestContext) {
             _blogService = blogService;
 
             OnGetDisplayShape<BlogPostPart>(SetModelProperties);
@@ -32,8 +30,7 @@ namespace Orchard.Blogs.Handlers
                     blogPost => context.ContentManager.Remove(blogPost.ContentItem)));
         }
 
-        private void ProcessBlogPostsCount(BlogPostPart blogPostPart)
-        {
+        private void ProcessBlogPostsCount(BlogPostPart blogPostPart) {
             CommonPart commonPart = blogPostPart.As<CommonPart>();
             if (commonPart != null &&
                 commonPart.Record.Container != null)
@@ -43,13 +40,11 @@ namespace Orchard.Blogs.Handlers
             }
         }
 
-        private static void SetModelProperties(BuildShapeContext context, BlogPostPart blogPost)
-        {
+        private static void SetModelProperties(BuildShapeContext context, BlogPostPart blogPost) {
             context.Shape.Blog = blogPost.BlogPart;
         }
 
-        protected override void GetItemMetadata(GetContentItemMetadataContext context)
-        {
+        protected override void GetItemMetadata(GetContentItemMetadataContext context) {
             var blogPost = context.ContentItem.As<BlogPostPart>();
 
             // BlogPart can be null if this is a new Blog Post item.

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Migrations.cs
@@ -131,5 +131,12 @@ namespace Orchard.Blogs {
 
             return 6;
         }
+
+        public int UpdateFrom6() {
+            ContentDefinitionManager.AlterPartDefinition("BlogPostPart", builder => builder
+                .Attachable());
+
+            return 7;
+        }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Routes.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Routes.cs
@@ -4,24 +4,29 @@ using System.Web.Routing;
 using Orchard.Blogs.Routing;
 using Orchard.Mvc.Routes;
 
-namespace Orchard.Blogs {
-    public class Routes : IRouteProvider {
+namespace Orchard.Blogs
+{
+    public class Routes : IRouteProvider
+    {
         private readonly IArchiveConstraint _archiveConstraint;
         private readonly IRsdConstraint _rsdConstraint;
 
         public Routes(
             IArchiveConstraint archiveConstraint,
-            IRsdConstraint rsdConstraint) {
+            IRsdConstraint rsdConstraint)
+        {
             _archiveConstraint = archiveConstraint;
             _rsdConstraint = rsdConstraint;
         }
 
-        public void GetRoutes(ICollection<RouteDescriptor> routes) {
+        public void GetRoutes(ICollection<RouteDescriptor> routes)
+        {
             foreach (var routeDescriptor in GetRoutes())
                 routes.Add(routeDescriptor);
         }
 
-        public IEnumerable<RouteDescriptor> GetRoutes() {
+        public IEnumerable<RouteDescriptor> GetRoutes()
+        {
             return new[] {
                              new RouteDescriptor {
                                                      Route = new Route(
@@ -81,11 +86,12 @@ namespace Orchard.Blogs {
                                                  },
                              new RouteDescriptor {
                                                      Route = new Route(
-                                                         "Admin/Blogs/{blogId}/Posts/Create",
+                                                         "Admin/Blogs/{blogId}/Posts/Create/{contentType}",
                                                          new RouteValueDictionary {
                                                                                       {"area", "Orchard.Blogs"},
                                                                                       {"controller", "BlogPostAdmin"},
-                                                                                      {"action", "Create"}
+                                                                                      {"action", "Create"},
+                                                                                      {"contentType", "BlogPost"}
                                                                                   },
                                                          new RouteValueDictionary (),
                                                          new RouteValueDictionary {

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Routes.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Routes.cs
@@ -6,27 +6,23 @@ using Orchard.Mvc.Routes;
 
 namespace Orchard.Blogs
 {
-    public class Routes : IRouteProvider
-    {
+    public class Routes : IRouteProvider {
         private readonly IArchiveConstraint _archiveConstraint;
         private readonly IRsdConstraint _rsdConstraint;
 
         public Routes(
             IArchiveConstraint archiveConstraint,
-            IRsdConstraint rsdConstraint)
-        {
+            IRsdConstraint rsdConstraint) {
             _archiveConstraint = archiveConstraint;
             _rsdConstraint = rsdConstraint;
         }
 
-        public void GetRoutes(ICollection<RouteDescriptor> routes)
-        {
+        public void GetRoutes(ICollection<RouteDescriptor> routes) {
             foreach (var routeDescriptor in GetRoutes())
                 routes.Add(routeDescriptor);
         }
 
-        public IEnumerable<RouteDescriptor> GetRoutes()
-        {
+        public IEnumerable<RouteDescriptor> GetRoutes() {
             return new[] {
                              new RouteDescriptor {
                                                      Route = new Route(

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogPostService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogPostService.cs
@@ -3,67 +3,82 @@ using System.Collections.Generic;
 using System.Linq;
 using Orchard.Blogs.Models;
 using Orchard.ContentManagement;
+using Orchard.ContentManagement.MetaData;
 using Orchard.Core.Common.Models;
 using Orchard.Data;
 using Orchard.Tasks.Scheduling;
 
-namespace Orchard.Blogs.Services {
-    public class BlogPostService : IBlogPostService {
+namespace Orchard.Blogs.Services
+{
+    public class BlogPostService : IBlogPostService
+    {
         private readonly IContentManager _contentManager;
         private readonly IRepository<BlogPartArchiveRecord> _blogArchiveRepository;
         private readonly IPublishingTaskManager _publishingTaskManager;
 
         public BlogPostService(
-            IContentManager contentManager, 
-            IRepository<BlogPartArchiveRecord> blogArchiveRepository, 
-            IPublishingTaskManager publishingTaskManager) {
+            IContentManager contentManager,
+            IRepository<BlogPartArchiveRecord> blogArchiveRepository,
+            IPublishingTaskManager publishingTaskManager,
+            IContentDefinitionManager contentDefinitionManager)
+        {
             _contentManager = contentManager;
             _blogArchiveRepository = blogArchiveRepository;
             _publishingTaskManager = publishingTaskManager;
         }
 
-        public BlogPostPart Get(int id) {
+        public BlogPostPart Get(int id)
+        {
             return Get(id, VersionOptions.Published);
         }
 
-        public BlogPostPart Get(int id, VersionOptions versionOptions) {
+        public BlogPostPart Get(int id, VersionOptions versionOptions)
+        {
             return _contentManager.Get<BlogPostPart>(id, versionOptions);
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart) {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart)
+        {
             return Get(blogPart, VersionOptions.Published);
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, VersionOptions versionOptions) {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, VersionOptions versionOptions)
+        {
             return GetBlogQuery(blogPart, versionOptions).List().Select(ci => ci.As<BlogPostPart>());
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, int skip, int count) {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, int skip, int count)
+        {
             return Get(blogPart, skip, count, VersionOptions.Published);
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, int skip, int count, VersionOptions versionOptions) {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, int skip, int count, VersionOptions versionOptions)
+        {
             return GetBlogQuery(blogPart, versionOptions)
                     .Slice(skip, count)
                     .ToList()
                     .Select(ci => ci.As<BlogPostPart>());
         }
 
-        public int PostCount(BlogPart blogPart) {
+        public int PostCount(BlogPart blogPart)
+        {
             return PostCount(blogPart, VersionOptions.Published);
         }
 
-        public int PostCount(BlogPart blogPart, VersionOptions versionOptions) {
-            return _contentManager.Query(versionOptions, "BlogPost")
+        public int PostCount(BlogPart blogPart, VersionOptions versionOptions)
+        {
+            return _contentManager.Query<BlogPostPart>(versionOptions)
                 .Join<CommonPartRecord>().Where(
                     cr => cr.Container.Id == blogPart.Id)
                 .Count();
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, ArchiveData archiveData) {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, ArchiveData archiveData)
+        {
             var query = GetBlogQuery(blogPart, VersionOptions.Published);
 
-            if (archiveData.Day > 0) {
+            if (archiveData.Day > 0)
+            {
                 var dayDate = new DateTime(archiveData.Year, archiveData.Month, archiveData.Day);
 
                 query = query.Where(cr => cr.CreatedUtc >= dayDate && cr.CreatedUtc < dayDate.AddDays(1));
@@ -74,7 +89,8 @@ namespace Orchard.Blogs.Services {
 
                 query = query.Where(cr => cr.CreatedUtc >= monthDate && cr.CreatedUtc < monthDate.AddMonths(1));
             }
-            else {
+            else
+            {
                 var yearDate = new DateTime(archiveData.Year, 1, 1);
 
                 query = query.Where(cr => cr.CreatedUtc >= yearDate && cr.CreatedUtc < yearDate.AddYears(1));
@@ -83,8 +99,9 @@ namespace Orchard.Blogs.Services {
             return query.List().Select(ci => ci.As<BlogPostPart>());
         }
 
-        public IEnumerable<KeyValuePair<ArchiveData, int>> GetArchives(BlogPart blogPart) {
-            var query = 
+        public IEnumerable<KeyValuePair<ArchiveData, int>> GetArchives(BlogPart blogPart)
+        {
+            var query =
                 from bar in _blogArchiveRepository.Table
                 where bar.BlogPart.Id == blogPart.Id
                 orderby bar.Year descending, bar.Month descending
@@ -97,32 +114,38 @@ namespace Orchard.Blogs.Services {
                                                        bar.PostCount));
         }
 
-        public void Delete(BlogPostPart blogPostPart) {
+        public void Delete(BlogPostPart blogPostPart)
+        {
             _publishingTaskManager.DeleteTasks(blogPostPart.ContentItem);
             _contentManager.Remove(blogPostPart.ContentItem);
         }
 
-        public void Publish(BlogPostPart blogPostPart) {
+        public void Publish(BlogPostPart blogPostPart)
+        {
             _publishingTaskManager.DeleteTasks(blogPostPart.ContentItem);
             _contentManager.Publish(blogPostPart.ContentItem);
         }
 
-        public void Publish(BlogPostPart blogPostPart, DateTime scheduledPublishUtc) {
+        public void Publish(BlogPostPart blogPostPart, DateTime scheduledPublishUtc)
+        {
             _publishingTaskManager.Publish(blogPostPart.ContentItem, scheduledPublishUtc);
         }
 
-        public void Unpublish(BlogPostPart blogPostPart) {
+        public void Unpublish(BlogPostPart blogPostPart)
+        {
             _contentManager.Unpublish(blogPostPart.ContentItem);
         }
 
-        public DateTime? GetScheduledPublishUtc(BlogPostPart blogPostPart) {
+        public DateTime? GetScheduledPublishUtc(BlogPostPart blogPostPart)
+        {
             var task = _publishingTaskManager.GetPublishTask(blogPostPart.ContentItem);
             return (task == null ? null : task.ScheduledUtc);
         }
 
-        private IContentQuery<ContentItem, CommonPartRecord> GetBlogQuery(BlogPart blog, VersionOptions versionOptions) {
+        private IContentQuery<BlogPostPart, CommonPartRecord> GetBlogQuery(BlogPart blog, VersionOptions versionOptions)
+        {
             return
-                _contentManager.Query(versionOptions, "BlogPost")
+                _contentManager.Query<BlogPostPart>(versionOptions)
                 .Join<CommonPartRecord>().Where(
                     cr => cr.Container.Id == blog.Id).OrderByDescending(cr => cr.CreatedUtc)
                     ;

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogPostService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogPostService.cs
@@ -3,15 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Orchard.Blogs.Models;
 using Orchard.ContentManagement;
-using Orchard.ContentManagement.MetaData;
 using Orchard.Core.Common.Models;
 using Orchard.Data;
 using Orchard.Tasks.Scheduling;
 
 namespace Orchard.Blogs.Services
 {
-    public class BlogPostService : IBlogPostService
-    {
+    public class BlogPostService : IBlogPostService {
         private readonly IContentManager _contentManager;
         private readonly IRepository<BlogPartArchiveRecord> _blogArchiveRepository;
         private readonly IPublishingTaskManager _publishingTaskManager;
@@ -19,62 +17,51 @@ namespace Orchard.Blogs.Services
         public BlogPostService(
             IContentManager contentManager,
             IRepository<BlogPartArchiveRecord> blogArchiveRepository,
-            IPublishingTaskManager publishingTaskManager,
-            IContentDefinitionManager contentDefinitionManager)
-        {
+            IPublishingTaskManager publishingTaskManager) {
             _contentManager = contentManager;
             _blogArchiveRepository = blogArchiveRepository;
             _publishingTaskManager = publishingTaskManager;
         }
 
-        public BlogPostPart Get(int id)
-        {
+        public BlogPostPart Get(int id) {
             return Get(id, VersionOptions.Published);
         }
 
-        public BlogPostPart Get(int id, VersionOptions versionOptions)
-        {
+        public BlogPostPart Get(int id, VersionOptions versionOptions) {
             return _contentManager.Get<BlogPostPart>(id, versionOptions);
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart)
-        {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart) {
             return Get(blogPart, VersionOptions.Published);
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, VersionOptions versionOptions)
-        {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, VersionOptions versionOptions) {
             return GetBlogQuery(blogPart, versionOptions).List().Select(ci => ci.As<BlogPostPart>());
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, int skip, int count)
-        {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, int skip, int count) {
             return Get(blogPart, skip, count, VersionOptions.Published);
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, int skip, int count, VersionOptions versionOptions)
-        {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, int skip, int count, VersionOptions versionOptions) {
             return GetBlogQuery(blogPart, versionOptions)
                     .Slice(skip, count)
                     .ToList()
                     .Select(ci => ci.As<BlogPostPart>());
         }
 
-        public int PostCount(BlogPart blogPart)
-        {
+        public int PostCount(BlogPart blogPart) {
             return PostCount(blogPart, VersionOptions.Published);
         }
 
-        public int PostCount(BlogPart blogPart, VersionOptions versionOptions)
-        {
+        public int PostCount(BlogPart blogPart, VersionOptions versionOptions) {
             return _contentManager.Query<BlogPostPart>(versionOptions)
                 .Join<CommonPartRecord>().Where(
                     cr => cr.Container.Id == blogPart.Id)
                 .Count();
         }
 
-        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, ArchiveData archiveData)
-        {
+        public IEnumerable<BlogPostPart> Get(BlogPart blogPart, ArchiveData archiveData) {
             var query = GetBlogQuery(blogPart, VersionOptions.Published);
 
             if (archiveData.Day > 0)
@@ -99,8 +86,7 @@ namespace Orchard.Blogs.Services
             return query.List().Select(ci => ci.As<BlogPostPart>());
         }
 
-        public IEnumerable<KeyValuePair<ArchiveData, int>> GetArchives(BlogPart blogPart)
-        {
+        public IEnumerable<KeyValuePair<ArchiveData, int>> GetArchives(BlogPart blogPart) {
             var query =
                 from bar in _blogArchiveRepository.Table
                 where bar.BlogPart.Id == blogPart.Id
@@ -114,36 +100,30 @@ namespace Orchard.Blogs.Services
                                                        bar.PostCount));
         }
 
-        public void Delete(BlogPostPart blogPostPart)
-        {
+        public void Delete(BlogPostPart blogPostPart) {
             _publishingTaskManager.DeleteTasks(blogPostPart.ContentItem);
             _contentManager.Remove(blogPostPart.ContentItem);
         }
 
-        public void Publish(BlogPostPart blogPostPart)
-        {
+        public void Publish(BlogPostPart blogPostPart) {
             _publishingTaskManager.DeleteTasks(blogPostPart.ContentItem);
             _contentManager.Publish(blogPostPart.ContentItem);
         }
 
-        public void Publish(BlogPostPart blogPostPart, DateTime scheduledPublishUtc)
-        {
+        public void Publish(BlogPostPart blogPostPart, DateTime scheduledPublishUtc) {
             _publishingTaskManager.Publish(blogPostPart.ContentItem, scheduledPublishUtc);
         }
 
-        public void Unpublish(BlogPostPart blogPostPart)
-        {
+        public void Unpublish(BlogPostPart blogPostPart) {
             _contentManager.Unpublish(blogPostPart.ContentItem);
         }
 
-        public DateTime? GetScheduledPublishUtc(BlogPostPart blogPostPart)
-        {
+        public DateTime? GetScheduledPublishUtc(BlogPostPart blogPostPart) {
             var task = _publishingTaskManager.GetPublishTask(blogPostPart.ContentItem);
             return (task == null ? null : task.ScheduledUtc);
         }
 
-        private IContentQuery<BlogPostPart, CommonPartRecord> GetBlogQuery(BlogPart blog, VersionOptions versionOptions)
-        {
+        private IContentQuery<BlogPostPart, CommonPartRecord> GetBlogQuery(BlogPart blog, VersionOptions versionOptions) {
             return
                 _contentManager.Query<BlogPostPart>(versionOptions)
                 .Join<CommonPartRecord>().Where(

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogPostsCountProcessor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogPostsCountProcessor.cs
@@ -2,19 +2,24 @@
 using Orchard.ContentManagement;
 using Orchard.Core.Common.Models;
 
-namespace Orchard.Blogs.Services {
-    public class BlogPostsCountProcessor : IBlogPostsCountProcessor {
+namespace Orchard.Blogs.Services
+{
+    public class BlogPostsCountProcessor : IBlogPostsCountProcessor
+    {
         private readonly IContentManager _contentManager;
 
         public BlogPostsCountProcessor(
-            IContentManager contentManager) {
+            IContentManager contentManager)
+        {
             _contentManager = contentManager;
         }
 
-        public void Process(int blogPartId) {
+        public void Process(int blogPartId)
+        {
             var blogPart = _contentManager.Get<BlogPart>(blogPartId);
-            if (blogPart != null) {
-                var count = _contentManager.Query(VersionOptions.Published, "BlogPost")
+            if (blogPart != null)
+            {
+                var count = _contentManager.Query(VersionOptions.Published)
                     .Join<CommonPartRecord>().Where(
                         cr => cr.Container.Id == blogPartId)
                     .Count();

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogPostsCountProcessor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogPostsCountProcessor.cs
@@ -4,18 +4,15 @@ using Orchard.Core.Common.Models;
 
 namespace Orchard.Blogs.Services
 {
-    public class BlogPostsCountProcessor : IBlogPostsCountProcessor
-    {
+    public class BlogPostsCountProcessor : IBlogPostsCountProcessor {
         private readonly IContentManager _contentManager;
 
         public BlogPostsCountProcessor(
-            IContentManager contentManager)
-        {
+            IContentManager contentManager) {
             _contentManager = contentManager;
         }
 
-        public void Process(int blogPartId)
-        {
+        public void Process(int blogPartId) {
             var blogPart = _contentManager.Get<BlogPart>(blogPartId);
             if (blogPart != null)
             {

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogService.cs
@@ -5,72 +5,97 @@ using Orchard.Autoroute.Services;
 using Orchard.Blogs.Models;
 using Orchard.Caching;
 using Orchard.ContentManagement;
+using Orchard.ContentManagement.MetaData;
+using Orchard.ContentManagement.MetaData.Models;
 using Orchard.Core.Title.Models;
 using Orchard.Environment.Configuration;
 using Orchard.Environment.Descriptor;
 using Orchard.Environment.State;
 
-namespace Orchard.Blogs.Services {
-    public class BlogService : IBlogService {
+namespace Orchard.Blogs.Services
+{
+    public class BlogService : IBlogService
+    {
         private readonly IContentManager _contentManager;
         private readonly IProcessingEngine _processingEngine;
         private readonly ShellSettings _shellSettings;
         private readonly IShellDescriptorManager _shellDescriptorManager;
         private readonly HashSet<int> _processedBlogParts = new HashSet<int>();
         IPathResolutionService _pathResolutionService;
+        private readonly IContentDefinitionManager _contentDefinitionManager;
 
         public BlogService(
             IContentManager contentManager,
             IProcessingEngine processingEngine,
             ShellSettings shellSettings,
             IShellDescriptorManager shellDescriptorManager,
-            IPathResolutionService pathResolutionService) {
+            IPathResolutionService pathResolutionService,
+            IContentDefinitionManager contentDefinitionManager)
+        {
             _contentManager = contentManager;
             _processingEngine = processingEngine;
             _shellSettings = shellSettings;
             _shellDescriptorManager = shellDescriptorManager;
             _pathResolutionService = pathResolutionService;
+            _contentDefinitionManager = contentDefinitionManager;
         }
 
-        public BlogPart Get(string path) {
+        public BlogPart Get(string path)
+        {
             var blog = _pathResolutionService.GetPath(path);
 
-            if (blog == null) {
+            if (blog == null)
+            {
                 return null;
             }
 
-            if (!blog.Has<BlogPart>()) {
+            if (!blog.Has<BlogPart>())
+            {
                 return null;
             }
 
             return blog.As<BlogPart>();
         }
 
-        public ContentItem Get(int id, VersionOptions versionOptions) {
+        public ContentItem Get(int id, VersionOptions versionOptions)
+        {
             var blogPart = _contentManager.Get<BlogPart>(id, versionOptions);
             return blogPart == null ? null : blogPart.ContentItem;
         }
 
-        public IEnumerable<BlogPart> Get() {
+        public IEnumerable<BlogPart> Get()
+        {
             return Get(VersionOptions.Published);
         }
 
-        public IEnumerable<BlogPart> Get(VersionOptions versionOptions) {
+        public IEnumerable<BlogPart> Get(VersionOptions versionOptions)
+        {
             return _contentManager.Query<BlogPart>(versionOptions, "Blog")
                 .Join<TitlePartRecord>()
                 .OrderBy(br => br.Title)
                 .List();
         }
 
-        public void Delete(ContentItem blog) {
+        public void Delete(ContentItem blog)
+        {
             _contentManager.Remove(blog);
         }
 
-        public void ProcessBlogPostsCount(int blogPartId) {
-            if (!_processedBlogParts.Contains(blogPartId)) {
+        public void ProcessBlogPostsCount(int blogPartId)
+        {
+            if (!_processedBlogParts.Contains(blogPartId))
+            {
                 _processedBlogParts.Add(blogPartId);
                 _processingEngine.AddTask(_shellSettings, _shellDescriptorManager.GetShellDescriptor(), "IBlogPostsCountProcessor.Process", new Dictionary<string, object> { { "blogPartId", blogPartId } });
             }
+        }
+
+        public IEnumerable<ContentTypeDefinition> GetBlogPostContentTypes()
+        {
+            var blogPostTypes = _contentDefinitionManager.ListTypeDefinitions().Where(ctd =>
+                ctd.Parts.Any(x => x.PartDefinition.Name == "BlogPostPart"));
+
+            return blogPostTypes;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogService.cs
@@ -14,8 +14,7 @@ using Orchard.Environment.State;
 
 namespace Orchard.Blogs.Services
 {
-    public class BlogService : IBlogService
-    {
+    public class BlogService : IBlogService {
         private readonly IContentManager _contentManager;
         private readonly IProcessingEngine _processingEngine;
         private readonly ShellSettings _shellSettings;
@@ -30,8 +29,7 @@ namespace Orchard.Blogs.Services
             ShellSettings shellSettings,
             IShellDescriptorManager shellDescriptorManager,
             IPathResolutionService pathResolutionService,
-            IContentDefinitionManager contentDefinitionManager)
-        {
+            IContentDefinitionManager contentDefinitionManager) {
             _contentManager = contentManager;
             _processingEngine = processingEngine;
             _shellSettings = shellSettings;
@@ -40,8 +38,7 @@ namespace Orchard.Blogs.Services
             _contentDefinitionManager = contentDefinitionManager;
         }
 
-        public BlogPart Get(string path)
-        {
+        public BlogPart Get(string path) {
             var blog = _pathResolutionService.GetPath(path);
 
             if (blog == null)
@@ -57,32 +54,27 @@ namespace Orchard.Blogs.Services
             return blog.As<BlogPart>();
         }
 
-        public ContentItem Get(int id, VersionOptions versionOptions)
-        {
+        public ContentItem Get(int id, VersionOptions versionOptions) {
             var blogPart = _contentManager.Get<BlogPart>(id, versionOptions);
             return blogPart == null ? null : blogPart.ContentItem;
         }
 
-        public IEnumerable<BlogPart> Get()
-        {
+        public IEnumerable<BlogPart> Get() {
             return Get(VersionOptions.Published);
         }
 
-        public IEnumerable<BlogPart> Get(VersionOptions versionOptions)
-        {
+        public IEnumerable<BlogPart> Get(VersionOptions versionOptions) {
             return _contentManager.Query<BlogPart>(versionOptions, "Blog")
                 .Join<TitlePartRecord>()
                 .OrderBy(br => br.Title)
                 .List();
         }
 
-        public void Delete(ContentItem blog)
-        {
+        public void Delete(ContentItem blog) {
             _contentManager.Remove(blog);
         }
 
-        public void ProcessBlogPostsCount(int blogPartId)
-        {
+        public void ProcessBlogPostsCount(int blogPartId) {
             if (!_processedBlogParts.Contains(blogPartId))
             {
                 _processedBlogParts.Add(blogPartId);
@@ -90,8 +82,7 @@ namespace Orchard.Blogs.Services
             }
         }
 
-        public IEnumerable<ContentTypeDefinition> GetBlogPostContentTypes()
-        {
+        public IEnumerable<ContentTypeDefinition> GetBlogPostContentTypes() {
             var blogPostTypes = _contentDefinitionManager.ListTypeDefinitions().Where(ctd =>
                 ctd.Parts.Any(x => x.PartDefinition.Name == "BlogPostPart"));
 

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/IBlogService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/IBlogService.cs
@@ -5,8 +5,7 @@ using Orchard.ContentManagement.MetaData.Models;
 
 namespace Orchard.Blogs.Services
 {
-    public interface IBlogService : IDependency
-    {
+    public interface IBlogService : IDependency {
         BlogPart Get(string path);
         ContentItem Get(int id, VersionOptions versionOptions);
         IEnumerable<BlogPart> Get();

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/IBlogService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/IBlogService.cs
@@ -1,14 +1,18 @@
 using System.Collections.Generic;
 using Orchard.Blogs.Models;
 using Orchard.ContentManagement;
+using Orchard.ContentManagement.MetaData.Models;
 
-namespace Orchard.Blogs.Services {
-    public interface IBlogService : IDependency {
+namespace Orchard.Blogs.Services
+{
+    public interface IBlogService : IDependency
+    {
         BlogPart Get(string path);
         ContentItem Get(int id, VersionOptions versionOptions);
         IEnumerable<BlogPart> Get();
         IEnumerable<BlogPart> Get(VersionOptions versionOptions);
         void Delete(ContentItem blog);
         void ProcessBlogPostsCount(int blogPartId);
+        IEnumerable<ContentTypeDefinition> GetBlogPostContentTypes();
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/XmlRpcHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/XmlRpcHandler.cs
@@ -19,9 +19,11 @@ using Orchard.Blogs.Extensions;
 using Orchard.Mvc.Html;
 using Orchard.Core.Title.Models;
 
-namespace Orchard.Blogs.Services {
+namespace Orchard.Blogs.Services
+{
     [OrchardFeature("Orchard.Blogs.RemotePublishing")]
-    public class XmlRpcHandler : IXmlRpcHandler {
+    public class XmlRpcHandler : IXmlRpcHandler
+    {
         private readonly IBlogService _blogService;
         private readonly IBlogPostService _blogPostService;
         private readonly IContentManager _contentManager;
@@ -30,8 +32,9 @@ namespace Orchard.Blogs.Services {
         private readonly RouteCollection _routeCollection;
 
         public XmlRpcHandler(IBlogService blogService, IBlogPostService blogPostService, IContentManager contentManager,
-            IAuthorizationService authorizationService, IMembershipService membershipService, 
-            RouteCollection routeCollection) {
+            IAuthorizationService authorizationService, IMembershipService membershipService,
+            RouteCollection routeCollection)
+        {
             _blogService = blogService;
             _blogPostService = blogPostService;
             _contentManager = contentManager;
@@ -45,15 +48,18 @@ namespace Orchard.Blogs.Services {
         public ILogger Logger { get; set; }
         public Localizer T { get; set; }
 
-        public void SetCapabilities(XElement options) {
+        public void SetCapabilities(XElement options)
+        {
             const string manifestUri = "http://schemas.microsoft.com/wlw/manifest/weblog";
             options.SetElementValue(XName.Get("supportsSlug", manifestUri), "Yes");
         }
 
-        public void Process(XmlRpcContext context) {
+        public void Process(XmlRpcContext context)
+        {
             var urlHelper = new UrlHelper(context.ControllerContext.RequestContext, _routeCollection);
 
-            if (context.Request.MethodName == "blogger.getUsersBlogs") {
+            if (context.Request.MethodName == "blogger.getUsersBlogs")
+            {
                 var result = MetaWeblogGetUserBlogs(urlHelper,
                     Convert.ToString(context.Request.Params[1].Value),
                     Convert.ToString(context.Request.Params[2].Value));
@@ -61,7 +67,8 @@ namespace Orchard.Blogs.Services {
                 context.Response = new XRpcMethodResponse().Add(result);
             }
 
-            if (context.Request.MethodName == "metaWeblog.getRecentPosts") {
+            if (context.Request.MethodName == "metaWeblog.getRecentPosts")
+            {
                 var result = MetaWeblogGetRecentPosts(urlHelper,
                     Convert.ToString(context.Request.Params[0].Value),
                     Convert.ToString(context.Request.Params[1].Value),
@@ -72,7 +79,8 @@ namespace Orchard.Blogs.Services {
                 context.Response = new XRpcMethodResponse().Add(result);
             }
 
-            if (context.Request.MethodName == "metaWeblog.newPost") {
+            if (context.Request.MethodName == "metaWeblog.newPost")
+            {
                 var result = MetaWeblogNewPost(
                     Convert.ToString(context.Request.Params[0].Value),
                     Convert.ToString(context.Request.Params[1].Value),
@@ -84,7 +92,8 @@ namespace Orchard.Blogs.Services {
                 context.Response = new XRpcMethodResponse().Add(result);
             }
 
-            if (context.Request.MethodName == "metaWeblog.getPost") {
+            if (context.Request.MethodName == "metaWeblog.getPost")
+            {
                 var result = MetaWeblogGetPost(
                     urlHelper,
                     Convert.ToInt32(context.Request.Params[0].Value),
@@ -94,7 +103,8 @@ namespace Orchard.Blogs.Services {
                 context.Response = new XRpcMethodResponse().Add(result);
             }
 
-            if (context.Request.MethodName == "metaWeblog.editPost") {
+            if (context.Request.MethodName == "metaWeblog.editPost")
+            {
                 var result = MetaWeblogEditPost(
                     Convert.ToInt32(context.Request.Params[0].Value),
                     Convert.ToString(context.Request.Params[1].Value),
@@ -105,7 +115,8 @@ namespace Orchard.Blogs.Services {
                 context.Response = new XRpcMethodResponse().Add(result);
             }
 
-            if (context.Request.MethodName == "blogger.deletePost") {
+            if (context.Request.MethodName == "blogger.deletePost")
+            {
                 var result = MetaWeblogDeletePost(
                     Convert.ToString(context.Request.Params[1].Value),
                     Convert.ToString(context.Request.Params[2].Value),
@@ -117,14 +128,17 @@ namespace Orchard.Blogs.Services {
 
         private XRpcArray MetaWeblogGetUserBlogs(UrlHelper urlHelper,
             string userName,
-            string password) {
+            string password)
+        {
 
             IUser user = ValidateUser(userName, password);
 
             XRpcArray array = new XRpcArray();
-            foreach (BlogPart blog in _blogService.Get()) {
+            foreach (BlogPart blog in _blogService.Get())
+            {
                 // User needs to at least have permission to edit its own blog posts to access the service
-                if (_authorizationService.TryCheckAccess(Permissions.EditBlogPost, user, blog)) {
+                if (_authorizationService.TryCheckAccess(Permissions.EditBlogPost, user, blog))
+                {
 
                     BlogPart blogPart = blog;
                     array.Add(new XRpcStruct()
@@ -143,7 +157,8 @@ namespace Orchard.Blogs.Services {
             string userName,
             string password,
             int numberOfPosts,
-            IEnumerable<IXmlRpcDriver> drivers) {
+            IEnumerable<IXmlRpcDriver> drivers)
+        {
 
             IUser user = ValidateUser(userName, password);
 
@@ -151,12 +166,14 @@ namespace Orchard.Blogs.Services {
             _authorizationService.CheckAccess(Permissions.EditBlogPost, user, null);
 
             BlogPart blog = _contentManager.Get<BlogPart>(Convert.ToInt32(blogId));
-            if (blog == null) {
+            if (blog == null)
+            {
                 throw new ArgumentException();
             }
 
             var array = new XRpcArray();
-            foreach (var blogPost in _blogPostService.Get(blog, 0, numberOfPosts, VersionOptions.Latest)) {
+            foreach (var blogPost in _blogPostService.Get(blog, 0, numberOfPosts, VersionOptions.Latest))
+            {
                 var postStruct = CreateBlogStruct(blogPost, urlHelper);
 
                 foreach (var driver in drivers)
@@ -173,7 +190,8 @@ namespace Orchard.Blogs.Services {
             string password,
             XRpcStruct content,
             bool publish,
-            IEnumerable<IXmlRpcDriver> drivers) {
+            IEnumerable<IXmlRpcDriver> drivers)
+        {
 
             IUser user = ValidateUser(userName, password);
 
@@ -188,27 +206,32 @@ namespace Orchard.Blogs.Services {
             var description = content.Optional<string>("description");
             var slug = content.Optional<string>("wp_slug");
 
+            //TODO: Needs contentType parameter. See: http://orchard.uservoice.com/forums/50435-general/suggestions/9064510-multiple-blogpost-type-support
             var blogPost = _contentManager.New<BlogPostPart>("BlogPost");
 
             // BodyPart
-            if (blogPost.Is<BodyPart>()) {
+            if (blogPost.Is<BodyPart>())
+            {
                 blogPost.As<BodyPart>().Text = description;
             }
 
             //CommonPart
-            if (blogPost.Is<ICommonPart>()) {
+            if (blogPost.Is<ICommonPart>())
+            {
                 blogPost.As<ICommonPart>().Owner = user;
                 blogPost.As<ICommonPart>().Container = blog;
             }
 
             //TitlePart
-            if (blogPost.Is<TitlePart>()) {
+            if (blogPost.Is<TitlePart>())
+            {
                 blogPost.As<TitlePart>().Title = HttpUtility.HtmlDecode(title);
             }
-            
+
             //AutoroutePart
             dynamic dBlogPost = blogPost;
-            if (dBlogPost.AutoroutePart!=null){
+            if (dBlogPost.AutoroutePart != null)
+            {
                 dBlogPost.AutoroutePart.DisplayAlias = slug;
             }
 
@@ -216,11 +239,13 @@ namespace Orchard.Blogs.Services {
 
             // try to get the UTC timezone by default
             var publishedUtc = content.Optional<DateTime?>("date_created_gmt");
-            if (publishedUtc == null) {
+            if (publishedUtc == null)
+            {
                 // take the local one
                 publishedUtc = content.Optional<DateTime?>("dateCreated");
             }
-            else {
+            else
+            {
                 // ensure it's read as a UTC time
                 publishedUtc = new DateTime(publishedUtc.Value.Ticks, DateTimeKind.Utc);
             }
@@ -228,7 +253,8 @@ namespace Orchard.Blogs.Services {
             if (publish && (publishedUtc == null || publishedUtc <= DateTime.UtcNow))
                 _blogPostService.Publish(blogPost);
 
-            if (publishedUtc != null) {
+            if (publishedUtc != null)
+            {
                 blogPost.As<CommonPart>().CreatedUtc = publishedUtc;
             }
 
@@ -243,7 +269,8 @@ namespace Orchard.Blogs.Services {
             int postId,
             string userName,
             string password,
-            IEnumerable<IXmlRpcDriver> drivers) {
+            IEnumerable<IXmlRpcDriver> drivers)
+        {
 
             IUser user = ValidateUser(userName, password);
             var blogPost = _blogPostService.Get(postId, VersionOptions.Latest);
@@ -266,11 +293,13 @@ namespace Orchard.Blogs.Services {
             string password,
             XRpcStruct content,
             bool publish,
-            IEnumerable<IXmlRpcDriver> drivers) {
+            IEnumerable<IXmlRpcDriver> drivers)
+        {
 
             IUser user = ValidateUser(userName, password);
             var blogPost = _blogPostService.Get(postId, VersionOptions.DraftRequired);
-            if (blogPost == null) {
+            if (blogPost == null)
+            {
                 throw new OrchardCoreException(T("The specified Blog Post doesn't exist anymore. Please create a new Blog Post."));
             }
 
@@ -281,27 +310,32 @@ namespace Orchard.Blogs.Services {
             var slug = content.Optional<string>("wp_slug");
 
             // BodyPart
-            if (blogPost.Is<BodyPart>()) {
+            if (blogPost.Is<BodyPart>())
+            {
                 blogPost.As<BodyPart>().Text = description;
             }
 
             //TitlePart
-            if (blogPost.Is<TitlePart>()) {
+            if (blogPost.Is<TitlePart>())
+            {
                 blogPost.As<TitlePart>().Title = HttpUtility.HtmlDecode(title);
             }
             //AutoroutePart
             dynamic dBlogPost = blogPost;
-            if (dBlogPost.AutoroutePart != null) {
+            if (dBlogPost.AutoroutePart != null)
+            {
                 dBlogPost.AutoroutePart.DisplayAlias = slug;
             }
 
             // try to get the UTC timezone by default
             var publishedUtc = content.Optional<DateTime?>("date_created_gmt");
-            if (publishedUtc == null) {
+            if (publishedUtc == null)
+            {
                 // take the local one
                 publishedUtc = content.Optional<DateTime?>("dateCreated");
             }
-            else {
+            else
+            {
                 // ensure it's read as a UTC time
                 publishedUtc = new DateTime(publishedUtc.Value.Ticks, DateTimeKind.Utc);
             }
@@ -309,7 +343,8 @@ namespace Orchard.Blogs.Services {
             if (publish && (publishedUtc == null || publishedUtc <= DateTime.UtcNow))
                 _blogPostService.Publish(blogPost);
 
-            if (publishedUtc != null) {
+            if (publishedUtc != null)
+            {
                 blogPost.As<CommonPart>().CreatedUtc = publishedUtc;
             }
 
@@ -323,7 +358,8 @@ namespace Orchard.Blogs.Services {
             string postId,
             string userName,
             string password,
-            IEnumerable<IXmlRpcDriver> drivers) {
+            IEnumerable<IXmlRpcDriver> drivers)
+        {
 
             IUser user = ValidateUser(userName, password);
             var blogPost = _blogPostService.Get(Convert.ToInt32(postId), VersionOptions.Latest);
@@ -339,9 +375,11 @@ namespace Orchard.Blogs.Services {
             return true;
         }
 
-        private IUser ValidateUser(string userName, string password) {
+        private IUser ValidateUser(string userName, string password)
+        {
             IUser user = _membershipService.ValidateUser(userName, password);
-            if (user == null) {
+            if (user == null)
+            {
                 throw new OrchardCoreException(T("The username or e-mail or password provided is incorrect."));
             }
 
@@ -350,26 +388,29 @@ namespace Orchard.Blogs.Services {
 
         private static XRpcStruct CreateBlogStruct(
             BlogPostPart blogPostPart,
-            UrlHelper urlHelper) {
+            UrlHelper urlHelper)
+        {
 
             var url = urlHelper.AbsoluteAction(() => urlHelper.ItemDisplayUrl(blogPostPart));
 
-            if (blogPostPart.HasDraft()) {
+            if (blogPostPart.HasDraft())
+            {
                 url = urlHelper.AbsoluteAction("Preview", "Item", new { area = "Contents", id = blogPostPart.ContentItem.Id });
             }
 
             var blogStruct = new XRpcStruct()
                 .Set("postid", blogPostPart.Id)
                 .Set("title", HttpUtility.HtmlEncode(blogPostPart.Title))
-                
+
                 .Set("description", blogPostPart.Text)
                 .Set("link", url)
                 .Set("permaLink", url);
-            
-            blogStruct.Set("wp_slug", blogPostPart.As<IAliasAspect>().Path);
-            
 
-            if (blogPostPart.PublishedUtc != null) {
+            blogStruct.Set("wp_slug", blogPostPart.As<IAliasAspect>().Path);
+
+
+            if (blogPostPart.PublishedUtc != null)
+            {
                 blogStruct.Set("dateCreated", blogPostPart.PublishedUtc);
                 blogStruct.Set("date_created_gmt", blogPostPart.PublishedUtc);
             }

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/XmlRpcHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/XmlRpcHandler.cs
@@ -22,8 +22,7 @@ using Orchard.Core.Title.Models;
 namespace Orchard.Blogs.Services
 {
     [OrchardFeature("Orchard.Blogs.RemotePublishing")]
-    public class XmlRpcHandler : IXmlRpcHandler
-    {
+    public class XmlRpcHandler : IXmlRpcHandler {
         private readonly IBlogService _blogService;
         private readonly IBlogPostService _blogPostService;
         private readonly IContentManager _contentManager;
@@ -33,8 +32,7 @@ namespace Orchard.Blogs.Services
 
         public XmlRpcHandler(IBlogService blogService, IBlogPostService blogPostService, IContentManager contentManager,
             IAuthorizationService authorizationService, IMembershipService membershipService,
-            RouteCollection routeCollection)
-        {
+            RouteCollection routeCollection) {
             _blogService = blogService;
             _blogPostService = blogPostService;
             _contentManager = contentManager;
@@ -48,14 +46,12 @@ namespace Orchard.Blogs.Services
         public ILogger Logger { get; set; }
         public Localizer T { get; set; }
 
-        public void SetCapabilities(XElement options)
-        {
+        public void SetCapabilities(XElement options) {
             const string manifestUri = "http://schemas.microsoft.com/wlw/manifest/weblog";
             options.SetElementValue(XName.Get("supportsSlug", manifestUri), "Yes");
         }
 
-        public void Process(XmlRpcContext context)
-        {
+        public void Process(XmlRpcContext context) {
             var urlHelper = new UrlHelper(context.ControllerContext.RequestContext, _routeCollection);
 
             if (context.Request.MethodName == "blogger.getUsersBlogs")
@@ -128,8 +124,7 @@ namespace Orchard.Blogs.Services
 
         private XRpcArray MetaWeblogGetUserBlogs(UrlHelper urlHelper,
             string userName,
-            string password)
-        {
+            string password) {
 
             IUser user = ValidateUser(userName, password);
 
@@ -157,8 +152,7 @@ namespace Orchard.Blogs.Services
             string userName,
             string password,
             int numberOfPosts,
-            IEnumerable<IXmlRpcDriver> drivers)
-        {
+            IEnumerable<IXmlRpcDriver> drivers) {
 
             IUser user = ValidateUser(userName, password);
 
@@ -190,8 +184,7 @@ namespace Orchard.Blogs.Services
             string password,
             XRpcStruct content,
             bool publish,
-            IEnumerable<IXmlRpcDriver> drivers)
-        {
+            IEnumerable<IXmlRpcDriver> drivers) {
 
             IUser user = ValidateUser(userName, password);
 
@@ -269,8 +262,7 @@ namespace Orchard.Blogs.Services
             int postId,
             string userName,
             string password,
-            IEnumerable<IXmlRpcDriver> drivers)
-        {
+            IEnumerable<IXmlRpcDriver> drivers) {
 
             IUser user = ValidateUser(userName, password);
             var blogPost = _blogPostService.Get(postId, VersionOptions.Latest);
@@ -293,8 +285,7 @@ namespace Orchard.Blogs.Services
             string password,
             XRpcStruct content,
             bool publish,
-            IEnumerable<IXmlRpcDriver> drivers)
-        {
+            IEnumerable<IXmlRpcDriver> drivers) {
 
             IUser user = ValidateUser(userName, password);
             var blogPost = _blogPostService.Get(postId, VersionOptions.DraftRequired);
@@ -358,8 +349,7 @@ namespace Orchard.Blogs.Services
             string postId,
             string userName,
             string password,
-            IEnumerable<IXmlRpcDriver> drivers)
-        {
+            IEnumerable<IXmlRpcDriver> drivers) {
 
             IUser user = ValidateUser(userName, password);
             var blogPost = _blogPostService.Get(Convert.ToInt32(postId), VersionOptions.Latest);
@@ -375,8 +365,7 @@ namespace Orchard.Blogs.Services
             return true;
         }
 
-        private IUser ValidateUser(string userName, string password)
-        {
+        private IUser ValidateUser(string userName, string password) {
             IUser user = _membershipService.ValidateUser(userName, password);
             if (user == null)
             {
@@ -388,8 +377,7 @@ namespace Orchard.Blogs.Services
 
         private static XRpcStruct CreateBlogStruct(
             BlogPostPart blogPostPart,
-            UrlHelper urlHelper)
-        {
+            UrlHelper urlHelper) {
 
             var url = urlHelper.AbsoluteAction(() => urlHelper.ItemDisplayUrl(blogPostPart));
 

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Views/BlogPostAdmin/Create.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Views/BlogPostAdmin/Create.cshtml
@@ -1,9 +1,6 @@
-@{
-    Layout.Title = T("New {0}", Model.ContentItem.TypeDefinition.DisplayName).ToString();
-}
+@{ Layout.Title = T("New {0}", Model.ContentItem.TypeDefinition.DisplayName).ToString(); }
 
-@using (Html.BeginFormAntiForgeryPost())
-{
+@using (Html.BeginFormAntiForgeryPost()) {
     @Html.ValidationSummary()
     // Model is a Shape, calling Display() so that it is rendered using the most specific template for its Shape type
     @Display(Model)

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Views/BlogPostAdmin/Create.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Views/BlogPostAdmin/Create.cshtml
@@ -1,6 +1,9 @@
-@{ Layout.Title = T("New Post").ToString(); }
+@{
+    Layout.Title = T("New {0}", Model.ContentItem.TypeDefinition.DisplayName).ToString();
+}
 
-@using (Html.BeginFormAntiForgeryPost()) {
+@using (Html.BeginFormAntiForgeryPost())
+{
     @Html.ValidationSummary()
     // Model is a Shape, calling Display() so that it is rendered using the most specific template for its Shape type
     @Display(Model)

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Views/BlogPostAdmin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Views/BlogPostAdmin/Edit.cshtml
@@ -1,6 +1,9 @@
-@{ Layout.Title = T("Edit Blog Post").ToString(); }
+@{
+    Layout.Title = T("Edit {0}", Model.ContentItem.TypeDefinition.DisplayName).ToString();
+}
 
-@using (Html.BeginFormAntiForgeryPost()) {
+@using (Html.BeginFormAntiForgeryPost())
+{
     @Html.ValidationSummary()
     // Model is a Shape, calling Display() so that it is rendered using the most specific template for its Shape type
     @Display(Model)

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Views/BlogPostAdmin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Views/BlogPostAdmin/Edit.cshtml
@@ -1,9 +1,6 @@
-@{
-    Layout.Title = T("Edit {0}", Model.ContentItem.TypeDefinition.DisplayName).ToString();
-}
+@{ Layout.Title = T("Edit {0}", Model.ContentItem.TypeDefinition.DisplayName).ToString(); }
 
-@using (Html.BeginFormAntiForgeryPost())
-{
+@using (Html.BeginFormAntiForgeryPost()) {
     @Html.ValidationSummary()
     // Model is a Shape, calling Display() so that it is rendered using the most specific template for its Shape type
     @Display(Model)

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Views/Parts.Blogs.Blog.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Views/Parts.Blogs.Blog.SummaryAdmin.cshtml
@@ -1,10 +1,15 @@
 ﻿@using Orchard.Blogs.Extensions;
 @using Orchard.Blogs.Models;
 @using Orchard.ContentManagement;
+@using Orchard.ContentManagement.MetaData.Models
 @using Orchard.Utility.Extensions;
 @{
     ContentItem contentItem = Model.ContentItem;
     BlogPart blog = (BlogPart)contentItem.Get(typeof(BlogPart));
 }
 <a href="@Url.BlogForAdmin(blog)" title="@T("List Posts")">@T("List Posts")</a>@T(" | ")
-<a href="@Url.BlogPostCreate(blog)" title="@T("New Post")">@T("New Post")</a>@T(" | ")
+
+@foreach (ContentTypeDefinition blogPostType in Layout.BlogPostContentTypes)
+{
+    <a href="@Url.BlogPostCreate(blog,blogPostType.Name)" title="@T("New {0}", blogPostType.DisplayName)">@T("New {0}", blogPostType.DisplayName)</a>@T(" | ")
+}

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Views/Parts.Blogs.Blog.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Views/Parts.Blogs.Blog.SummaryAdmin.cshtml
@@ -9,7 +9,6 @@
 }
 <a href="@Url.BlogForAdmin(blog)" title="@T("List Posts")">@T("List Posts")</a>@T(" | ")
 
-@foreach (ContentTypeDefinition blogPostType in Layout.BlogPostContentTypes)
-{
+@foreach (ContentTypeDefinition blogPostType in Layout.BlogPostContentTypes) {
     <a href="@Url.BlogPostCreate(blog,blogPostType.Name)" title="@T("New {0}", blogPostType.DisplayName)">@T("New {0}", blogPostType.DisplayName)</a>@T(" | ")
 }


### PR DESCRIPTION
For reference: http://orchard.uservoice.com/forums/50435-general/suggestions/9064510-multiple-blogpost-type-support

![orchard-blog-example](https://cloud.githubusercontent.com/assets/5072557/8944423/eed11b6e-3580-11e5-8884-03b7092c64d2.png)


- BlogPostPart ContentPart is also made Attachable() in migration, while this creates more flexibility in creating custom ContentTypes in the Content Definition admin, it might also create some implications as the Blog module functionality requires ContentTypes which have a BlogPostPart attached to also have TitlePart and BodyPart attached.