### PR TITLE
Issue 20514 - Remove id from custom form returnUrl hidden field

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Parts.CustomForm.Wrapper.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Parts.CustomForm.Wrapper.cshtml
@@ -14,7 +14,7 @@
     // Model is a Shape, calling Display() so that it is rendered using the most specific template for its Shape type
     @Display(editor)
 
-    @Html.Hidden("returnUrl", Request.RawUrl);
+    @Html.Hidden("returnUrl", Request.RawUrl, new { id = string.Empty });
 
     <fieldset class="submit-button">
         <button type="submit" name="submit.Save" value="submit.Save">@Model.ContentPart.SubmitButtonText</button>


### PR DESCRIPTION
Implemented fix for custom form module to eliminate HTML validation error. See original work item here https://orchard.codeplex.com/workitem/20514

Fixes #4343 