### PR TITLE
Filter out when no contentTypeNames provided

### DIFF
--- a/src/Orchard.Web/Core/Contents/AdminMenu.cs
+++ b/src/Orchard.Web/Core/Contents/AdminMenu.cs
@@ -22,6 +22,7 @@ namespace Orchard.Core.Contents {
             var contentTypeDefinitions = _contentDefinitionManager.ListTypeDefinitions().OrderBy(d => d.Name);
             builder.AddImageSet("content")
                 .Add(T("Content"), "1.4", menu => menu
+                    .Permission(Permissions.EditOwnContent)
                     .Add(T("Content Items"), "1", item => item.Action("List", "Admin", new { area = "Contents", id = "" }).LocalNav()));
             var contentTypes = contentTypeDefinitions.Where(ctd => ctd.Settings.GetModel<ContentTypeSettings>().Creatable).OrderBy(ctd => ctd.DisplayName);
             if (contentTypes.Any()) {

--- a/src/Orchard/ContentManagement/DefaultContentQuery.cs
+++ b/src/Orchard/ContentManagement/DefaultContentQuery.cs
@@ -92,7 +92,7 @@ namespace Orchard.ContentManagement {
         }
 
         private void ForType(params string[] contentTypeNames) {
-            if (contentTypeNames != null && contentTypeNames.Length != 0) {
+            if (contentTypeNames != null) {
                 var contentTypeIds = contentTypeNames.Select(GetContentTypeRecordId).ToArray();
                 // don't use the IN operator if not needed for performance reasons
                 if (contentTypeNames.Length == 1) {


### PR DESCRIPTION
Suggested solution to [Issue 6043](https://github.com/OrchardCMS/Orchard/issues/6043)

Previously, when no content type names where provided (from a prior conditional statement, so there is an initialized array but it is empty) then the filtering steps are skipped and instead of serving "no content
types", as an empty array would state: all content types are served.
When contentTypeNamed.Length == 0, still .Select() as this is safe for empty collections and will filter out all types in this event.

Any feedback or sidcussion welcome.