### PR TITLE
With the Element editor dialog, use dialog iframe's jQuery for form submission

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Scripts/dialog.js
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Scripts/dialog.js
@@ -169,8 +169,8 @@
                         break;
                     case "save":
                         {
-                            var frameDoc = self.frame.getDocument();
-                            var form = frameDoc.find("form:first");
+                            var frameWindow = self.frame.getWindow();
+                            var form = frameWindow.$("form:first");
                             form.submit();
                         }
                         break;


### PR DESCRIPTION
When an Element is being edited, it is done in an iframe embedded in a dialog box that appears over the Layout editor. The "Save" button is handled outside the iframe, and when it is clicked, jQuery code looks for the form inside the iframe and submits it.

The problem is that since the outer window's jQuery is used to submit the form that belongs to the iframe, it does not trigger any of the event handlers that may have been placed on the form by code inside the iframe.

For example, often I need to perform serialization of data (such as serializing a knockoutjs view model to a hidden field) or validation inside an editor. The code in the form would set an event handler on the submit event of the form. Validation could prevent the submission of the form if there are problems.

My fix uses the iframe's jQuery to find the form and submit it, which has access to the event handlers.

