### PR TITLE
HttpRequestPlaceholder should implement property AnonymousID

### DIFF
--- a/src/Orchard/Mvc/MvcModule.cs
+++ b/src/Orchard/Mvc/MvcModule.cs
@@ -158,6 +158,17 @@ namespace Orchard.Mvc {
                 get { return false; }
             }
 
+            /// <summary>
+            /// Create an anonymous ID the same way as ASP.NET would.
+            /// Some users of an HttpRequestPlaceHolder object could expect this,
+            /// say CookieCultureSelector from module Orchard.CulturePicker.
+            /// </summary>
+            public override string AnonymousID {
+                get {
+                    return Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture);
+                }
+            }
+
             // empty collection provided for background operation
             public override NameValueCollection Form {
                 get {


### PR DESCRIPTION
The issue is that `CookieCultureSelector` from module Orchard.CulturePicker would face `NotImplementedException` when accessing property `AnonymousID` on a given `HttpRequestBase` object.

The issue is caused by `CookieCultureSelector` is expecting a working implementation of `HttpRequestBase.AnonymousID`, yet in one case that wont'be true. During background task execution, which is started by `SweepGenerator` on a background thread without real HTTP request, the `HttpRequestBase` object is created using `HttpRequestPlaceholder`, which is trying to simulate a valid HTTP Request to some extent, particularly leaving its property `AnonymousID` not implemented. However, `CookieCultureSelector.EvaluateResult` is expecting `context.Request.AnonymousID` being implemented in some way.

This could be seen as a bug in Orchard.CultureSelector, as one can justify that it should be aware of fake `HttpRequestBase` objects. On the other hand, this could be an Orchard bug as well, if the philosophy is to keep the users of `HttpRequestBase` objects ignorant of the actual implementations. I prefer the latter, thus this fix.