### PR TITLE
Fixes #5475 : Don't try to get culture when using HttpContextPlaceholder

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Localization/Selectors/BrowserCultureSelector.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Selectors/BrowserCultureSelector.cs
@@ -16,7 +16,7 @@ namespace Orchard.Localization.Selectors {
         }
 
         public CultureSelectorResult GetCulture(HttpContextBase context) {
-            if (context == null) return null;
+            if (context == null || context.GetType() == typeof(Orchard.Mvc.MvcModule.HttpContextPlaceholder)) return null;
 
             /* Fall back to Browser */
             var userLanguages = context.Request.UserLanguages;

--- a/src/Orchard.Web/Modules/Orchard.Localization/Selectors/ContentCultureSelector.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Selectors/ContentCultureSelector.cs
@@ -23,7 +23,7 @@ namespace Orchard.Localization.Selectors {
         }
 
         public CultureSelectorResult GetCulture(HttpContextBase context) {
-            if (context == null || ContextHelpers.IsRequestAdmin(context)) return null;
+            if (context == null || context.GetType() == typeof(Orchard.Mvc.MvcModule.HttpContextPlaceholder) || ContextHelpers.IsRequestAdmin(context)) return null;
 
             // Attempt to determine culture by previous route if by POST
             string path;

--- a/src/Orchard.Web/Modules/Orchard.Localization/Selectors/RouteCultureSelector.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Selectors/RouteCultureSelector.cs
@@ -7,7 +7,7 @@ namespace Orchard.Localization.Selectors {
     [OrchardFeature("Orchard.Localization.CultureSelector")]
     public class RouteCultureSelector : ICultureSelector {
         public CultureSelectorResult GetCulture(HttpContextBase context) {
-            if (context == null || ContextHelpers.IsRequestAdmin(context)) return null;
+            if (context == null || context.GetType() == typeof(Orchard.Mvc.MvcModule.HttpContextPlaceholder) || ContextHelpers.IsRequestAdmin(context)) return null;
 
             // Attempt to determine culture by route.
             // This normally happens when you are using non standard pages that are not content items


### PR DESCRIPTION
Prevents command line from throwing when CultureSelector is enabled.