### PR TITLE
Suppressed warning CS0436 in Orchard.Framework

### DIFF
--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -55,6 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=2.1.13.813, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">


### PR DESCRIPTION
Daniel changed the Orchaard.Framework project to ignore the JetBrains.Annotations conflicts for debug builds several months back. See http://orchard.codeplex.com/workitem/21056 and 78901ba . However, the problem still exists for release builds. This pull request applies the same fix (ignoring the warning) to release builds.