### PR TITLE
Update CacheItemRecord.cs

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Models/CacheItemRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Models/CacheItemRecord.cs
@@ -12,7 +12,7 @@ namespace Orchard.OutputCache.Models {
         public virtual int GraceTime { get; set; }
         public virtual DateTime ValidUntilUtc { get; set; }
         public virtual DateTime StoredUntilUtc { get; set; }
-        public virtual byte[] Output { get; set; }
+        [StringLengthMax] public virtual byte[] Output { get; set; }
         public virtual string ContentType { get; set; }
         [StringLength(2048)] public virtual string QueryString { get; set; }
         [StringLength(2048)] public virtual string CacheKey { get; set; }


### PR DESCRIPTION
Fixed database output cache module when using SQL Server database.  This resolves the following exception which results from NHibernate trying to truncate the Output field to 8K:

NHibernate.AssertionFailure: null id in Orchard.OutputCache.Models.CacheItemRecord entry (don't flush the Session after an exception occurs)