### PR TITLE
Fix for Lucene throwing exception when maxClauseCount exceeds 1024

### DIFF
--- a/src/Orchard.Web/Modules/Lucene/Services/LuceneIndexProvider.cs
+++ b/src/Orchard.Web/Modules/Lucene/Services/LuceneIndexProvider.cs
@@ -27,6 +27,8 @@ namespace Lucene.Services {
         private readonly string _basePath;
         private ILuceneAnalyzerProvider _analyzerProvider;
 
+        private static int MAX_DOC_COUNT = 1000;
+
         public static readonly Version LuceneVersion = Version.LUCENE_29;
         public static readonly DateTime DefaultMinDateTime = new DateTime(1980, 1, 1);
         
@@ -131,11 +133,17 @@ namespace Lucene.Services {
             Delete(indexName, indexDocuments.Select(i => i.ContentItemId));
 
             using (var writer = new IndexWriter(GetDirectory(indexName), _analyzerProvider.GetAnalyzer(indexName), false, IndexWriter.MaxFieldLength.UNLIMITED)) {
-                foreach (var indexDocument in indexDocuments) {
-                    var doc = CreateDocument(indexDocument);
+                var pageCount = (int)Math.Ceiling((decimal)indexDocuments.Count() / MAX_DOC_COUNT);
+                for (int i = 0; i < pageCount; i++)
+                {
+                    var documentsToIndex = indexDocuments.Skip(i * MAX_DOC_COUNT).Take(MAX_DOC_COUNT);
+                    foreach (var indexDocument in documentsToIndex)
+                    {
+                        var doc = CreateDocument(indexDocument);
 
-                    writer.AddDocument(doc);
-                    Logger.Debug("Document [{0}] indexed", indexDocument.ContentItemId);
+                        writer.AddDocument(doc);
+                        Logger.Debug("Document [{0}] indexed", indexDocument.ContentItemId);
+                    }
                 }
             }
         }
@@ -144,24 +152,34 @@ namespace Lucene.Services {
             Delete(indexName, new[] { documentId });
         }
 
-        public void Delete(string indexName, IEnumerable<int> documentIds) {
+        public void Delete(string indexName, IEnumerable<int> documentIds)
+        {
             documentIds = documentIds.ToArray();
-            
-            if (!documentIds.Any()) {
+
+            if (!documentIds.Any())
+            {
                 return;
             }
 
-            using (var writer = new IndexWriter(GetDirectory(indexName), _analyzerProvider.GetAnalyzer(indexName), false, IndexWriter.MaxFieldLength.UNLIMITED)) {
-                var query = new BooleanQuery();
+            using (var writer = new IndexWriter(GetDirectory(indexName), _analyzerProvider.GetAnalyzer(indexName), false, IndexWriter.MaxFieldLength.UNLIMITED))
+            {
+                var pageCount = (int)Math.Ceiling((decimal)documentIds.Count() / MAX_DOC_COUNT);
+                try
+                {
+                    for (int i = 0; i < pageCount; i++)
+                    {
+                        var documentsToDelete = documentIds.Skip(i * MAX_DOC_COUNT).Take(MAX_DOC_COUNT);
+                        var query = new BooleanQuery();
+                        foreach (var id in documentsToDelete)
+                        {
+                            query.Add(new BooleanClause(new TermQuery(new Term("id", id.ToString(CultureInfo.InvariantCulture))), Occur.SHOULD));
+                        }
 
-                try {
-                    foreach (var id in documentIds) {
-                        query.Add(new BooleanClause(new TermQuery(new Term("id", id.ToString(CultureInfo.InvariantCulture))), Occur.SHOULD));
+                        writer.DeleteDocuments(query);
                     }
-
-                    writer.DeleteDocuments(query);
                 }
-                catch (Exception ex) {
+                catch (Exception ex)
+                {
                     Logger.Error(ex, "An unexpected error occured while removing the documents [{0}] from the index [{1}].", String.Join(", ", documentIds), indexName);
                 }
             }


### PR DESCRIPTION
When search index gets built with more than 1024 contents, Lucene thrown an exception "maxClauseCount exceeds 1024....."

I thought we had max record of 50 in the IndexingTaskExecutor class implementation. 