### PR TITLE
#5552: ContentPicker Search Route issue

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Search/Controllers/ContentPickerController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Search/Controllers/ContentPickerController.cs
@@ -47,8 +47,6 @@ namespace Orchard.Search.Controllers {
         public ActionResult Index(PagerParameters pagerParameters, string part, string field, string searchText = "") {
             var pager = new Pager(_siteService.GetSiteSettings(), pagerParameters);
             var searchSettingsPart = Services.WorkContext.CurrentSite.As<SearchSettingsPart>();
-            var searchIndex = searchSettingsPart.SearchIndex;
-            var searchFields = searchSettingsPart.GetSearchFields(searchSettingsPart.SearchIndex);
             var totalCount = 0;
             var foundIds = new int[0];
 
@@ -66,6 +64,11 @@ namespace Orchard.Search.Controllers {
                     return View("NoIndex");
                 }
 
+                var searchIndex = searchSettingsPart.SearchIndex;
+                if (settings != null && !String.IsNullOrEmpty(settings.SearchIndex))
+                    searchIndex = settings.SearchIndex;
+                var searchFields = searchSettingsPart.GetSearchFields(searchIndex);
+
                 var builder = _indexManager.GetSearchIndexProvider().CreateSearchBuilder(searchIndex);
 
                 try {
@@ -75,12 +78,12 @@ namespace Orchard.Search.Controllers {
                         var rawTypes = settings.DisplayedContentTypes.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries).ToList();
                         var contentTypes = _contentDefinitionManager
                             .ListTypeDefinitions()
-                            .Where(x => x.Parts.Any(p => rawTypes.Contains(p.PartDefinition.Name)))
+                            .Where(x => x.Parts.Any(p => rawTypes.Contains(p.PartDefinition.Name)) || rawTypes.Contains(x.Name))
                             .ToArray();
 
 
                         foreach (string type in contentTypes.Select(x => x.Name)) {
-                            builder.WithField("type", type).AsFilter();
+                            builder.WithField("type", type).NotAnalyzed().AsFilter();
                         }
                     }
 

--- a/src/Orchard.Web/Modules/Orchard.Search/Controllers/MediaController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Search/Controllers/MediaController.cs
@@ -34,7 +34,7 @@ namespace Orchard.Search.Controllers {
             } 
             
             if (!String.IsNullOrEmpty(mediaType)) {
-                builder.WithField("type", mediaType).Mandatory().AsFilter();
+                builder.WithField("type", mediaType).NotAnalyzed().AsFilter();
             }
 
             if (!String.IsNullOrEmpty(folderPath)) {

--- a/src/Orchard.Web/Modules/Orchard.Search/Routes.cs
+++ b/src/Orchard.Web/Modules/Orchard.Search/Routes.cs
@@ -15,6 +15,20 @@ namespace Orchard.Search {
             return new[] {
                 new RouteDescriptor {
                     Priority = 5,
+                    Route = new Route("Search/ContentPicker",
+                        new RouteValueDictionary {
+                            {"area", "Orchard.Search"},
+                            {"controller", "ContentPicker"},
+                            {"action", "Index"}
+                        },
+                        null,
+                        new RouteValueDictionary {
+                            {"area", "Orchard.Search"}
+                        },
+                        new MvcRouteHandler())
+                },
+                new RouteDescriptor {
+                    Priority = 5,
                     Route = new Route("Search/{searchIndex}",
                         new RouteValueDictionary {
                             {"area", "Orchard.Search"},


### PR DESCRIPTION
Here, fixes only the route issue of #5552. I do it here because it was introduced only in the dev branch, not in the 1.9.x, this after this commit that intoduces a new searchIndex optional parameter in Route.cs
https://github.com/OrchardCMS/Orchard/commit/b88d08b0ff33bc15c840c4307ea5c25f33c44bd7#diff-79bfb04dea87efbf537bf6cfc46d01cd
With the "Search/ContentPicker..." url, ContentPicker was considered as a index name...
Not the case with this more specialized url that also specify the controller action name
"Search/Media/MediaItems..."

I will do another PR on the 1.9.x branch for this 2 last points. Tell me if I have to do it also in the dev branch.
- UPDATE: Finally, I've done all the changes here because the search index and fields implementation has been improved in the dev branch. E.g the GetSearchFields() method has now a search index parameter, not in the 1.9.x branch... So, it can't be correctly implemented in the 1.9.x branch
- Search index issue: The search action was not using the search index specified in the content picker field settings

- Type filtering issue: When added to the document index, the "type" field isn't analyzed and tokenized (see in CommonPartHandler), so, when used with the search builder we need to use .NotAnalyzed(). Elsewhere, the query with a lowercase term will not match the stored value with uppercases (idem with the MediaController)
