### PR TITLE
Fixes #5518: Add TinyMce support for inline styles

### DIFF
--- a/src/Orchard.Web/Modules/TinyMce/Scripts/orchard-tinymce.js
+++ b/src/Orchard.Web/Modules/TinyMce/Scripts/orchard-tinymce.js
@@ -24,6 +24,8 @@ tinyMCE.init({
     valid_elements: "*[*]",
     // Shouldn't be needed due to the valid_elements setting, but TinyMCE would strip script.src without it.
     extended_valid_elements: "script[type|defer|src|language]",
+    //allow inline styles 
+    valid_children : "+body[style]",
     //menubar: false,
     //statusbar: false,
     skin: "orchardlightgray",


### PR DESCRIPTION
TinyMCE will strip out anything with the `<style>` tag by default.  This enables inline style tags within the src editor