### PR TITLE
Add extension point to allow developers to provide custom logic when validating User Data

### DIFF
--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -185,6 +185,8 @@
     <Compile Include="Security\NullMembershipService.cs" />
     <Compile Include="Security\Providers\DefaultSslSettingsProvider.cs" />
     <Compile Include="Security\Providers\DefaultMembershipValidationService.cs" />
+    <Compile Include="Security\IUserDataValidationProvider.cs" />
+    <Compile Include="Security\Providers\TenantAwareUserDataValidationProvider.cs" />
     <Compile Include="StaticHttpContextScope.cs" />
     <Compile Include="StaticHttpContextScopeFactory.cs" />
     <Compile Include="Caching\DefaultCacheContextAccessor.cs" />

--- a/src/Orchard/Security/IUserDataValidationProvider.cs
+++ b/src/Orchard/Security/IUserDataValidationProvider.cs
@@ -1,0 +1,23 @@
+namespace Orchard.Security {
+    /// <summary>
+    /// Allows you to place custom data into the UserData property of the FormsAuthenticationTicket and then validate the data whn validating the current signed in user
+    /// </summary>
+    public interface IUserDataValidationProvider : IDependency {
+        /// <summary>
+        /// A key that should uniquely identify this provider. 
+        /// This key will be paired with the User Data that this provider generates and will be used to identify which provider is responsible for subsequently validating that data.
+        /// </summary>
+        string Key { get; }
+        /// <summary>
+        /// Generates and returns the value that should be placed into User Data.
+        /// </summary>
+        /// <returns>The data to be paired with the key. This data will subseqently be passed to ValidateUserData().</returns>
+        string GetUserData();
+        /// <summary>
+        /// Checks that the value retrieved from User Data is valid for the currently logged in user.
+        /// </summary>
+        /// <param name="value">The value that was retrieved from User Data</param>
+        /// <returns>True if the provided value was valid; false otherwise. If this method returns false, the current user will be unauthenticated.</returns>
+        bool ValidateUserData(string value);
+    }
+}

--- a/src/Orchard/Security/Providers/FormsAuthenticationService.cs
+++ b/src/Orchard/Security/Providers/FormsAuthenticationService.cs
@@ -54,7 +54,7 @@ namespace Orchard.Security.Providers {
             var now = _clock.UtcNow.ToLocalTime();
 
             // The cookie user data is "{userName.Base64};{providerKey|providerValue};{providerKey|providerValue}....".
-            // The UserName is encoded to Base64 to prevent collisions with the ';' and '|' seprarators.
+            // The UserName is encoded to Base64 to prevent collisions with the ';' and '|' seprarators (which do not exist in the Base 64 alphabet).
             var userData = user.UserName.ToBase64();
 
             foreach (var userDataValidationProvider in _userDataValidationProviders) {
@@ -154,8 +154,8 @@ namespace Orchard.Security.Providers {
             }
 
             // Iterate over all but the first user data segment because the first is the username
-            for (var i = 1; i < userDataSegments.Length; i++) {
-                var segmentSplit = userDataSegments[i].Split('|');
+            foreach (var segment in userDataSegments.Skip(1)) {
+                var segmentSplit = segment.Split('|');
 
                 if (segmentSplit.Length < 2) {
                     continue;
@@ -164,7 +164,7 @@ namespace Orchard.Security.Providers {
                 var providerKey = segmentSplit[0].FromBase64();
                 var providerValue = segmentSplit[1].FromBase64();
 
-                foreach (var userDataValidationProvider in _userDataValidationProviders.Where(p=>p.Key == providerKey)) {
+                foreach (var userDataValidationProvider in _userDataValidationProviders.Where(p => p.Key == providerKey)) {
                     try {
                         if (!userDataValidationProvider.ValidateUserData(providerValue)) {
                             return null;

--- a/src/Orchard/Security/Providers/FormsAuthenticationService.cs
+++ b/src/Orchard/Security/Providers/FormsAuthenticationService.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Web;
 using System.Web.Security;
 using Orchard.Environment.Configuration;
@@ -10,7 +12,7 @@ using Orchard.Utility.Extensions;
 
 namespace Orchard.Security.Providers {
     public class FormsAuthenticationService : IAuthenticationService {
-        private const int _cookieVersion = 3;
+        private const int _cookieVersion = 4;
 
         private readonly ShellSettings _settings;
         private readonly IClock _clock;
@@ -18,6 +20,7 @@ namespace Orchard.Security.Providers {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ISslSettingsProvider _sslSettingsProvider;
         private readonly IMembershipValidationService _membershipValidationService;
+        private readonly IEnumerable<IUserDataValidationProvider> _userDataValidationProviders;
 
         private IUser _signedInUser;
         private bool _isAuthenticated;
@@ -28,13 +31,15 @@ namespace Orchard.Security.Providers {
             IMembershipService membershipService,
             IHttpContextAccessor httpContextAccessor,
             ISslSettingsProvider sslSettingsProvider,
-            IMembershipValidationService membershipValidationService) {
+            IMembershipValidationService membershipValidationService,
+            IEnumerable<IUserDataValidationProvider> userDataValidationProviders) {
             _settings = settings;
             _clock = clock;
             _membershipService = membershipService;
             _httpContextAccessor = httpContextAccessor;
             _sslSettingsProvider = sslSettingsProvider;
             _membershipValidationService = membershipValidationService;
+            _userDataValidationProviders = userDataValidationProviders;
 
             Logger = NullLogger.Instance;
             
@@ -48,9 +53,21 @@ namespace Orchard.Security.Providers {
         public void SignIn(IUser user, bool createPersistentCookie) {
             var now = _clock.UtcNow.ToLocalTime();
 
-            // The cookie user data is "{userName.Base64};{tenant}".
-            // The username is encoded to Base64 to prevent collisions with the ';' seprarator.
-            var userData = String.Concat(user.UserName.ToBase64(), ";", _settings.Name);
+            // The cookie user data is "{userName.Base64};{providerKey|providerValue};{providerKey|providerValue}....".
+            // The UserName is encoded to Base64 to prevent collisions with the ';' and '|' seprarators.
+            var userData = user.UserName.ToBase64();
+
+            foreach (var userDataValidationProvider in _userDataValidationProviders) {
+                try {
+                    // The data provided by this provider is base 64 encoded to avoid collisions with the ';' seprarator.
+                    userData += String.Format(";{0}|{1}", userDataValidationProvider.Key.ToBase64(), userDataValidationProvider.GetUserData().ToBase64());
+                }
+                catch (Exception ex) {
+                    Logger.Error(ex, "An exception was thrown by {0} when generating the values to be added to User Data.", userDataValidationProvider.GetType().FullName);
+
+                    throw;
+                }
+            }
 
             var ticket = new FormsAuthenticationTicket(
                 _cookieVersion,
@@ -124,15 +141,10 @@ namespace Orchard.Security.Providers {
             var formsIdentity = (FormsIdentity)httpContext.User.Identity;
             var userData = formsIdentity.Ticket.UserData ?? "";
 
-            // The cookie user data is {userName.Base64};{tenant}.
+            // The cookie user data is "{userName.Base64};{providerKey|providerValue};{providerKey|providerValue}....".
             var userDataSegments = userData.Split(';');
-            
-            if (userDataSegments.Length < 2) {
-                return null;
-            }
 
             var userDataName = userDataSegments[0];
-            var userDataTenant = userDataSegments[1];
 
             try {
                 userDataName = userDataName.FromBase64();
@@ -141,8 +153,30 @@ namespace Orchard.Security.Providers {
                 return null;
             }
 
-            if (!String.Equals(userDataTenant, _settings.Name, StringComparison.Ordinal)) {
-                return null;
+            // Iterate over all but the first user data segment because the first is the username
+            for (var i = 1; i < userDataSegments.Length; i++) {
+                var segmentSplit = userDataSegments[i].Split('|');
+
+                if (segmentSplit.Length < 2) {
+                    continue;
+                }
+
+                var providerKey = segmentSplit[0].FromBase64();
+                var providerValue = segmentSplit[1].FromBase64();
+
+                foreach (var userDataValidationProvider in _userDataValidationProviders.Where(p=>p.Key == providerKey)) {
+                    try {
+                        if (!userDataValidationProvider.ValidateUserData(providerValue)) {
+                            return null;
+                        }   
+                    }
+                    catch (Exception ex) {
+                        Logger.Error(ex, "An exception was thrown by {0} when validating the values found in User Data.", userDataValidationProvider.GetType().FullName);
+
+                        // Throwing here would result in a YSOD. Instead, just return null, indicating that the user is not logged in.
+                        return null;
+                    }
+                }
             }
 
             _signedInUser = _membershipService.GetUser(userDataName);

--- a/src/Orchard/Security/Providers/TenantAwareUserDataValidationProvider.cs
+++ b/src/Orchard/Security/Providers/TenantAwareUserDataValidationProvider.cs
@@ -1,0 +1,22 @@
+using System;
+using Orchard.Environment.Configuration;
+
+namespace Orchard.Security.Providers {
+    public class TenantAwareUserDataValidationProvider : IUserDataValidationProvider {
+        private readonly ShellSettings _shellSettings;
+
+        public TenantAwareUserDataValidationProvider(ShellSettings shellSettings) {
+            _shellSettings = shellSettings;
+        }
+
+        public string Key { get { return "Tenant"; } }
+
+        public string GetUserData() {
+            return _shellSettings.Name;
+        }
+
+        public bool ValidateUserData(string value) {
+            return String.Equals(value, _shellSettings.Name, StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an extension point to `FormsAuthenticationService` that allows module developers to place custom values into User Data and then provide custom logic to be able to ensure that this User Data value is still valid during the `GetAuthenticatedUser` method.

The logic to ensure that auth cookies are tenant aware has been abstracted into one of these providers.

Example use cases would be where auth implementation has been switched out to a system with a token that needs to be validated during `GetAuthenticatedUser`.