### PR TITLE
Serialization error is thrown when creating layout or page in the dashboard when using Layouts in a Web Farm.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Models/ElementSessionState.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Models/ElementSessionState.cs
@@ -1,5 +1,8 @@
+using System;
+
 ﻿namespace Orchard.Layouts.Models {
-    public class ElementSessionState {
+﻿        [Serializable]
+        public class ElementSessionState {
         public string TypeName { get; set; }
         public string ElementData { get; set; }
         public string ElementEditorData { get; set; }


### PR DESCRIPTION
Make Model Serializable for use in Web Farms with session state stored in a database. Currently a Serialization error is thrown when creating layout or page in the dashboard.