### PR TITLE
Fixes 5591 : ContentType's name encoding

### DIFF
--- a/src/Orchard.Web/Core/Contents/Views/Admin/Create.cshtml
+++ b/src/Orchard.Web/Core/Contents/Views/Admin/Create.cshtml
@@ -4,9 +4,8 @@
 @{
     ContentItem contentItem = Model.ContentItem;
     var typeDisplayName = contentItem.TypeDefinition.DisplayName ?? contentItem.ContentType.CamelFriendly();
-    var pageTitle = T("New {0}", typeDisplayName);
 
-    Layout.Title = (string)pageTitle.Text;
+    Layout.Title = T("New {0}", Html.Raw(typeDisplayName)).Text;
 }
 
 @using (Html.BeginFormAntiForgeryPost(Url.Action("Create", new { ReturnUrl = Request.QueryString["ReturnUrl"] }), FormMethod.Post, new { enctype = "multipart/form-data" })) {

--- a/src/Orchard.Web/Core/Contents/Views/Admin/List.cshtml
+++ b/src/Orchard.Web/Core/Contents/Views/Admin/List.cshtml
@@ -4,13 +4,13 @@
     var pageTitle = T("Manage Content");
     var createLinkText = T("Create New Content");
     if (!string.IsNullOrWhiteSpace(typeDisplayName)) {
-        pageTitle = T("Manage {0} Content", typeDisplayName);
-        createLinkText = T("Create New {0}", typeDisplayName);
+        pageTitle = T("Manage {0} Content", Html.Raw(typeDisplayName));
+        createLinkText = T("Create New {0}", Html.Raw(typeDisplayName));
     }
 
     IEnumerable<string> cultures = Model.Options.Cultures;
     
-    Layout.Title = pageTitle;
+    Layout.Title = pageTitle.Text;
 }
 
 <div class="manage">

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/Edit.cshtml
@@ -2,7 +2,7 @@
 @{
     Style.Require("ContentTypesAdmin");
     Script.Require("jQuery");
-    Layout.Title = T("Edit Content Type - {0}", Model.DisplayName).ToString();
+    Layout.Title = T("Edit Content Type - {0}", Html.Raw(Model.DisplayName)).Text;
 }
 
 <div class="manage">

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/EditField.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/Admin/EditField.cshtml
@@ -3,7 +3,7 @@
 @{
     Style.Require("ContentTypesAdmin");
 
-    Layout.Title = T("Edit Field \"{0}\"", Model.Name).ToString();
+    Layout.Title = T("Edit Field \"{0}\"", Html.Raw(Model.DisplayName)).ToString();
 }
 
 @using (Html.BeginFormAntiForgeryPost()) {

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/DisplayTemplates/EditTypeViewModel.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Views/DisplayTemplates/EditTypeViewModel.cshtml
@@ -9,7 +9,7 @@
     <div class="properties">
         <h3>@Model.DisplayName</h3> @if (!string.IsNullOrWhiteSpace(stereotype)) { <text><span class="stereotype" title="Stereotype">- @stereotype</span></text>}
         @if (creatable) {
-        <p class="pageStatus">@Html.ActionLink(T("Create New {0}", Model.DisplayName).Text, "Create", new {area = "Contents", id = Model.Name})</p>
+        <p class="pageStatus">@Html.ActionLink(T("Create New {0}", Html.Raw(Model.DisplayName)).Text, "Create", new {area = "Contents", id = Model.Name})</p>
         }
     </div>
     <div class="related">@if (creatable) {


### PR DESCRIPTION
It's the only workaround if we choose keeping Localizer to default encode arguments.