### PR TITLE
fix Href, new Tref

### DIFF
--- a/src/Orchard/Mvc/ViewEngines/Razor/WebViewPage.cs
+++ b/src/Orchard/Mvc/ViewEngines/Razor/WebViewPage.cs
@@ -193,7 +193,8 @@ namespace Orchard.Mvc.ViewEngines.Razor {
             return writer;
         }
 
-        private string _tenantPrefix;
+        private string _tenantPrefix = null;
+
         public override string Href(string path, params object[] pathParts) {
             if (_tenantPrefix == null) {
                 _tenantPrefix = WorkContext.Resolve<ShellSettings>().RequestUrlPrefix ?? "";
@@ -212,6 +213,11 @@ namespace Orchard.Mvc.ViewEngines.Razor {
             }
 
             return base.Href(path, pathParts);
+        }
+
+        // resolve url relative to the current theme 
+        public string Tref(string pathInTheme, params object[] pathParts) {
+            return base.Href(WorkContext.CurrentTheme.VirtualPath + pathInTheme, pathParts);
         }
 
         public IDisposable Capture(Action<IHtmlString> callback) {


### PR DESCRIPTION
This PR does two things:

1. Fix the initialization of _tenantPrefix 

2 Add a Tref function 
Tref is similar to Href,  the argument path is relative to the root of the Theme.
 
```csharp
  Href("~/Themes/PJS.Bootstrap/Content/Swatches")
```
can be written like this :
```csharp
  Tref("/Content/Swatches")
```
and will not have to be updated if the theme name/location is changed
