### PR TITLE
#5647: Fixing WorkContext usage in other places

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/AdminCultureSelectorFactory.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/AdminCultureSelectorFactory.cs
@@ -9,22 +9,24 @@ namespace Orchard.Localization.Services {
     [OrchardFeature("Orchard.Localization.CultureSelector")]
     public class AdminCultureSelectorFactory : ShapeDisplayEvents {
         private readonly ICultureManager _cultureManager;
-        private readonly WorkContext _workContext;
+        private readonly IWorkContextAccessor _workContextAccessor;
 
         public AdminCultureSelectorFactory(
             IWorkContextAccessor workContextAccessor, 
             IShapeFactory shapeFactory,
             ICultureManager cultureManager) {
             _cultureManager = cultureManager;
-            _workContext = workContextAccessor.GetContext();
+            _workContextAccessor = workContextAccessor;
             Shape = shapeFactory;
         }
 
         dynamic Shape { get; set; }
 
         private bool IsActivable() {
+            var workContext = _workContextAccessor.GetContext();
+
             // activate on admin screen only
-            if (AdminFilter.IsApplied(new RequestContext(_workContext.HttpContext, new RouteData())))
+            if (AdminFilter.IsApplied(new RequestContext(workContext.HttpContext, new RouteData())))
                 return true;
 
             return false;
@@ -35,7 +37,8 @@ namespace Orchard.Localization.Services {
                 if (displayedContext.ShapeMetadata.Type == "Layout" && IsActivable()) {
                     var supportedCultures = _cultureManager.ListCultures().ToList();
                     if (supportedCultures.Count() > 1) {
-                        _workContext.Layout.Header.Add(Shape.AdminCultureSelector(SupportedCultures: supportedCultures));
+                        var workContext = _workContextAccessor.GetContext();
+                        workContext.Layout.Header.Add(Shape.AdminCultureSelector(SupportedCultures: supportedCultures));
                     }
                 }
             });

--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/AdminDirectionalityFactory.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/AdminDirectionalityFactory.cs
@@ -7,17 +7,19 @@ using Orchard.UI.Admin;
 namespace Orchard.Localization.Services {
     [OrchardFeature("Orchard.Localization.CultureSelector")]
     public class AdminDirectionalityFactory : ShapeDisplayEvents {
-        private readonly WorkContext _workContext;
+        private readonly IWorkContextAccessor _workContextAccessor;
 
         public AdminDirectionalityFactory(
             IWorkContextAccessor workContextAccessor) {
-            _workContext = workContextAccessor.GetContext();
+            _workContextAccessor = workContextAccessor;
         }
 
 
         private bool IsActivable() {
+            var workContext = _workContextAccessor.GetContext();
+
             // activate on admin screen only
-            if (AdminFilter.IsApplied(new RequestContext(_workContext.HttpContext, new RouteData())))
+            if (AdminFilter.IsApplied(new RequestContext(workContext.HttpContext, new RouteData())))
                 return true;
 
             return false;
@@ -43,7 +45,8 @@ namespace Orchard.Localization.Services {
                     }
                 }
 
-                var className = "content-" + _workContext.GetTextDirection(contentItem);
+                var workContext = _workContextAccessor.GetContext();
+                var className = "content-" + workContext.GetTextDirection(contentItem);
 
                 if (!_workContext.Layout.Content.Classes.Contains(className))
                     _workContext.Layout.Content.Classes.Add(className);

--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/AdminDirectionalityFactory.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/AdminDirectionalityFactory.cs
@@ -48,8 +48,8 @@ namespace Orchard.Localization.Services {
                 var workContext = _workContextAccessor.GetContext();
                 var className = "content-" + workContext.GetTextDirection(contentItem);
 
-                if (!_workContext.Layout.Content.Classes.Contains(className))
-                    _workContext.Layout.Content.Classes.Add(className);
+                if (!workContext.Layout.Content.Classes.Contains(className))
+                    workContext.Layout.Content.Classes.Add(className);
             });
         }
 

--- a/src/Orchard.Web/Modules/TinyMce/Services/TinyMceShapeDisplayEvent.cs
+++ b/src/Orchard.Web/Modules/TinyMce/Services/TinyMceShapeDisplayEvent.cs
@@ -11,7 +11,7 @@ namespace TinyMce.Services {
         private readonly ICacheManager _cacheManager;
         private readonly ISignals _signals;
         private readonly IVirtualPathProvider _virtualPathProvider;
-        private readonly WorkContext _workContext;
+        private readonly IWorkContextAccessor _workContextAccessor;
 
         private const string CacheKeyFormat = "tinymce-locales-{0}";
         private const string DefaultLanguage = "en";
@@ -24,7 +24,7 @@ namespace TinyMce.Services {
             _signals = signals;
             _cacheManager = cacheManager;
             _virtualPathProvider = virtualPathProvider;
-            _workContext = workContextAccessor.GetContext();
+            _workContextAccessor = workContextAccessor;
         }
 
         public override void Displaying(ShapeDisplayingContext context) {
@@ -40,7 +40,8 @@ namespace TinyMce.Services {
         }
 
         private string GetTinyMceLanguageIdentifier() {
-            var currentCulture = CultureInfo.GetCultureInfo(_workContext.CurrentCulture);
+            var workContext = _workContextAccessor.GetContext();
+            var currentCulture = CultureInfo.GetCultureInfo(workContext.CurrentCulture);
 
             if (currentCulture.Name.Equals(DefaultLanguage, StringComparison.OrdinalIgnoreCase))
                 return currentCulture.Name;


### PR DESCRIPTION
Same as #5647 already closed but in other places. Seems to be related to all classes that init a `WorkContext` in their constructor, and that inherit from `ShapeDisplayEvents` or `IShapeDisplayEvents`.

Here, to prevent from getting errors, in the last dev branch, when enabling `Culture Picker` and when using a `Body Editor`. This concerns `AdminDirectionalityFactory`, `AdminCultureSelectorFactory` and `TinyMceShapeDisplayEvent`

As I've mentioned in #5647, this occurs after this commit: https://github.com/OrchardCMS/Orchard/commit/83cae5f0a0d6a3000be2e52e2fcf8e80966005b4. Really, if in `FormsAuthenticationService` I use a `Lazy<IMembershipService>`, it works without changing the `WorkContext` usage (see more details in #5647)

So, even `FormsAuthenticationService` is well implemented, let me know if you want to use a `Lazy<IMembershipService>`, this not to break some other third party modules

Best