### PR TITLE
#4852: Wrap IOrchardShellEvents in a work context

### DIFF
--- a/src/Orchard/Environment/DefaultOrchardShell.cs
+++ b/src/Orchard/Environment/DefaultOrchardShell.cs
@@ -17,7 +17,7 @@ using IModelBinderProvider = Orchard.Mvc.ModelBinders.IModelBinderProvider;
 
 namespace Orchard.Environment {
     public class DefaultOrchardShell : IOrchardShell {
-        private readonly Func<Owned<IOrchardShellEvents>> _eventsFactory;
+        private readonly IWorkContextAccessor _workContextAccessor;
         private readonly IEnumerable<IRouteProvider> _routeProviders;
         private readonly IEnumerable<IHttpRouteProvider> _httpRouteProviders;
         private readonly IRoutePublisher _routePublisher;
@@ -28,7 +28,7 @@ namespace Orchard.Environment {
         private readonly ShellSettings _shellSettings;
 
         public DefaultOrchardShell(
-            Func<Owned<IOrchardShellEvents>> eventsFactory,
+            IWorkContextAccessor workContextAccessor,
             IEnumerable<IRouteProvider> routeProviders,
             IEnumerable<IHttpRouteProvider> httpRouteProviders,
             IRoutePublisher routePublisher,
@@ -37,7 +37,7 @@ namespace Orchard.Environment {
             ISweepGenerator sweepGenerator,
             IEnumerable<IOwinMiddlewareProvider> owinMiddlewareProviders,
             ShellSettings shellSettings) {
-            _eventsFactory = eventsFactory;
+            _workContextAccessor = workContextAccessor;
             _routeProviders = routeProviders;
             _httpRouteProviders = httpRouteProviders;
             _routePublisher = routePublisher;
@@ -76,8 +76,10 @@ namespace Orchard.Environment {
             _routePublisher.Publish(allRoutes, pipeline);
             _modelBinderPublisher.Publish(_modelBinderProviders.SelectMany(provider => provider.GetModelBinders()));
 
-            using (var events = _eventsFactory()) {
-                events.Value.Activated();
+            using (var scope = _workContextAccessor.CreateWorkContextScope()) {
+                using (var events = scope.Resolve<Owned<IOrchardShellEvents>>()) {
+                    events.Value.Activated();
+                }
             }
 
             _sweepGenerator.Activate();
@@ -85,10 +87,12 @@ namespace Orchard.Environment {
 
         public void Terminate() {
             SafelyTerminate(() => {
-                       using (var events = _eventsFactory()) {
-                           SafelyTerminate(() => events.Value.Terminating());
-                       }
-                   });
+                using (var scope = _workContextAccessor.CreateWorkContextScope()) {
+                    using (var events = scope.Resolve<Owned<IOrchardShellEvents>>()) {
+                        SafelyTerminate(() => events.Value.Terminating());
+                    }
+                }
+            });
 
             SafelyTerminate(() => _sweepGenerator.Terminate());
         }


### PR DESCRIPTION
This is a fix for #4852

This fixes some of the problems we are seeing relating to being unable to inject HttpContextBase during IOrchardShellEvents.

This has mainly been a problem when attempting to access ContentManager or site settings in Data Migrations, such as seen in #5305 #5490 #5528.

We seem to only be hitting the problem when Orchard is compiled under VS2015, but this is probably the correct behavior even when building under previous environments.
