### PR TITLE
Update OrchardLog4netLogger.cs

### DIFF
--- a/src/Orchard/Logging/OrchardLog4netLogger.cs
+++ b/src/Orchard/Logging/OrchardLog4netLogger.cs
@@ -23,7 +23,7 @@ namespace Orchard.Logging {
             Logger = logger;
             Factory = factory;
 
-            _shellSettings = new Lazy<ShellSettings>(LoadSettings);
+             _shellSettings = new Lazy<ShellSettings>(LoadSettings, System.Threading.LazyThreadSafetyMode.PublicationOnly);
         }
 
         internal OrchardLog4netLogger() {


### PR DESCRIPTION
Fix for "ValueFactory attempted to access the Value property of this instance".

**Exception Details:**

ValueFactory attempted to access the Value property of this instance.

Description: An unhandled exception occurred during the execution of the current web request. Please review the stack trace for more information about the error and where it originated in the code. 

Exception Details: System.InvalidOperationException: ValueFactory attempted to access the Value property of this instance.

Source Error: 

Line 61:         // Load the log4net thread with additional properties if they are available
Line 62:         protected internal void AddExtendedThreadInfo() {
Line 63:             if (_shellSettings.Value != null) {
Line 64:                 ThreadContext.Properties["Tenant"] = _shellSettings.Value.Name;
Line 65:             }

Source File: D:\Proj\Src\Orchard\Logging\OrchardLog4netLogger.cs    Line: 63 