### PR TITLE
make orchard help command more intuitive - closes #422

### DIFF
--- a/src/Orchard/Commands/Builtin/HelpCommand.cs
+++ b/src/Orchard/Commands/Builtin/HelpCommand.cs
@@ -37,12 +37,15 @@ namespace Orchard.Commands.Builtin {
         [CommandHelp("help <command>\r\n\t" + "Display help text for <command>")]
         public void SingleCommand(string[] commandNameStrings) {
             string command = string.Join(" ", commandNameStrings);
-            var descriptor = _commandManager.GetCommandDescriptors().SingleOrDefault(d => string.Equals(command, d.Name, StringComparison.OrdinalIgnoreCase));
-            if (descriptor == null) {
+            var descriptors = _commandManager.GetCommandDescriptors().Where(t => t.Name.StartsWith(command, StringComparison.OrdinalIgnoreCase)).OrderBy(d => d.Name);
+            if (!descriptors.Any()) {
                 Context.Output.WriteLine(T("Command {0} doesn't exist").ToString(), command);
             }
             else {
-                Context.Output.WriteLine(GetHelpText(descriptor));
+                foreach (var descriptor in descriptors) {
+                    Context.Output.WriteLine(GetHelpText(descriptor));
+                    Context.Output.WriteLine();
+                }
             }
         }
     }


### PR DESCRIPTION
closes #422

This makes the orchard.exe `help` command more intuitive. 

Currently it makes you type out the full command to get help on it:

![image](https://cloud.githubusercontent.com/assets/1038062/10391133/c9a2948a-6e74-11e5-883b-fa2f220939d3.png)

From the way command line's work I think most users would expect `user` to be the command and the rest of the elements are arguments.

This small change filters the help so it just lists all the help it can based on the input:

`> help user`

![image](https://cloud.githubusercontent.com/assets/1038062/10391177/169b557e-6e75-11e5-83a3-43c327fc625d.png)

I decided not to change the help command description:

    [CommandHelp("help <command>\r\n\t" + "Display help text for <command>")]

This is because:

  - Like I said, users won't realise that orchard considers the actual command to be several words long
  - The new filtered help just acts like autocomplete

Reminder note: If help text is deemed to need changing we also need to update text in [OrchardHost.cs](https://github.com/OrchardCMS/Orchard/blob/6763bd8bb85a8f226955f4331dfa830be05e0666/src/Tools/Orchard/OrchardHost.cs)