### PR TITLE
Enhancement to allow multi-select for the content picker

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="ViewModels\NavigationPartViewModel.cs" />
     <Content Include="Scripts\ContentPicker.js" />
+    <Content Include="Scripts\RecentContentTab.js" />
     <Content Include="Styles\content-picker-admin.css" />
     <Content Include="Styles\ContentPicker.css" />
     <Content Include="Styles\Images\move.gif" />

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
@@ -72,7 +72,7 @@
   <ItemGroup>
     <Compile Include="ViewModels\NavigationPartViewModel.cs" />
     <Content Include="Scripts\ContentPicker.js" />
-    <Content Include="Scripts\RecentContentTab.js" />
+    <Content Include="Scripts\SelectableContentTab.js" />
     <Content Include="Styles\content-picker-admin.css" />
     <Content Include="Styles\ContentPicker.css" />
     <Content Include="Styles\Images\move.gif" />

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/ResourceManifest.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/ResourceManifest.cs
@@ -5,6 +5,7 @@ namespace Orchard.ContentPicker {
         public void BuildManifests(ResourceManifestBuilder builder) {
             var manifest = builder.Add();
             manifest.DefineScript("ContentPicker").SetUrl("ContentPicker.js", "ContentPicker.js").SetDependencies("jQuery");
+            manifest.DefineScript("RecentContentTab").SetUrl("RecentContentTab.js", "RecentContentTab.js").SetDependencies("jQuery");
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/ResourceManifest.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/ResourceManifest.cs
@@ -5,7 +5,7 @@ namespace Orchard.ContentPicker {
         public void BuildManifests(ResourceManifestBuilder builder) {
             var manifest = builder.Add();
             manifest.DefineScript("ContentPicker").SetUrl("ContentPicker.js", "ContentPicker.js").SetDependencies("jQuery");
-            manifest.DefineScript("RecentContentTab").SetUrl("RecentContentTab.js", "RecentContentTab.js").SetDependencies("jQuery");
+            manifest.DefineScript("SelectableContentTab").SetUrl("SelectableContentTab.js", "SelectableContentTab.js").SetDependencies("jQuery");
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Scripts/ContentPicker.js
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Scripts/ContentPicker.js
@@ -80,14 +80,26 @@
             addButton.click(function() {
                 addButton.trigger("orchard-admin-contentpicker-open", {
                     callback: function(data) {
-                        var tmpl = template.replace( /\{contentItemId\}/g , data.id)
-                            .replace( /\{edit-link\}/g , data.editLink)
-                            .replace( /\{status-text}/g , data.published? "" : " - " + notPublishedText);
-                        var content = $(tmpl);
-                        $(self).find('table.content-picker tbody').append(content);
+                        if (Array.isArray && Array.isArray(data)) {
+                            data.forEach(function (d) {
+                                var tmpl = template.replace(/\{contentItemId\}/g, d.id)
+                                    .replace(/\{edit-link\}/g, d.editLink)
+                                    .replace(/\{status-text}/g, d.published ? "" : " - " + notPublishedText);
+                                var content = $(tmpl);
+                                $(self).find('table.content-picker tbody').append(content);
+                            });
+                            refreshIds();
+                            $(self).find('.content-picker-message').show();
+                        } else {
+                            var tmpl = template.replace(/\{contentItemId\}/g, data.id)
+                                .replace(/\{edit-link\}/g, data.editLink)
+                                .replace(/\{status-text}/g, data.published ? "" : " - " + notPublishedText);
+                            var content = $(tmpl);
+                            $(self).find('table.content-picker tbody').append(content);
 
-                        refreshIds();
-                        $(self).find('.content-picker-message').show();
+                            refreshIds();
+                            $(self).find('.content-picker-message').show();
+                        }
                     },
                     baseUrl: baseUrl,
                     part: partName,

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Scripts/RecentContentTab.js
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Scripts/RecentContentTab.js
@@ -1,0 +1,29 @@
+﻿jQuery(function ($) {
+
+    Initialize = function () {
+ 
+        $('.button.addSelected').on('click', function () {
+            var selectedItems = $('.content-picker-itemCheck:checked');
+            var itemsToAdd = new Array();
+            $.each(selectedItems, function (index, item) {
+                var related = $(item).siblings('.content-picker-item').children('.related');
+                var data = {
+                    id: related.data("id"),
+                    displayText: related.data("display-text"),
+                    editLink: related.data("edit-link"),
+                    editUrl: related.data("edit-url"),
+                    adminUrl: related.data("admin-url"),
+                    displayLink: related.data("display-link"),
+                    published: related.data("published")
+                };
+                return itemsToAdd.push(data);
+            });
+            window.opener.jQuery[query("callback")](itemsToAdd);
+            window.close();
+        });
+    };
+
+    $(document).ready(function () {
+        return Initialize();
+    });
+});

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Scripts/SelectableContentTab.js
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Scripts/SelectableContentTab.js
@@ -21,6 +21,9 @@
             window.opener.jQuery[query("callback")](itemsToAdd);
             window.close();
         });
+        $('.content-picker-SelectAll').on('click', function () {
+            $('.content-picker-itemCheck').prop('checked', $(this).prop("checked"));
+        });
     };
 
     $(document).ready(function () {

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Styles/ContentPicker.css
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Styles/ContentPicker.css
@@ -20,3 +20,24 @@ body {
     background: white;
     border: 1px solid #E4E5E6;
 }
+
+.content-picker-item
+{
+    margin-left: 20px;
+}
+
+.content-picker-itemCheck
+{
+    position:absolute;
+
+}
+
+.addSelected
+{
+    margin-bottom: 10px;
+}
+
+.page-size-options > div:first-child
+{
+    display:inline-block;
+}

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Styles/ContentPicker.css
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Styles/ContentPicker.css
@@ -32,6 +32,18 @@ body {
 
 }
 
+label[for="selectAll"]:before
+{
+    content:'';
+    display:block;
+    margin-top:20px;
+}
+
+label[for="selectAll"]
+{
+    display:inline;
+}
+
 .addSelected
 {
     margin-bottom: 10px;

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/ContentPicker.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/ContentPicker.SummaryAdmin.cshtml
@@ -3,27 +3,30 @@
     ContentItem contentItem = Model.ContentItem;
 }
 <div class="summary" itemscope="itemscope" itemid="@contentItem.Id" itemtype="http://orchardproject.net/data/ContentItem">
-    <div class="properties">
-        @*<input type="checkbox" value="@contentItem.Id" name="itemIds"/>*@
-        <h3>@Html.ItemDisplayText(contentItem)</h3> - <div class="contentType">@contentItem.TypeDefinition.DisplayName</div>
-        @if (Model.Header != null) {
-            <div class="header">@Display(Model.Header)</div>
-        }
-        @if (Model.Meta != null) {
-            <div class="metadata">@Display(Model.Meta)</div>
+    <input type="checkbox" class="content-picker-itemCheck" />
+    <div class="content-picker-item">
+        <div class="properties">
+            @*<input type="checkbox" value="@contentItem.Id" name="itemIds"/>*@
+            <h3>@Html.ItemDisplayText(contentItem)</h3> - <div class="contentType">@contentItem.TypeDefinition.DisplayName</div>
+            @if (Model.Header != null) {
+                <div class="header">@Display(Model.Header)</div>
+            }
+            @if (Model.Meta != null) {
+                <div class="metadata">@Display(Model.Meta)</div>
+            }
+        </div>
+        <div class="related" 
+             data-display-text="@Html.ItemDisplayText(contentItem)"
+             data-id="@contentItem.Id"
+             data-edit-link="@Html.Encode(Html.ItemEditLink(contentItem))"
+             data-edit-url="@Html.Encode(Url.ItemEditUrl(contentItem))"
+             data-admin-url="@Html.Encode(Url.ItemAdminUrl(contentItem))"
+             data-display-link="@Html.Encode(Html.ItemDisplayLink(contentItem))"
+             data-published="@contentItem.VersionRecord.Published.ToString().ToLower()" >
+            @Html.Link(T("Select").Text, "#", new { @class = "button select"})
+        </div>
+        @if (Model.Content != null) {
+            <div class="primary">@Display(Model.Content)</div>
         }
     </div>
-    <div class="related" 
-         data-display-text="@Html.ItemDisplayText(contentItem)"
-         data-id="@contentItem.Id"
-         data-edit-link="@Html.Encode(Html.ItemEditLink(contentItem))"
-         data-edit-url="@Html.Encode(Url.ItemEditUrl(contentItem))"
-         data-admin-url="@Html.Encode(Url.ItemAdminUrl(contentItem))"
-         data-display-link="@Html.Encode(Html.ItemDisplayLink(contentItem))"
-         data-published="@contentItem.VersionRecord.Published.ToString().ToLower()" >
-        @Html.Link(T("Select").Text, "#", new { @class = "button select"})
-    </div>
-    @if (Model.Content != null) {
-        <div class="primary">@Display(Model.Content)</div>
-    }
 </div>

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/RecentContentTab.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/RecentContentTab.cshtml
@@ -1,6 +1,6 @@
 ﻿@using Orchard.Core.Contents.ViewModels;
 @{
-    Script.Include("RecentContentTab.js");
+    Script.Require("SelectableContentTab");
     
     var typeDisplayName = Model.TypeDisplayName;
     var pageTitle = T("Recent Content");

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/RecentContentTab.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/RecentContentTab.cshtml
@@ -1,5 +1,7 @@
 ﻿@using Orchard.Core.Contents.ViewModels;
 @{
+    Script.Include("RecentContentTab.js");
+    
     var typeDisplayName = Model.TypeDisplayName;
     var pageTitle = T("Recent Content");
 
@@ -8,6 +10,7 @@
     }
 
     Layout.Title = pageTitle;
+    
 }
 
 <div class="manage">
@@ -33,6 +36,7 @@
     <fieldset class="contentItems bulk-items">
 @Display(Model.ContentItems)
     </fieldset>
+    @Html.Link(T("Add Selected").Text, "#", new { @class = "button addSelected"})
 @Display(Model.Pager)
 }
 

--- a/src/Orchard.Web/Modules/Orchard.Search/Views/SearchContentTab.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Search/Views/SearchContentTab.cshtml
@@ -1,4 +1,6 @@
 ﻿@{
+    Script.Require("SelectableContentTab");
+    
     var pageTitle = T("Search Content");
     Layout.Title = pageTitle;
 }
@@ -11,10 +13,18 @@
         <button type="submit">@T("Search")</button>
     </fieldset>
     
+    if (Model.ContentItems.Items.Count > 0)
+    {
+        <label for="selectAll">@T("Select All")</label>
+        <input name="selectAll" type="checkbox" class="content-picker-SelectAll" />
+    }
     <fieldset class="contentItems bulk-items">
-        @Display(Model.ContentItems)
+            @Display(Model.ContentItems)
     </fieldset>
-        
+    if (Model.ContentItems.Items.Count > 0)
+    {    
+        @Html.Link(T("Add Selected").Text, "#", new { @class = "button addSelected"})
+    }
     @Display(Model.Pager)
 }
 


### PR DESCRIPTION
We needed the ability to create a custom tab on the contentPicker for the new layouts to allow our clients the ability to paste a list of ID's into.  In doing so, I found I needed to modify the contentPicker.js callback to handle an array of items.  I would love for contentPicker.js to be submitted on it's own but felt that a more complete solution would be more beneficial.  With this addition I have added new checkbox's for each content item in addition to the select button.  I added a new button at the bottom of the list to add the checked content items.  Once the add items button is click the window closes as does the current behavior for select buttons.  If the user experience of this new behavior does not pass review, I ask that you consider keeping the contentPicker.js changes as this would allow me to maintain my custom tab functionality.

Thank you for your time in review of this submission.