### PR TITLE
allow comments count to be customized in Detail and Summary as other s…

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Comments/Drivers/CommentsPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Drivers/CommentsPartDriver.cs
@@ -77,14 +77,6 @@ namespace Orchard.Comments.Drivers {
                         return shapeHelper.Parts_Comments_Count(
                             CommentCount: part.CommentsCount);
                     }),
-                ContentShape("Parts_Comments_Count_Detail",
-                    () => {
-                        if (part.CommentsShown == false)
-                            return null;
-
-                        return shapeHelper.Parts_Comments_Count_Detail(
-                            CommentCount: part.CommentsCount);
-                    }),
                 ContentShape("Parts_Comments_Count_Summary",
                     () => {
                         if (part.CommentsShown == false)

--- a/src/Orchard.Web/Modules/Orchard.Comments/Drivers/CommentsPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Drivers/CommentsPartDriver.cs
@@ -77,6 +77,22 @@ namespace Orchard.Comments.Drivers {
                         return shapeHelper.Parts_Comments_Count(
                             CommentCount: part.CommentsCount);
                     }),
+                ContentShape("Parts_Comments_Count_Detail",
+                    () => {
+                        if (part.CommentsShown == false)
+                            return null;
+
+                        return shapeHelper.Parts_Comments_Count_Detail(
+                            CommentCount: part.CommentsCount);
+                    }),
+                ContentShape("Parts_Comments_Count_Summary",
+                    () => {
+                        if (part.CommentsShown == false)
+                            return null;
+
+                        return shapeHelper.Parts_Comments_Count_Summary(
+                            CommentCount: part.CommentsCount);
+                    }),
                 ContentShape("Parts_Comments_Count_SummaryAdmin",
                     () => {
 

--- a/src/Orchard.Web/Modules/Orchard.Comments/Orchard.Comments.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Orchard.Comments.csproj
@@ -183,6 +183,9 @@
   <ItemGroup>
     <Content Include="Views\Template.Comment.Notification.cshtml" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Parts.Comments.Count.Summary.cshtml" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comments.Count.Detail.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comments.Count.Detail.cshtml
@@ -1,0 +1,1 @@
+﻿<span class="comment-count">@T.Plural("No Comments", "1 Comment", "{0} Comments", (int)Model.CommentCount)</span>

--- a/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comments.Count.Detail.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comments.Count.Detail.cshtml
@@ -1,1 +1,0 @@
-﻿<span class="comment-count">@T.Plural("No Comments", "1 Comment", "{0} Comments", (int)Model.CommentCount)</span>

--- a/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comments.Count.Summary.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comments.Count.Summary.cshtml
@@ -1,0 +1,1 @@
+﻿<span class="comment-count">@T.Plural("No Comments", "1 Comment", "{0} Comments", (int)Model.CommentCount)</span>


### PR DESCRIPTION
I needed to customize Comments Count in a Summary BlogPost and in a Detail BlogPost. The only way I found was to add in Comment Drivers the two shapes.

Then I get allowed to add the html to customize in summary blogpost projection and in the blog post itself.
