### PR TITLE
Fixes #5879: Layout part OnIndexing fails when called in a background task

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultCacheStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultCacheStorageProvider.cs
@@ -27,7 +27,8 @@ namespace Orchard.OutputCache.Services {
         }
 
         public void Remove(string key) {
-            _workContext.HttpContext.Cache.Remove(key);
+            if (_workContext.HttpContext != null)
+                _workContext.HttpContext.Cache.Remove(key);
         }
 
         public void RemoveAll() {

--- a/src/Orchard/Environment/WorkContextAccessor.cs
+++ b/src/Orchard/Environment/WorkContextAccessor.cs
@@ -27,7 +27,11 @@ namespace Orchard.Environment {
         }
 
         public WorkContext GetContext(HttpContextBase httpContext) {
-            return httpContext.Items[_workContextKey] as WorkContext;
+            if (!httpContext.IsBackgroundContext())
+                return httpContext.Items[_workContextKey] as WorkContext;
+
+            WorkContext workContext;
+            return EnsureThreadStaticContexts().TryGetValue(_workContextKey, out workContext) ? workContext : null;
         }
 
         public WorkContext GetContext() {


### PR DESCRIPTION
Fixes #5879

And maybe other issues, when the `GetContext(httpContext) method`, the one that has an `HttpContextBase parameter`, is called in the context of a `BackgroundTask`.