### PR TITLE
Fixes #5885

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Drivers/AutoroutePartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Drivers/AutoroutePartDriver.cs
@@ -146,7 +146,7 @@ namespace Orchard.Autoroute.Drivers {
                 }
                 
                 if (part.DisplayAlias != null && part.DisplayAlias.Length > 1850){
-                    updater.AddModelError("CurrentUrl", T("Your Display Alias is too long. The Display Alias can only be up to 1,850 characters."));
+                    updater.AddModelError("CurrentUrl", T("Your permalink is too long. The permalink can only be up to 1,850 characters."));
                 }
 
                 // Mark the content item to be the homepage. Once this content isp ublished, the home alias will be updated to point to this content item.

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Drivers/AutoroutePartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Drivers/AutoroutePartDriver.cs
@@ -144,6 +144,10 @@ namespace Orchard.Autoroute.Drivers {
                 if (!_autorouteService.IsPathValid(part.DisplayAlias)) {
                     updater.AddModelError("CurrentUrl", T("Please do not use any of the following characters in your permalink: \":\", \"?\", \"#\", \"[\", \"]\", \"@\", \"!\", \"$\", \"&\", \"'\", \"(\", \")\", \"*\", \"+\", \",\", \";\", \"=\", \", \"<\", \">\", \"\\\", \"|\", \"%\", \".\". No spaces are allowed (please use dashes or underscores instead)."));
                 }
+                
+                if (part.DisplayAlias != null && part.DisplayAlias.Length > 1850){
+                    updater.AddModelError("CurrentUrl", T("Your Display Alias is too long. The Display Alias can only be up to 1,850 characters."));
+                }
 
                 // Mark the content item to be the homepage. Once this content isp ublished, the home alias will be updated to point to this content item.
                 part.PromoteToHomePage = viewModel.PromoteToHomePage;


### PR DESCRIPTION
This should fix issue #5885, the DisplayAlias not having length validated. I arbitrarily set it to 1850 for the simple fact that, while the database can hold a 2048 character DisplayAlias, a URL should not be longer than ~2000 characters (per http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers ). If the DisplayAlias is 2048, it's already over the limit and that's not the entire URL for the page, this gives some buffer room for domains.