### PR TITLE
Fixes 5591 : ContentType names html encoded twice.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/Edit.cshtml
@@ -2,7 +2,7 @@
 @{
     Style.Require("ContentTypesAdmin");
     Script.Require("jQuery");
-    Layout.Title = T("Edit Content Type - {0}", new HtmlString(Model.DisplayName)).ToString();
+    Layout.Title = T("Edit Content Type - {0}", Model.DisplayName);
 }
 
 <div class="manage">

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/Edit.cshtml
@@ -2,7 +2,7 @@
 @{
     Style.Require("ContentTypesAdmin");
     Script.Require("jQuery");
-    Layout.Title = T("Edit Content Type - {0}", Model.DisplayName).ToString();
+    Layout.Title = T("Edit Content Type - {0}", new HtmlString(Model.DisplayName)).ToString();
 }
 
 <div class="manage">

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/EditField.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/EditField.cshtml
@@ -3,7 +3,7 @@
 @{
     Style.Require("ContentTypesAdmin");
 
-    Layout.Title = T("Edit Field \"{0}\"", Model.Name);
+    Layout.Title = T("Edit Field \"{0}\"", Model.DisplayName);
 }
 
 @using (Html.BeginFormAntiForgeryPost()) {

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/EditField.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/EditField.cshtml
@@ -3,7 +3,7 @@
 @{
     Style.Require("ContentTypesAdmin");
 
-    Layout.Title = T("Edit Field \"{0}\"", new HtmlString(Model.DisplayName)).ToString();
+    Layout.Title = T("Edit Field \"{0}\"", Model.Name);
 }
 
 @using (Html.BeginFormAntiForgeryPost()) {

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/EditField.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/EditField.cshtml
@@ -3,7 +3,7 @@
 @{
     Style.Require("ContentTypesAdmin");
 
-    Layout.Title = T("Edit Field \"{0}\"", Model.Name).ToString();
+    Layout.Title = T("Edit Field \"{0}\"", new HtmlString(Model.DisplayName)).ToString();
 }
 
 @using (Html.BeginFormAntiForgeryPost()) {

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/DisplayTemplates/EditTypeViewModel.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/DisplayTemplates/EditTypeViewModel.cshtml
@@ -9,7 +9,7 @@
     <div class="properties">
         <h3>@Model.DisplayName</h3> @if (!string.IsNullOrWhiteSpace(stereotype)) { <text><span class="stereotype" title="Stereotype">- @stereotype</span></text>}
         @if (creatable) {
-        <p class="pageStatus">@Html.ActionLink(T("Create New {0}", Model.DisplayName).Text, "Create", new {area = "Contents", id = Model.Name})</p>
+        <p class="pageStatus">@Html.ActionLink(T("Create New {0}", new HtmlString(Model.DisplayName)).Text, "Create", new {area = "Contents", id = Model.Name})</p>
         }
     </div>
     <div class="related">@if (creatable) {


### PR DESCRIPTION
Shows Field's DisplayName instead of technical name in title.