### PR TITLE
#5779: Query and Taxonomy Elements should include value attribute for default option

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/QueryElementDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/QueryElementDriver.cs
@@ -136,7 +136,7 @@ namespace Orchard.DynamicForms.Drivers {
             var runtimeValues = GetRuntimeValues(element);
 
             if (!String.IsNullOrWhiteSpace(optionLabel)) {
-                yield return new SelectListItem { Text = displayType != "Design" ? _tokenizer.Replace(optionLabel, tokenData) : optionLabel };
+                yield return new SelectListItem { Text = displayType != "Design" ? _tokenizer.Replace(optionLabel, tokenData) : optionLabel, Value = string.Empty };
             }
 
             if (queryId == null)

--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/TaxonomyElementDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/TaxonomyElementDriver.cs
@@ -138,7 +138,7 @@ namespace Orchard.DynamicForms.Drivers {
             var runtimeValues = GetRuntimeValues(element);
 
             if (!String.IsNullOrWhiteSpace(optionLabel)) {
-                yield return new SelectListItem { Text = displayType != "Design" ? _tokenizer.Replace(optionLabel, tokenData) : optionLabel };
+                yield return new SelectListItem { Text = displayType != "Design" ? _tokenizer.Replace(optionLabel, tokenData) : optionLabel, Value = string.Empty };
             }
 
             if (taxonomyId == null)


### PR DESCRIPTION
This change ensures that value attribute is included in the default (no value selected) option for dropdown select lists that are generated for Query and Taxonomy elements. Fixes #5779 