### PR TITLE
Extends theme.txt to allow different zones for each layer fixes #5933

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Widgets/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Controllers/AdminController.cs
@@ -79,9 +79,11 @@ namespace Orchard.Widgets.Controllers {
             }
 
             IEnumerable<string> allZones = _widgetsService.GetZones();
-            IEnumerable<string> currentThemesZones = _widgetsService.GetZones(currentTheme);
+            IEnumerable<string> currentThemesZones = _widgetsService.GetZones(currentTheme,currentLayer.Name);
 
             string zonePreviewImagePath = string.Format("{0}/{1}/ThemeZonePreview.png", currentTheme.Location, currentTheme.Id);
+            if ( !string.IsNullOrEmpty(currentTheme.Layers) && !string.IsNullOrEmpty(currentTheme.LayerZones) && _widgetsService.HasDedicatedZones(currentTheme,currentLayer.Name) )
+                zonePreviewImagePath = string.Format("{0}/{1}/{2}/ThemeZonePreview.png", currentTheme.Location, currentTheme.Id,currentLayer.Name);
             string zonePreviewImage = _virtualPathProvider.FileExists(zonePreviewImagePath) ? zonePreviewImagePath : null;
 
             var widgets = _widgetsService.GetWidgets();

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/IWidgetsService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/IWidgetsService.cs
@@ -5,10 +5,11 @@ using Orchard.Widgets.Models;
 
 namespace Orchard.Widgets.Services {
     public interface IWidgetsService : IDependency {
-        
         IEnumerable<string> GetZones();
+        [Obsolete("Use GetZones(ExtensionDescriptor theme,string layer)")]
         IEnumerable<string> GetZones(ExtensionDescriptor theme);
-
+        IEnumerable<string> GetZones(ExtensionDescriptor theme,string layer=null);
+        bool HasDedicatedZones(ExtensionDescriptor theme, string layer);
         IEnumerable<LayerPart> GetLayers();
 
         IEnumerable<Tuple<string, string>> GetWidgetTypes();

--- a/src/Orchard/Environment/Extensions/Folders/ExtensionHarvester.cs
+++ b/src/Orchard/Environment/Extensions/Folders/ExtensionHarvester.cs
@@ -23,6 +23,8 @@ namespace Orchard.Environment.Extensions.Folders {
         private const string TagsSection = "tags";
         private const string AntiForgerySection = "antiforgery";
         private const string ZonesSection = "zones";
+        private const string LayersSection = "layers";
+        private const string LayerZonesSection = "layerzones";
         private const string BaseThemeSection = "basetheme";
         private const string DependenciesSection = "dependencies";
         private const string CategorySection = "category";
@@ -128,6 +130,8 @@ namespace Orchard.Environment.Extensions.Folders {
                 Tags = GetValue(manifest, TagsSection),
                 AntiForgery = GetValue(manifest, AntiForgerySection),
                 Zones = GetValue(manifest, ZonesSection),
+                Layers = GetValue(manifest, LayersSection),
+                LayerZones = GetValue(manifest, LayerZonesSection),
                 BaseTheme = GetValue(manifest, BaseThemeSection),
                 SessionState = GetValue(manifest, SessionStateSection),
                 LifecycleStatus = GetValue(manifest, LifecycleStatusSection, LifecycleStatus.Production)
@@ -201,6 +205,12 @@ namespace Orchard.Environment.Extensions.Folders {
                             break;
                         case ZonesSection:
                             manifest.Add(ZonesSection, field[1]);
+                            break;
+                        case LayersSection:
+                            manifest.Add(LayersSection, field[1]);
+                            break;
+                        case LayerZonesSection:
+                            manifest.Add(LayerZonesSection, field[1]);
                             break;
                         case BaseThemeSection:
                             manifest.Add(BaseThemeSection, field[1]);

--- a/src/Orchard/Environment/Extensions/Models/ExtensionDescriptor.cs
+++ b/src/Orchard/Environment/Extensions/Models/ExtensionDescriptor.cs
@@ -32,6 +32,8 @@ namespace Orchard.Environment.Extensions.Models {
         public string Tags { get; set; }
         public string AntiForgery { get; set; }
         public string Zones { get; set; }
+        public string Layers { get; set; }
+        public string LayerZones { get; set; }
         public string BaseTheme { get; set; }
         public string SessionState { get; set; }
         public LifecycleStatus LifecycleStatus { get; set; }


### PR DESCRIPTION
Just add 2 more lines in your theme.txt to create layers and their corresponding zone.
>Layers: TheNextHomepage, Calendar
>LayerZones: {"TheNextHomepage":"Messages, Headerhome, Edito, Agenda, Actus, Catalogue","Calendar":"Header, Navigation, AsideFirst, Messages, BeforeContent, Content, Footer"}

Then in Widgets menu, add the 2 layers TheNextHomepage and Calendar.
This also relies on alternates to create the corresponding layout-url-xxx.cshtml with code for your new zones as
> @if (Model.Edito != null) {
>           @Zone(Model.Edito)
>               }
