### PR TITLE
Fixed reply button and comment link and added useful CSS class.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comment.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comment.cshtml
@@ -8,8 +8,13 @@
     var children = New.List(Items: Model.Items);
     children.Classes.Add("comments");
 
+    if (Model.Items.Count > 0) {
+        Model.Classes.Add("has-replies");
+    }
+    
     Model.Classes.Add("comment");
-    Model.Classes.Add("comment-"+comment.Id);
+
+    Model.Id = "comment" + comment.Id;
     var tag = Tag(Model, "article");
 }
 @tag.StartElement
@@ -17,8 +22,8 @@
         <h4>
             <span class="who">@Display.CommentAuthor(ContentPart: comment)</span>
             <span class="when">@Display.CommentMetadata(ContentPart: comment)</span>
-            @if (comments.ThreadedComments) {
-                <span class="reply">@Display.CommentReplyButton(ContentPart: comment)</span>
+            @if (comments.ThreadedComments && comments.CommentsActive) {
+                @Display.CommentReplyButton(ContentPart: comment)
             }
         </h4>
     </header>

--- a/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comment.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Views/Parts.Comment.cshtml
@@ -1,10 +1,12 @@
-﻿@using Orchard.Comments.Models
-@using Orchard.ContentManagement
+﻿@using Orchard.ContentManagement
+@using Orchard.Comments
+@using Orchard.Comments.Models
 
 @{
     CommentPart comment = Model.ContentPart;
     CommentsPart comments = comment.CommentedOnContentItem.As<CommentsPart>();
-
+    var isAuthorized = AuthorizedFor(Permissions.AddComment, Model.ContentItem);
+    
     var children = New.List(Items: Model.Items);
     children.Classes.Add("comments");
 
@@ -22,7 +24,7 @@
         <h4>
             <span class="who">@Display.CommentAuthor(ContentPart: comment)</span>
             <span class="when">@Display.CommentMetadata(ContentPart: comment)</span>
-            @if (comments.ThreadedComments && comments.CommentsActive) {
+            @if (comments.ThreadedComments && comments.CommentsActive && isAuthorized) {
                 @Display.CommentReplyButton(ContentPart: comment)
             }
         </h4>


### PR DESCRIPTION
1. Fixed comment links so that when the user clicks on comment metadata on the front end the desired scrolling effect is achieved.
2. Added a `.has-replies` class to comments that have replies for easier styling.
3. Stopped the comment reply button from showing when comments are disabled. Also needs fixing to not display the reply button if a user doesn't have permission to post comments.
4. Removed span around reply button as it adds no ease to styling.