### PR TITLE
#5197: ContentFields missing if part is welded on via ActivatingFilter

### DIFF
--- a/src/Orchard/ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard/ContentManagement/DefaultContentManager.cs
@@ -91,11 +91,13 @@ namespace Orchard.ContentManagement {
                 contentTypeDefinition = new ContentTypeDefinitionBuilder().Named(contentType).Build();
             }
 
+            var contentPartDefinitions = _contentDefinitionManager.ListPartDefinitions().ToList();
+
             // create a new kernel for the model instance
             var context = new ActivatingContentContext {
                 ContentType = contentTypeDefinition.Name,
                 Definition = contentTypeDefinition,
-                Builder = new ContentItemBuilder(contentTypeDefinition)
+                Builder = new ContentItemBuilder(contentTypeDefinition, contentPartDefinitions)
             };
 
             // invoke handlers to weld aspects onto kernel

--- a/src/Orchard/ContentManagement/Handlers/ContentItemBuilder.cs
+++ b/src/Orchard/ContentManagement/Handlers/ContentItemBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Orchard.ContentManagement.MetaData.Models;
 
 namespace Orchard.ContentManagement.Handlers {
@@ -7,14 +8,17 @@ namespace Orchard.ContentManagement.Handlers {
     /// </summary>
     public class ContentItemBuilder {
         private readonly ContentTypeDefinition _definition;
+        private readonly IList<ContentPartDefinition> _partDefinitions;
         private readonly ContentItem _item;
 
         /// <summary>
         /// Constructs a new Content Item Builder instance.
         /// </summary>
         /// <param name="definition">The definition for the content item to be built.</param>
-        public ContentItemBuilder(ContentTypeDefinition definition) {
+        /// <param name="partDefinitions">An optional list of part definitions used to weld parts on the fly.</param>
+        public ContentItemBuilder(ContentTypeDefinition definition, IList<ContentPartDefinition> partDefinitions = null) {
             _definition = definition;
+            _partDefinitions = partDefinitions;
 
             // TODO: could / should be done on the build method ?
             _item = new ContentItem {
@@ -41,9 +45,14 @@ namespace Orchard.ContentManagement.Handlers {
                 // obtain the type definition for the part
                 var typePartDefinition = _definition.Parts.FirstOrDefault(p => p.PartDefinition.Name == partName);
                 if (typePartDefinition == null) {
-                    // If the content item's type definition does not define the part; use an empty type definition.
+                    // If the content item's type definition does not define the part, retrieve the part definition.
+                    ContentPartDefinition contentPartDefinition = null;
+                    if (_partDefinitions != null) {
+                        contentPartDefinition = _partDefinitions.Where(p => p.Name == partName).FirstOrDefault() ;
+                    }
+                    // And create a new type definition for the part.
                     typePartDefinition = new ContentTypePartDefinition(
-                        new ContentPartDefinition(partName),
+                        contentPartDefinition ?? new ContentPartDefinition(partName),
                         new SettingsDictionary());
                 }
 


### PR DESCRIPTION
Fixes #5197 

If a part that has some content fields is welded through an ActivatingFilter, a new content part is created but with an empty collection of ContentPartFieldDefinition...