### PR TITLE
Mark the npm repository as private

### DIFF
--- a/src/Package.json
+++ b/src/Package.json
@@ -1,4 +1,5 @@
 {
+    "private": true,
     "devDependencies": {
         "glob": "^5.0.14",
         "path-posix": "^1.0.0",


### PR DESCRIPTION
'npm install' was generating several warnings about missing properties in package.json. Marking the repository as private clears up the warnings.