### PR TITLE
Fixes #5607 - Assets.json options

### DIFF
--- a/src/Gulpfile.js
+++ b/src/Gulpfile.js
@@ -126,7 +126,7 @@ function buildCssPipeline(assetGroup, doRebuild) {
     else {
         console.log("Force Rebuild is enabled, rebuilding all input files.");
     }
-    var generateSourceMaps = assetGroup.generateSourceMaps !== undefined ? assetGroup.generateSourceMaps : true;
+    var generateSourceMaps = assetGroup.hasOwnProperty("generateSourceMaps") ? assetGroup.generateSourceMaps : true;
     return gulp.src(assetGroup.inputPaths)
         .pipe(gulpif(!doRebuild,
             gulpif(doConcat,
@@ -164,7 +164,7 @@ function buildJsPipeline(assetGroup, doRebuild) {
             throw "Input file '" + inputPath + "' is not of a valid type for output file '" + assetGroup.outputPath + "'.";
     });
     var doConcat = path.basename(assetGroup.outputFileName, ".js") !== "@";
-    var generateSourceMaps = assetGroup.generateSourceMaps !== undefined ? assetGroup.generateSourceMaps : true;
+    var generateSourceMaps = assetGroup.hasOwnProperty("generateSourceMaps") ? assetGroup.generateSourceMaps : true;
     return gulp.src(assetGroup.inputPaths)
         .pipe(gulpif(!doRebuild,
             gulpif(doConcat,
@@ -181,7 +181,7 @@ function buildJsPipeline(assetGroup, doRebuild) {
             noEmitOnError: true,
             sortOutput: true,
         }).js))
-	.pipe(gulpif(doConcat, concat(assetGroup.outputFileName)))
+		.pipe(gulpif(doConcat, concat(assetGroup.outputFileName)))
         // TODO: Start using below whenever gulp-header supports sourcemaps.
         //.pipe(header(
         //    "/*\n" +
@@ -191,9 +191,9 @@ function buildJsPipeline(assetGroup, doRebuild) {
         //    "*/\n\n"))
         .pipe(gulpif(generateSourceMaps, sourcemaps.write()))
         .pipe(gulp.dest(assetGroup.outputDir))
-	.pipe(uglify())
-	.pipe(rename({
-	    suffix: ".min"
-	}))
-	.pipe(gulp.dest(assetGroup.outputDir));
+		.pipe(uglify())
+		.pipe(rename({
+		    suffix: ".min"
+		}))
+		.pipe(gulp.dest(assetGroup.outputDir));
 }

--- a/src/Gulpfile.js
+++ b/src/Gulpfile.js
@@ -36,6 +36,10 @@ gulp.task("rebuild", function () {
 // Continuous watch (each asset group is built whenever one of its inputs changes).
 gulp.task("watch", function () {
     getAssetGroups().forEach(function (assetGroup) {
+    	assetGroup.watchPaths = !!assetGroup.watch ?
+        	assetGroup.watch.map(function (watchPath) {
+            	return path.join(assetGroup.basePath, watchPath);
+        }).concat(assetGroup.inputPaths) : assetGroup.inputPaths;
         gulp.watch(assetGroup.watchPaths, function (event) {
             console.log("Asset file '" + event.path + "' was " + event.type + ", rebuilding output '" + assetGroup.outputPath + "'.");
             var doRebuild = true; 
@@ -66,12 +70,6 @@ function resolveAssetGroupPaths(assetGroup, assetManifestPath) {
     assetGroup.inputPaths = assetGroup.inputs.map(function (inputPath) {
         return path.join(assetGroup.basePath, inputPath);
     });
-    
-    assetGroup.watchPaths = !!assetGroup.watch ?
-        assetGroup.watch.map(function (watchPath) {
-            return path.join(assetGroup.basePath, watchPath);
-        }).concat(assetGroup.inputPaths) : assetGroup.inputPaths;
-
     assetGroup.outputPath = path.join(assetGroup.basePath, assetGroup.output);
     assetGroup.outputDir = path.dirname(assetGroup.outputPath);
     assetGroup.outputFileName = path.basename(assetGroup.output);
@@ -152,7 +150,7 @@ function buildJsPipeline(assetGroup, doRebuild) {
             noEmitOnError: true,
             sortOutput: true,
         }).js))
-		.pipe(gulpif(doConcat, concat(assetGroup.outputFileName)))
+	.pipe(gulpif(doConcat, concat(assetGroup.outputFileName)))
         // TODO: Start using below whenever gulp-header supports sourcemaps.
         //.pipe(header(
         //    "/*\n" +
@@ -162,9 +160,9 @@ function buildJsPipeline(assetGroup, doRebuild) {
         //    "*/\n\n"))
         .pipe(gulpif(generateSourceMaps, sourcemaps.write()))
         .pipe(gulp.dest(assetGroup.outputDir))
-		.pipe(uglify())
-		.pipe(rename({
-		    suffix: ".min"
-		}))
-		.pipe(gulp.dest(assetGroup.outputDir));
+	.pipe(uglify())
+	.pipe(rename({
+		suffix: ".min"
+	     }))
+	.pipe(gulp.dest(assetGroup.outputDir));
 }

--- a/src/Gulpfile.js
+++ b/src/Gulpfile.js
@@ -31,7 +31,6 @@ var glob = require("glob"),
         "inputs": [ "Less/master.less" ], //Specifies which files to process during the Build task
         "output": "Styles/@.css", //When @ is specified, each file specified in "inputs" will be converted to [filename].css
         "watch": ["Less/*.less"], //specifies which files to watch, use this when you have a master Less file that imports other Less files
-        "rebuildAlways": true, //Will force rebuild, defaults to 'true'
         "generateSourceMaps": true //Will include source maps in unminified version, defaults to 'true'
       }
     ]
@@ -59,9 +58,9 @@ gulp.task("rebuild", function () {
 // Continuous watch (each asset group is built whenever one of its inputs changes).
 gulp.task("watch", function () {
     getAssetGroups().forEach(function (assetGroup) {
-        gulp.watch(assetGroup.watchPaths != undefined ? assetGroup.watchPaths : assetGroup.inputPaths, function (event) {
+        gulp.watch(assetGroup.watchPaths, function (event) {
             console.log("Asset file '" + event.path + "' was " + event.type + ", rebuilding output '" + assetGroup.outputPath + "'.");
-            var doRebuild = assetGroup.rebuildAlways != undefined ? assetGroup.rebuildAlways : true; //defaults to true
+            var doRebuild = true; 
             var task = createAssetGroupTask(assetGroup, doRebuild);
         });
     });
@@ -89,12 +88,12 @@ function resolveAssetGroupPaths(assetGroup, assetManifestPath) {
     assetGroup.inputPaths = assetGroup.inputs.map(function (inputPath) {
         return path.join(assetGroup.basePath, inputPath);
     });
-    if (assetGroup.watch != undefined) {
-        assetGroup.watchPaths = assetGroup.watch.map(function (watchPath) {
+    
+    assetGroup.watchPaths = !!assetGroup.watch ?
+        assetGroup.watch.map(function (watchPath) {
             return path.join(assetGroup.basePath, watchPath);
-        })
-        .concat(assetGroup.inputPaths); //include inputs in watch list
-    }
+        }).concat(assetGroup.inputPaths) : assetGroup.inputPaths;
+
     assetGroup.outputPath = path.join(assetGroup.basePath, assetGroup.output);
     assetGroup.outputDir = path.dirname(assetGroup.outputPath);
     assetGroup.outputFileName = path.basename(assetGroup.output);
@@ -127,7 +126,7 @@ function buildCssPipeline(assetGroup, doRebuild) {
     else {
         console.log("Force Rebuild is enabled, rebuilding all input files.");
     }
-    var generateSourceMaps = assetGroup.generateSourceMaps != undefined ? assetGroup.generateSourceMaps : true;
+    var generateSourceMaps = assetGroup.generateSourceMaps !== undefined ? assetGroup.generateSourceMaps : true;
     return gulp.src(assetGroup.inputPaths)
         .pipe(gulpif(!doRebuild,
             gulpif(doConcat,
@@ -155,7 +154,7 @@ function buildCssPipeline(assetGroup, doRebuild) {
             suffix: ".min"
         }))
         .pipe(gulp.dest(assetGroup.outputDir))
-        .pipe(gulpif(doRebuild, notify("Rebuild complete"),notify("Build process complete")));
+        .pipe(gulpif(doRebuild, notify("Rebuild complete"), notify("Build process complete")));
 }
 
 function buildJsPipeline(assetGroup, doRebuild) {
@@ -165,7 +164,7 @@ function buildJsPipeline(assetGroup, doRebuild) {
             throw "Input file '" + inputPath + "' is not of a valid type for output file '" + assetGroup.outputPath + "'.";
     });
     var doConcat = path.basename(assetGroup.outputFileName, ".js") !== "@";
-    var generateSourceMaps = assetGroup.generateSourceMaps != undefined ? assetGroup.generateSourceMaps : true;
+    var generateSourceMaps = assetGroup.generateSourceMaps !== undefined ? assetGroup.generateSourceMaps : true;
     return gulp.src(assetGroup.inputPaths)
         .pipe(gulpif(!doRebuild,
             gulpif(doConcat,
@@ -182,7 +181,7 @@ function buildJsPipeline(assetGroup, doRebuild) {
             noEmitOnError: true,
             sortOutput: true,
         }).js))
-		.pipe(gulpif(doConcat, concat(assetGroup.outputFileName)))
+	.pipe(gulpif(doConcat, concat(assetGroup.outputFileName)))
         // TODO: Start using below whenever gulp-header supports sourcemaps.
         //.pipe(header(
         //    "/*\n" +
@@ -192,9 +191,9 @@ function buildJsPipeline(assetGroup, doRebuild) {
         //    "*/\n\n"))
         .pipe(gulpif(generateSourceMaps, sourcemaps.write()))
         .pipe(gulp.dest(assetGroup.outputDir))
-		.pipe(uglify())
-		.pipe(rename({
-		    suffix: ".min"
-		}))
-		.pipe(gulp.dest(assetGroup.outputDir));
+	.pipe(uglify())
+	.pipe(rename({
+	    suffix: ".min"
+	}))
+	.pipe(gulp.dest(assetGroup.outputDir));
 }

--- a/src/Gulpfile.js
+++ b/src/Gulpfile.js
@@ -4,38 +4,16 @@ var glob = require("glob"),
     gulpif = require("gulp-if"),
     gulp = require("gulp"),
     newer = require("gulp-newer"),
-	plumber = require("gulp-plumber"),
+    plumber = require("gulp-plumber"),
     sourcemaps = require("gulp-sourcemaps"),
     less = require("gulp-less"),
-	autoprefixer = require("gulp-autoprefixer"),
-	minify = require("gulp-minify-css"),
+    autoprefixer = require("gulp-autoprefixer"),
+    minify = require("gulp-minify-css"),
     typescript = require("gulp-typescript"),
-	uglify = require("gulp-uglify"),
-	rename = require("gulp-rename"),
+    uglify = require("gulp-uglify"),
+    rename = require("gulp-rename"),
     concat = require("gulp-concat"),
-	header = require("gulp-header"),
-    notify = require("gulp-notify")
-
-/*
-** GULP TASKS
----------------------------------------
-   Checks Themes, Modules, and Core directories for an Assets.json file. 
-   Assets.json defines what Less, CSS, TypeScript, JS files should be processed by Gulp.
-   
-   When defining your own Assets.json file, it should be saved in the root of module or theme project
-
-   Assets.json example:
-   Saved to /Modules/My.Custom.Module/Assets.json
-   [
-      {
-        "inputs": [ "Less/master.less" ], //Specifies which files to process during the Build task
-        "output": "Styles/@.css", //When @ is specified, each file specified in "inputs" will be converted to [filename].css
-        "watch": ["Less/*.less"], //specifies which files to watch, use this when you have a master Less file that imports other Less files
-        "generateSourceMaps": true //Will include source maps in unminified version, defaults to 'true'
-      }
-    ]
-    "inputs" and "output" are required.  All other properties are optional.
-*/
+    header = require("gulp-header")
 
 // Incremental build (each asset group is built only if one or more inputs are newer than the output).
 gulp.task("build", function () {
@@ -120,12 +98,6 @@ function buildCssPipeline(assetGroup, doRebuild) {
             throw "Input file '" + inputPath + "' is not of a valid type for output file '" + assetGroup.outputPath + "'.";
     });
     var doConcat = path.basename(assetGroup.outputFileName, ".css") !== "@";
-    if (!doRebuild) {
-        console.log("CSS will only rebuild if less files specified in 'inputs' are newer.");
-    }
-    else {
-        console.log("Force Rebuild is enabled, rebuilding all input files.");
-    }
     var generateSourceMaps = assetGroup.hasOwnProperty("generateSourceMaps") ? assetGroup.generateSourceMaps : true;
     return gulp.src(assetGroup.inputPaths)
         .pipe(gulpif(!doRebuild,
@@ -153,8 +125,7 @@ function buildCssPipeline(assetGroup, doRebuild) {
         .pipe(rename({
             suffix: ".min"
         }))
-        .pipe(gulp.dest(assetGroup.outputDir))
-        .pipe(gulpif(doRebuild, notify("Rebuild complete"), notify("Build process complete")));
+        .pipe(gulp.dest(assetGroup.outputDir));
 }
 
 function buildJsPipeline(assetGroup, doRebuild) {

--- a/src/Package.json
+++ b/src/Package.json
@@ -15,7 +15,8 @@
         "gulp-uglify": "^1.2.0",
         "gulp-rename": "^1.2.2",
         "gulp-concat": "^2.5.2",
-        "gulp-header": "^1.2.2"
+        "gulp-header": "^1.2.2",
+        "gulp-notify": "^2.2.0"
     },
     "dependencies": { }
 }

--- a/src/Package.json
+++ b/src/Package.json
@@ -15,8 +15,7 @@
         "gulp-uglify": "^1.2.0",
         "gulp-rename": "^1.2.2",
         "gulp-concat": "^2.5.2",
-        "gulp-header": "^1.2.2",
-        "gulp-notify": "^2.2.0"
+        "gulp-header": "^1.2.2"
     },
     "dependencies": { }
 }


### PR DESCRIPTION
Added support for separation of watch vs build .less files.
This required adding a flag for forcing rebuild, because the watch files may have changed, but the build files may not have, causing rebuild to fail.  Setting the rebuildAlways flag to true forces the rebuild to occur, regardless of files changed.  
Also added an option to exclude sourcemaps.  This defaults to false (include them if not set).

All options are ... wait for it ... optional.

Example Assets.json:
```
[
  {
    "inputs": [ "Less/master.less" ],
    "output": "Styles/@.css",
    "watch": ["Less/**/*.less", "Less/*.less"],
    "rebuildAlways": true,
    "excludeSourceMaps": true
  }
]
```

