### PR TITLE
[Fix #5618] taxonomy in autoroute needs to be saved twice

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TaxonomyFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TaxonomyFieldDriver.cs
@@ -60,7 +60,7 @@ namespace Orchard.Taxonomies.Drivers {
         protected override DriverResult Editor(ContentPart part, TaxonomyField field, dynamic shapeHelper) {
             return ContentShape("Fields_TaxonomyField_Edit", GetDifferentiator(field, part), () => {
                 var settings = field.PartFieldDefinition.Settings.GetModel<TaxonomyFieldSettings>();
-                var appliedTerms = _taxonomyService.GetTermsForContentItem(part.ContentItem.Id, field.Name, VersionOptions.Latest).Distinct(new TermPartComparer()).ToDictionary(t => t.Id, t => t);
+                var appliedTerms = GetAppliedTerms(part, field, VersionOptions.Latest).ToDictionary(t => t.Id, t => t);
                 var taxonomy = _taxonomyService.GetTaxonomyByName(settings.Taxonomy);
                 var terms = taxonomy != null
                     ? _taxonomyService.GetTerms(taxonomy.Id).Where(t => !string.IsNullOrWhiteSpace(t.Name)).Select(t => t.CreateTermEntry()).ToList()
@@ -84,7 +84,9 @@ namespace Orchard.Taxonomies.Drivers {
 
         protected override DriverResult Editor(ContentPart part, TaxonomyField field, IUpdateModel updater, dynamic shapeHelper) {
             // Initializing viewmodel using the terms that are already selected to prevent loosing them when updating an editor group this field isn't displayed in.
-            var viewModel = new TaxonomyFieldViewModel { Terms = field.Terms.Select(t => t.CreateTermEntry()).ToList() };
+            // Get all the selected, published terms of all the TaxonomyFields of the content item.
+            var appliedTerms = GetAppliedTerms(part).ToList();
+            var viewModel = new TaxonomyFieldViewModel { Terms = appliedTerms.Select(t => t.CreateTermEntry()).ToList() };
             foreach (var item in viewModel.Terms) item.IsChecked = true;
             
             if (updater.TryUpdateModel(viewModel, GetPrefix(field, part), null, null)) {
@@ -157,6 +159,13 @@ namespace Orchard.Taxonomies.Drivers {
             }
 
             return term;
+        }
+
+
+        private IEnumerable<TermPart> GetAppliedTerms(ContentPart part, TaxonomyField field = null, VersionOptions versionOptions = null) {
+            string fieldName = field != null ? field.Name : string.Empty;
+
+            return _taxonomyService.GetTermsForContentItem(part.ContentItem.Id, fieldName, versionOptions?? VersionOptions.Published).Distinct(new TermPartComparer());
         }
     }
 


### PR DESCRIPTION
Call taxonomyservice to load all the terms for a content item to avoid calling TaxonomyField's Terms property.