### PR TITLE
#4766: Unable to generate RouteUrl for webapi

### DIFF
--- a/src/Orchard/Mvc/Routes/ShellRoute.cs
+++ b/src/Orchard/Mvc/Routes/ShellRoute.cs
@@ -71,6 +71,10 @@ namespace Orchard.Mvc.Routes {
 
 
         public override VirtualPathData GetVirtualPath(RequestContext requestContext, RouteValueDictionary values) {
+
+            if (values.ContainsKey("httproute") && values["httproute"] is bool && (bool)values["httproute"] != IsHttpRoute)
+                return null;
+
             // locate appropriate shell settings for request
             var settings = _runningShellTable.Match(requestContext.HttpContext);
 

--- a/src/Orchard/WebApi/Routes/StandardExtensionHttpRouteProvider.cs
+++ b/src/Orchard/WebApi/Routes/StandardExtensionHttpRouteProvider.cs
@@ -22,9 +22,10 @@ namespace Orchard.WebApi.Routes {
                 var displayPath = item.Distinct().Single();
 
                 yield return new HttpRouteDescriptor {
+                    Name = displayPath + ".Api",
                     Priority = -10,
                     RouteTemplate = "api/" + displayPath + "/{controller}/{id}",
-                    Defaults = new {area = areaName, controller = "api", id = RouteParameter.Optional}
+                    Defaults = new {area = areaName, id = RouteParameter.Optional}
                 };
             }
         }


### PR DESCRIPTION
Fixes #4766

And maybe other related issues

> **In ShellRoute.cs, fixes the priority issue**

When using an UrlHelper extension, you needed to define your own HttpRouteDescriptor with a higher priority than other desciptors in the same area...

> **In StandardExtensionHttpRouteProvider.cs, defines default httproute names**

This by using the extension path that is equal to the extension name if no some special characters (e.g spaces if multiples words). Otherwise, it is equal to the extension Id (the extension folder name).

Then, for the http route name you can use "ModuleName.Api". If you can't, depending on the module name, then you can use "FolderName.Api"... This with an UrlHelper extension without having to specify the area name...

> **In RoutePublisher.cs, prevent the program to fail if duplicate route names**

There is a checking before the insertion in the final RouteCollection, but before there are 2 others internal RouteCollection where this is not done. Because the route name is useless for these 2 collections, we can pass an empty string

Best