### PR TITLE
Added woff2 mimetype

### DIFF
--- a/src/Orchard.Web/Web.config
+++ b/src/Orchard.Web/Web.config
@@ -130,6 +130,8 @@
             <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
             <remove fileExtension=".woff" />
             <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+            <remove fileExtension=".woff2" />
+            <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
         </staticContent>
     </system.webServer>
 


### PR DESCRIPTION
The new WOFF 2.0 Web Font compression format offers a 30% average gain over WOFF 1.0 (up to 50%+ in some cases).

Can be safely used side-by-side with WOFF 1.0 as only browsers that support it request it. That is according to [Can I Use](http://caniuse.com/#search=woff2) more than 50% global browser usage.