### PR TITLE
Autogeneration of report type in service

### DIFF
--- a/src/Orchard.Web/Core/Reports/Views/Admin/Display.cshtml
+++ b/src/Orchard.Web/Core/Reports/Views/Admin/Display.cshtml
@@ -3,37 +3,34 @@
 
 @{ Layout.Title = T("Display Report").ToString(); }
 
-@using(Html.BeginFormAntiForgeryPost()) {
-    @Html.ValidationSummary()
-    <fieldset>
-        <table class="items" summary="@T("This is a table of the reports in your application")">
-            <colgroup>
-                <col id="Col1" />
-                <col id="Col2" />
-                <col id="Col3" />
-                <col id="Col4" />
-            </colgroup>
-            <thead>
-                <tr>
-                    <th scope="col">@T("Type")</th>
-                    <th scope="col">@T("Message")</th>
-                    <th scope="col">@T("Date")</th>
-                    <th scope="col"></th>
-                </tr>
-            </thead>
-            @foreach (var reportEntry in Model.Report.Entries) {
+
+<fieldset>
+    <table class="items" summary="@T("This is a table of the reports in your application")">
+        <colgroup>
+            <col id="Col1" />
+            <col id="Col2" />
+            <col id="Col3" />
+        </colgroup>
+        <thead>
+            <tr>
+                <th scope="col">@T("Type")</th>
+                <th scope="col">@T("Message")</th>
+                <th scope="col">@T("Date")</th>
+            </tr>
+        </thead>
+        @foreach (var reportEntry in Model.Report.Entries)
+        {
             <tr>
                 <td>
                     @reportEntry.Type
                 </td>
                 <td>
-                    @reportEntry.Message
+                    @Html.Raw(reportEntry.Message)
                 </td>
                 <td>
                     @reportEntry.Utc.ToLocalTime().ToShortDateString() @reportEntry.Utc.ToLocalTime().ToShortTimeString()
                 </td>
             </tr>
-            }
-        </table>
-    </fieldset>
-}
+        }
+    </table>
+</fieldset>

--- a/src/Orchard/Reports/Report.cs
+++ b/src/Orchard/Reports/Report.cs
@@ -7,7 +7,7 @@ namespace Orchard.Reports {
             Entries = new List<ReportEntry>();
         }
 
-        public IList<ReportEntry> Entries { get; set;}
+        public List<ReportEntry> Entries { get; set;}
         public int ReportId { get; set; }
         public string Title { get; set; }
         public string ActivityName { get; set; }

--- a/src/Orchard/Reports/Services/IReportsCoordinator.cs
+++ b/src/Orchard/Reports/Services/IReportsCoordinator.cs
@@ -16,7 +16,8 @@
         /// <param name="reportKey">Key, i.e. technical name of the report. Should be the same as the one used when registering the report.</param>
         /// <param name="type">Type of the entry.</param>
         /// <param name="message">The message to include in the entry.</param>
-        void Add(string reportKey, ReportEntryType type, string message);
+        /// <param name="reportDescription">Description for the new type of reports message. Optional.</param>
+        void Add(string reportKey, ReportEntryType type, string message, string reportDescription = null);
 
         /// <summary>
         /// Registers a new report so entries can be added to it.

--- a/src/Orchard/Reports/Services/ReportsCoordinator.cs
+++ b/src/Orchard/Reports/Services/ReportsCoordinator.cs
@@ -11,6 +11,7 @@ namespace Orchard.Reports.Services {
             _reportsManager = reportsManager;
             Logger = NullLogger.Instance;
             _reports = new Dictionary<string, int>();
+            GenerateReports();
         }
 
         public ILogger Logger { get; set; }
@@ -18,10 +19,20 @@ namespace Orchard.Reports.Services {
             _reportsManager.Flush();
         }
 
-        public void Add(string reportKey, ReportEntryType type, string message) {
+        private void GenerateReports()
+        {
+            dynamic reportData = _reportsManager.GetReports();
+            foreach(var report in reportData)
+            {
+                _reports[report.ActivityName] = report.ReportId;
+            }
+        }
+
+        public void Add(string reportKey, ReportEntryType type, string message, string reportDescription = null) {
             if(!_reports.ContainsKey(reportKey)) {
-                // ignore message if no corresponding report
-                return;
+                //Create new report
+                Register(reportKey, reportKey, reportDescription);
+                GenerateReports();
             }
 
             _reportsManager.Add(_reports[reportKey], type, message);

--- a/src/Orchard/Reports/Services/ReportsManager.cs
+++ b/src/Orchard/Reports/Services/ReportsManager.cs
@@ -34,8 +34,7 @@ namespace Orchard.Reports.Services {
                 LoadReports();
                 _isDirty = true;
                 var reportId = _reports.Count == 0 ? 1 : _reports.Max(r => r.ReportId) + 1;
-                var report = new Report {ActivityName = activityName, ReportId = reportId, Title = title, Utc = DateTime.UtcNow};
-                _reports.Add(report);
+                _reports.Add(new Report {ActivityName = activityName, ReportId = reportId, Title = title, Utc = DateTime.UtcNow});
                 return reportId;
             }
         }


### PR DESCRIPTION
Now developers can create reports without need for type creating. 

For example:

```
_reportsCoordinator.Add(
                        "Email",
                        ReportEntryType.Information,
                        String.Format("User {0} send next message:<br/> <b>Subject:</b> {1} <br/> <b>Message:</b> {2} <br/> <b>Recipients:</b> {3} ", userName, parameters["Subject"], parameters["Body"], parameters["Recipients"]),
                        "Email logs"
                    );
```