### PR TITLE
Fixes dependency on Orchard.ImportExport bug by removing the Orchard.Setup.Services feature

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Module.txt
@@ -11,4 +11,4 @@ Features:
         Name: Import Export
         Description: Imports and exports content item data.
         Category: Content
-        Dependencies: Orchard.jQuery, Orchard.Recipes, Orchard.Setup.Services
+        Dependencies: Orchard.jQuery, Orchard.Recipes

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Orchard.ImportExport.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Orchard.ImportExport.csproj
@@ -89,6 +89,8 @@
     <Compile Include="Models\ImportActionConfigurationContext.cs" />
     <Compile Include="Services\DatabaseManager.cs" />
     <Compile Include="Services\IDatabaseManager.cs" />
+    <Compile Include="Services\ISetupServiceFactory.cs" />
+    <Compile Include="Services\SetupServiceFactory.cs" />
     <Compile Include="ViewModels\RecipeExecutionStepViewModel.cs" />
     <Compile Include="ViewModels\UploadRecipeViewModel.cs" />
     <Compile Include="Providers\ImportActions\ExecuteRecipeAction.cs" />

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Providers/ImportActions/ExecuteRecipeAction.cs
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Providers/ImportActions/ExecuteRecipeAction.cs
@@ -19,7 +19,7 @@ using Orchard.UI.Notify;
 namespace Orchard.ImportExport.Providers.ImportActions {
     public class ExecuteRecipeAction : ImportAction {
         private readonly IOrchardServices _orchardServices;
-        private readonly ISetupService _setupService;
+        private readonly ISetupServiceFactory _setupServiceFactory;
         private readonly ShellSettings _shellSettings;
         private readonly IEnumerable<IRecipeExecutionStep> _recipeExecutionSteps;
         private readonly IRecipeParser _recipeParser;
@@ -31,7 +31,7 @@ namespace Orchard.ImportExport.Providers.ImportActions {
 
         public ExecuteRecipeAction(
             IOrchardServices orchardServices,
-            ISetupService setupService,
+            ISetupServiceFactory setupServiceFactory,
             ShellSettings shellSettings,
             IEnumerable<IRecipeExecutionStep> recipeExecutionSteps, 
             IRecipeParser recipeParser, 
@@ -42,7 +42,7 @@ namespace Orchard.ImportExport.Providers.ImportActions {
             IRepository<RecipeStepResultRecord> recipeStepResultRepository) {
 
             _orchardServices = orchardServices;
-            _setupService = setupService;
+            _setupServiceFactory = setupServiceFactory;
             _shellSettings = shellSettings;
             _recipeExecutionSteps = recipeExecutionSteps;
             _recipeParser = recipeParser;
@@ -199,7 +199,8 @@ namespace Orchard.ImportExport.Providers.ImportActions {
             DropTenantDatabaseTables();
 
             // Execute Setup.
-            var executionId = _setupService.Setup(setupContext);
+            var setupService = _setupServiceFactory.CreateSetupService();
+            var executionId = setupService.Setup(setupContext);
 
             return executionId;
         }

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Services/ISetupServiceFactory.cs
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Services/ISetupServiceFactory.cs
@@ -1,0 +1,10 @@
+﻿using Orchard.Setup.Services;
+
+namespace Orchard.ImportExport.Services {
+    /// <summary>
+    /// We need to manually instantiate the SetupService class because the Orchard.Setup feature will be disabled after setup completes.
+    /// </summary>
+    public interface ISetupServiceFactory : IDependency {
+        ISetupService CreateSetupService();
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Services/SetupServiceFactory.cs
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Services/SetupServiceFactory.cs
@@ -1,0 +1,50 @@
+using Orchard.Environment;
+using Orchard.Environment.Configuration;
+using Orchard.Environment.ShellBuilders;
+using Orchard.Environment.State;
+using Orchard.Recipes.Services;
+using Orchard.Setup.Services;
+
+namespace Orchard.ImportExport.Services {
+    /// <summary>
+    /// We need to manually instantiate the SetupService class because the Orchard.Setup feature will be disabled after setup completes.
+    /// </summary>
+    public class SetupServiceFactory : ISetupServiceFactory {
+        private readonly ShellSettings _shellSettings;
+        private readonly IOrchardHost _orchardHost;
+        private readonly IShellSettingsManager _shellSettingsManager;
+        private readonly IShellContainerFactory _shellContainerFactory;
+        private readonly ICompositionStrategy _compositionStrategy;
+        private readonly IProcessingEngine _processingEngine;
+        private readonly IRecipeHarvester _recipeHarvester;
+
+        public SetupServiceFactory(
+            ShellSettings shellSettings,
+            IOrchardHost orchardHost,
+            IShellSettingsManager shellSettingsManager,
+            IShellContainerFactory shellContainerFactory,
+            ICompositionStrategy compositionStrategy,
+            IProcessingEngine processingEngine,
+            IRecipeHarvester recipeHarvester) {
+
+            _shellSettings = shellSettings;
+            _orchardHost = orchardHost;
+            _shellSettingsManager = shellSettingsManager;
+            _shellContainerFactory = shellContainerFactory;
+            _compositionStrategy = compositionStrategy;
+            _processingEngine = processingEngine;
+            _recipeHarvester = recipeHarvester;
+        }
+
+        public ISetupService CreateSetupService() {
+            return new SetupService(
+                _shellSettings,
+                _orchardHost,
+                _shellSettingsManager,
+                _shellContainerFactory,
+                _compositionStrategy,
+                _processingEngine,
+                _recipeHarvester);
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Setup/Commands/SetupCommand.cs
+++ b/src/Orchard.Web/Modules/Orchard.Setup/Commands/SetupCommand.cs
@@ -8,11 +8,9 @@ using Orchard.Setup.Services;
 namespace Orchard.Setup.Commands {
     public class SetupCommand : DefaultOrchardCommandHandler {
         private readonly ISetupService _setupService;
-        private readonly IRecipeHarvester _recipeHarvester;
 
-        public SetupCommand(ISetupService setupService, IRecipeHarvester recipeHarvester) {
+        public SetupCommand(ISetupService setupService) {
             _setupService = setupService;
-            _recipeHarvester = recipeHarvester;
         }
 
         [OrchardSwitch]

--- a/src/Orchard.Web/Modules/Orchard.Setup/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.Setup/Module.txt
@@ -6,9 +6,3 @@ OrchardVersion: 1.9
 Description: The setup module is creating the application's setup experience.
 FeatureDescription: Standard site setup. This feature is disabled automatically once setup is over.
 Category: Core
-Dependencies: Orchard.Setup.Services
-Features:
-    Orchard.Setup.Services
-        Name: Setup Services
-        Description: Provides programmatic APIs to the setup service.
-        Category: Core

--- a/src/Orchard.Web/Modules/Orchard.Setup/Services/SetupService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Setup/Services/SetupService.cs
@@ -14,7 +14,6 @@ using Orchard.Environment;
 using Orchard.Environment.Configuration;
 using Orchard.Environment.Descriptor;
 using Orchard.Environment.Descriptor.Models;
-using Orchard.Environment.Extensions;
 using Orchard.Environment.ShellBuilders;
 using Orchard.Environment.State;
 using Orchard.Localization.Services;
@@ -26,7 +25,6 @@ using Orchard.Settings;
 using Orchard.Utility.Extensions;
 
 namespace Orchard.Setup.Services {
-    [OrchardFeature("Orchard.Setup.Services")]
     public class SetupService : Component, ISetupService {
         private readonly ShellSettings _shellSettings;
         private readonly IOrchardHost _orchardHost;


### PR DESCRIPTION
This solves the issue as described in #5980 where the Setup screen would throw a YSOD if any module would have a dependency on Orchard.ImportExport.