### PR TITLE
AppConfigurationAccessor is now tenant aware

### DIFF
--- a/src/Orchard/Environment/Configuration/AppConfigurationAccessor.cs
+++ b/src/Orchard/Environment/Configuration/AppConfigurationAccessor.cs
@@ -7,13 +7,20 @@ using System.Threading.Tasks;
 
 namespace Orchard.Environment.Configuration {
     public class AppConfigurationAccessor : IAppConfigurationAccessor {
+        private readonly ShellSettings _shellSettings;
+        public AppConfigurationAccessor(ShellSettings shellSettings) {
+            _shellSettings = shellSettings;
+        }
+
         public string GetConfiguration(string name) {
-            var appSettingsValue = ConfigurationManager.AppSettings[name];
+            var tenantName = String.Format("{0}:{1}", _shellSettings.Name, name);
+
+            var appSettingsValue = ConfigurationManager.AppSettings[tenantName] ?? ConfigurationManager.AppSettings[name];
             if (appSettingsValue != null) {
                 return appSettingsValue;
             }
 
-            var connectionStringSettings = ConfigurationManager.ConnectionStrings[name];
+            var connectionStringSettings = ConfigurationManager.ConnectionStrings[tenantName] ?? ConfigurationManager.ConnectionStrings[name];
             if (connectionStringSettings != null) {
                 return connectionStringSettings.ConnectionString;
             }


### PR DESCRIPTION
Issue #5520.

`AppConfigurationAccessor` will check for a tenant specific key before falling back to the default key. This functionality is similar to that of `PlatformConfigurationAccessor`
