### PR TITLE
Fixes #5883: Logging thread infos overlapping

### DIFF
--- a/src/Orchard/Logging/OrchardLog4netLogger.cs
+++ b/src/Orchard/Logging/OrchardLog4netLogger.cs
@@ -63,11 +63,17 @@ namespace Orchard.Logging {
             if (_shellSettings.Value != null) {
                 ThreadContext.Properties["Tenant"] = _shellSettings.Value.Name;
             }
+            else {
+                ThreadContext.Properties.Remove("Tenant");
+            }
 
             try {
                 var ctx = HttpContext.Current;
                 if (ctx != null) {
                     ThreadContext.Properties["Url"] = ctx.Request.Url.ToString();
+                }
+                else {
+                    ThreadContext.Properties.Remove("Url");
                 }
             }
             catch(HttpException) {


### PR DESCRIPTION
Fixes #5883

By removing, when logging, the ThreadContext Properties for infos that are not available.