### PR TITLE
Feature / Projection content item security

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Projections/Controllers/FilterController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Controllers/FilterController.cs
@@ -115,19 +115,21 @@ namespace Orchard.Projections.Controllers {
             var form = filter.Form == null ? null : _formManager.Build(filter.Form);
 
             string description = "";
+            bool checkPermissions = false;
 
             // bind form with existing values).
             if (filterId != -1) {
-                var group = _groupRepository.Get(id);
+                var group = _groupRepository.Get(id);                
                 var filterRecord = group.Filters.FirstOrDefault(f => f.Id == filterId);
                 if (filterRecord != null) {
                     description = filterRecord.Description;
                     var parameters = FormParametersHelper.FromString(filterRecord.State);
                     _formManager.Bind(form, new DictionaryValueProvider<string>(parameters, CultureInfo.InvariantCulture));
+                    checkPermissions = filterRecord.CheckPermissions;
                 }
             }
 
-            var viewModel = new FilterEditViewModel { Id = id, Description = description, Filter = filter, Form = form };
+            var viewModel = new FilterEditViewModel { Id = id, Description = description, Filter = filter, Form = form, CheckPermissions = checkPermissions };
             return View(viewModel);
         }
 
@@ -149,8 +151,8 @@ namespace Orchard.Projections.Controllers {
                 // add new filter record if it's a newly created filter
                 if (filterRecord == null) {
                     filterRecord = new FilterRecord {
-                        Category = category, 
-                        Type = type, 
+                        Category = category,
+                        Type = type,
                         Position = group.Filters.Count
                     };
                     group.Filters.Add(filterRecord);
@@ -161,6 +163,7 @@ namespace Orchard.Projections.Controllers {
                 // save form parameters
                 filterRecord.State = FormParametersHelper.ToString(dictionary);
                 filterRecord.Description = model.Description;
+                filterRecord.CheckPermissions = model.CheckPermissions;
 
                 return RedirectToAction("Edit", "Admin", new { group.QueryPartRecord.Id });
             }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Drivers/QueryPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Drivers/QueryPartDriver.cs
@@ -49,6 +49,7 @@ namespace Orchard.Projections.Drivers {
                                              new XAttribute("Description", filter.Description ?? ""),
                                              new XAttribute("Position", filter.Position),
                                              new XAttribute("State", state ?? ""),
+                                             new XAttribute("CheckPermissions", filter.CheckPermissions ? "True" : "False" ),
                                              new XAttribute("Type", filter.Type ?? "")
                                     );
                             })
@@ -113,18 +114,20 @@ namespace Orchard.Projections.Drivers {
                         var category = filter.Attribute("Category").Value;
                         var type = filter.Attribute("Type").Value;
                         var state = filter.Attribute("State").Value;
+                        var checkPermissions = Convert.ToBoolean( filter.Attribute("CheckPermissions").Value );
                         
                         var descriptor = _projectionManager.GetFilter(category, type);
                         if (descriptor != null) {
                             state = _formManager.Import(descriptor.Form, state, context);
                         }
-                        
+
                         return new FilterRecord {
                             Category = category,
                             Description = filter.Attribute("Description").Value,
                             Position = Convert.ToInt32(filter.Attribute("Position").Value),
                             State = state,
-                            Type = type
+                            Type = type,
+                            CheckPermissions = checkPermissions
                         };
                     }).ToList()
                 })) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/Extensions/SecurityFilterExtension.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Extensions/SecurityFilterExtension.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Aspects;
+using Orchard.ContentPermissions.Models;
+using Orchard.Roles.Models;
+using Orchard.Security;
+
+namespace Orchard.Projections.Extensions
+{
+    public static class SecurityFilterExtension
+    {
+        private static readonly string[] AnonymousRole = { "Anonymous" };
+        private static readonly string[] AuthenticatedRole = { "Authenticated" };
+        public static IEnumerable<T> FilterContentItems<T>(this IEnumerable<T> list, IUser currentUser)
+            where T : ContentItem
+        {
+            return list.Where(x => x.As<ContentPermissionsPart>() == null ||
+                                   HasAccess(currentUser,x.As<ContentPermissionsPart>()
+                              ));
+            //Assuming owners can always view their own items.
+        }
+
+        public static bool HasAccess(IUser user, ContentPermissionsPart part)
+        {
+
+            if (user == null && part == null)
+                return true;
+            if (part == null || !part.Enabled)
+            {
+                return true;
+            }
+            if (part.ViewContent.Contains(AnonymousRole[0]))
+            {
+                return true;
+            }
+            if (user != null)
+            {
+                var isOwner = HasOwnership(user, part.ContentItem);
+                var userRoles = user.As<IUserRoles>();
+                if (userRoles == null)
+                {
+                    return part.ViewContent.Contains(AuthenticatedRole[0]); 
+                }
+                var authorizedRoles = part.ViewContent.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries).AsEnumerable().ToList();
+                if (isOwner) {
+                    authorizedRoles.AddRange(part.ViewOwnContent.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
+                }
+                var rolesToExamine = userRoles.Roles;
+                return rolesToExamine.Any(x => authorizedRoles.Contains(x, StringComparer.OrdinalIgnoreCase));
+            }
+            return false;
+
+        }
+
+        private static bool HasOwnership(IUser user, IContent content)
+        {
+            if (user == null || content == null)
+                return false;
+
+            var common = content.As<ICommonPart>();
+            if (common == null || common.Owner == null)
+                return false;
+
+            return user.Id == common.Owner.Id;
+        }
+    }
+    
+
+}

--- a/src/Orchard.Web/Modules/Orchard.Projections/Extensions/SecurityFilterExtension.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Extensions/SecurityFilterExtension.cs
@@ -16,7 +16,6 @@ namespace Orchard.Projections.Extensions {
             return list.Where(x => x.As<ContentPermissionsPart>() == null ||
                                    HasAccess(currentUser, x.As<ContentPermissionsPart>()
                               ));
-            //Assuming owners can always view their own items.
         }
 
         public static bool HasAccess(IUser user, ContentPermissionsPart part) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
@@ -274,5 +274,13 @@ namespace Orchard.Projections {
 
             return 3;
         }
+
+        public int UpdateFrom3() {
+            SchemaBuilder.AlterTable("FilterRecord",
+                table => table
+                    .AddColumn("CheckPermissions", DbType.Boolean)
+                    );
+            return 4;
+        }        
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Models/FilterRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Models/FilterRecord.cs
@@ -10,5 +10,7 @@
 
         // Parent property
         public virtual FilterGroupRecord FilterGroupRecord { get; set; }
+
+        public bool CheckPermissions { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Module.txt
@@ -2,8 +2,9 @@ Name: Projector
 AntiForgery: enabled
 Author: The Orchard Team
 Website: http://orchardprojections.codeplex.com
-Version: 1.9.1
+Version: 1.9.2
 OrchardVersion: 1.9
 Description: Provides methods to control how lists of content items are filtered and displayed
 Category: Content
-Dependencies: Orchard.Tokens, Orchard.Forms, Feeds, Title
+Dependencies: Orchard.Tokens, Orchard.Forms, Feeds, Title, Orchard.ContentPermissions
+

--- a/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
@@ -96,6 +96,7 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
+    <Compile Include="Extensions\SecurityFilterExtension.cs" />
     <Compile Include="Permissions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
@@ -109,9 +110,17 @@
       <Project>{9916839C-39FC-4CEB-A5AF-89CA7E87119F}</Project>
       <Name>Orchard.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Orchard.ContentPermissions\Orchard.ContentPermissions.csproj">
+      <Project>{e826f796-8ce3-4b5b-8423-5aa5f81d2fc3}</Project>
+      <Name>Orchard.ContentPermissions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Orchard.Forms\Orchard.Forms.csproj">
       <Project>{642A49D7-8752-4177-80D6-BFBBCFAD3DE0}</Project>
       <Name>Orchard.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Orchard.Roles\Orchard.Roles.csproj">
+      <Project>{d10ad48f-407d-4db5-a328-173ec7cb010f}</Project>
+      <Name>Orchard.Roles</Name>
     </ProjectReference>
     <ProjectReference Include="..\Orchard.Tokens\Orchard.Tokens.csproj">
       <Project>{6F759635-13D7-4E94-BCC9-80445D63F117}</Project>

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -144,6 +144,9 @@ namespace Orchard.Projections.Services {
                     var allCiFiltered = contentQuery.List().FilterContentItems(_services.WorkContext.CurrentUser);
                     contentItems.AddRange(allCiFiltered.Skip(skip).Take(count));
                 }
+                else {
+                    contentItems.AddRange(contentQuery.Slice(skip, count));
+                }
             }
 
             if (queryRecord.FilterGroups.Count <= 1) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -12,9 +12,10 @@ using Orchard.Projections.Descriptors.Layout;
 using Orchard.Projections.Descriptors.SortCriterion;
 using Orchard.Projections.Models;
 using Orchard.Tokens;
+using Orchard.Projections.Extensions;
 
 namespace Orchard.Projections.Services {
-    public class ProjectionManager : IProjectionManager{
+    public class ProjectionManager : IProjectionManager {
         private readonly ITokenizer _tokenizer;
         private readonly IEnumerable<IFilterProvider> _filterProviders;
         private readonly IEnumerable<ISortCriterionProvider> _sortCriterionProviders;
@@ -22,6 +23,7 @@ namespace Orchard.Projections.Services {
         private readonly IEnumerable<IPropertyProvider> _propertyProviders;
         private readonly IContentManager _contentManager;
         private readonly IRepository<QueryPartRecord> _queryRepository;
+        private readonly IOrchardServices _services;
 
         public ProjectionManager(
             ITokenizer tokenizer,
@@ -30,7 +32,8 @@ namespace Orchard.Projections.Services {
             IEnumerable<ILayoutProvider> layoutProviders,
             IEnumerable<IPropertyProvider> propertyProviders,
             IContentManager contentManager,
-            IRepository<QueryPartRecord> queryRepository) {
+            IRepository<QueryPartRecord> queryRepository,
+            IOrchardServices services) {
             _tokenizer = tokenizer;
             _filterProviders = filterProviders;
             _sortCriterionProviders = sortCriterionProviders;
@@ -38,6 +41,7 @@ namespace Orchard.Projections.Services {
             _propertyProviders = propertyProviders;
             _contentManager = contentManager;
             _queryRepository = queryRepository;
+            _services = services;
             T = NullLocalizer.Instance;
         }
 
@@ -112,9 +116,15 @@ namespace Orchard.Projections.Services {
             }
 
             // aggregate the result for each group query
+            var checkPermissions = queryRecord.FilterGroups.Any(x => x.Filters.Any(y => y.CheckPermissions));
 
-            return GetContentQueries(queryRecord, Enumerable.Empty<SortCriterionRecord>())
-                .Sum(contentQuery => contentQuery.Count());
+            var count = GetContentQueries(queryRecord, Enumerable.Empty<SortCriterionRecord>())
+                .Sum(contentQuery => checkPermissions ? 
+                                contentQuery.List().FilterContentItems(_services.WorkContext.CurrentUser).Count() : 
+                                contentQuery.Count()
+                                );
+
+            return count;
         }
 
         public IEnumerable<ContentItem> GetContentItems(int queryId, int skip = 0, int count = 0) {
@@ -122,25 +132,28 @@ namespace Orchard.Projections.Services {
 
             var queryRecord = _queryRepository.Get(queryId);
 
-            if(queryRecord == null) {
+            if (queryRecord == null) {
                 throw new ArgumentException("queryId");
             }
 
             var contentItems = new List<ContentItem>();
-
+            var checkPermissions = queryRecord.FilterGroups.Any(x => x.Filters.Any(y => y.CheckPermissions));
             // aggregate the result for each group query
-            foreach(var contentQuery in GetContentQueries(queryRecord, queryRecord.SortCriteria.OrderBy(sc => sc.Position))) {
-                contentItems.AddRange(contentQuery.Slice(skip, count));
+            foreach (var contentQuery in GetContentQueries(queryRecord, queryRecord.SortCriteria.OrderBy(sc => sc.Position))) {
+                if (checkPermissions) {
+                    var allCiFiltered = contentQuery.List().FilterContentItems(_services.WorkContext.CurrentUser);
+                    contentItems.AddRange(allCiFiltered.Skip(skip).Take(count));
+                }
             }
 
-            if(queryRecord.FilterGroups.Count <= 1) {
+            if (queryRecord.FilterGroups.Count <= 1) {
                 return contentItems;
             }
 
             // re-executing the sorting with the cumulated groups
             var ids = contentItems.Select(c => c.Id).ToArray();
 
-            if(ids.Length == 0) {
+            if (ids.Length == 0) {
                 return Enumerable.Empty<ContentItem>();
             }
 
@@ -237,7 +250,7 @@ namespace Orchard.Projections.Services {
 
 
                 yield return contentQuery;
-            }            
+            }
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/ViewModels/AdminEditViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/ViewModels/AdminEditViewModel.cs
@@ -23,6 +23,7 @@ namespace Orchard.Projections.ViewModels {
         public string Category { get; set; }
         public string Type { get; set; }
         public string DisplayText { get; set; }
+        public bool CheckPermissions { get; set; }
     }
 
     public class SortCriterionEntry {

--- a/src/Orchard.Web/Modules/Orchard.Projections/ViewModels/FilterEditViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/ViewModels/FilterEditViewModel.cs
@@ -7,5 +7,6 @@ namespace Orchard.Projections.ViewModels {
         public string Description { get; set; }
         public FilterDescriptor Filter { get; set; }
         public dynamic Form { get; set; }
+        public bool CheckPermissions { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Views/Filter/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Views/Filter/Edit.cshtml
@@ -31,6 +31,12 @@
 
     @Display.TokenHint()
 
+    <fieldset>
+        @Html.LabelFor(m => m.CheckPermissions, T("Check Permissions"))
+        @Html.CheckBoxFor(m => m.CheckPermissions)
+        <span class="hint">Check user permissions for content items</span>
+    </fieldset>
+
 <fieldset>
     <button class="primaryAction" type="submit">@T("Save")</button>
 </fieldset>

--- a/src/Orchard.Web/Modules/Orchard.Projections/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Web.config
@@ -31,6 +31,8 @@
                 <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=B77A5C561934E089"/>
                 <add assembly="System.Web.Mvc, Version=5.2.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
                 <add assembly="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+                <add assembly="Orchard.Framework"/>
+                <add assembly="Orchard.Core"/>
             </assemblies>
         </compilation>
     </system.web>


### PR DESCRIPTION
Adding preliminary support for content item security when using projections.  Enabling this option will degrade performance if there are a lot of content items returned in the projection query.  This option is enabled at the Filter level:
![screen shot 2015-08-26 at 11 04 46 am](https://cloud.githubusercontent.com/assets/52411/9497290/4f2360fe-4be2-11e5-87d5-a32a11ad9e40.png)


Related to issue: https://github.com/OrchardCMS/Orchard/issues/5695