### PR TITLE
Fixes #6023 : Ellipsize can spilt an HTML encoded character

### DIFF
--- a/src/Orchard.Tests/Mvc/Html/HtmlHelperExtensionsTests.cs
+++ b/src/Orchard.Tests/Mvc/Html/HtmlHelperExtensionsTests.cs
@@ -217,7 +217,7 @@ namespace Orchard.Tests.Mvc.Html {
             var html = new HtmlHelper(viewContext, viewDataContainer.Object);
 
             //act
-            var result = html.Excerpt("<p>foo &amp; bar</p>", 5);
+            var result = html.Excerpt("<p>foo &amp; bar</p>", 7);
 
             //assert
             Assert.AreEqual("foo &amp;&#160;\u2026", result.ToString());

--- a/src/Orchard.Tests/Mvc/Html/HtmlHelperExtensionsTests.cs
+++ b/src/Orchard.Tests/Mvc/Html/HtmlHelperExtensionsTests.cs
@@ -193,5 +193,35 @@ namespace Orchard.Tests.Mvc.Html {
             Assert.AreEqual(@"<label for=""prefix_SomeString"">bar</label>", result.ToString());
         }
         private class FooController : Controller { }
+
+        [Test]
+        public void Ellipsize_DontCutHtmlEncodedChars() {
+            //arrange
+            var viewContext = new ViewContext();
+            var viewDataContainer = new Mock<IViewDataContainer>();
+            var html = new HtmlHelper(viewContext, viewDataContainer.Object);
+
+            //act
+            var result = html.Ellipsize("foo & bar", 5);
+
+            //assert
+            Assert.AreEqual("foo &amp;&#160;\u2026", result.ToString());
+
+        }
+
+        [Test]
+        public void Excerpt_DontCutHtmlEncodedChars() {
+            //arrange
+            var viewContext = new ViewContext();
+            var viewDataContainer = new Mock<IViewDataContainer>();
+            var html = new HtmlHelper(viewContext, viewDataContainer.Object);
+
+            //act
+            var result = html.Excerpt("<p>foo &amp; bar</p>", 5);
+
+            //assert
+            Assert.AreEqual("foo &amp;&#160;\u2026", result.ToString());
+
+        }
     }
 }

--- a/src/Orchard.Tests/Utility/Extensions/StringExtensionsTests.cs
+++ b/src/Orchard.Tests/Utility/Extensions/StringExtensionsTests.cs
@@ -52,7 +52,7 @@ namespace Orchard.Tests.Utility.Extensions {
         [Test]
         public void Ellipsize_LongStringTruncatedToNearestWord() {
             const string toEllipsize = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sed purus quis purus orci aliquam.";
-            Assert.That(toEllipsize.Ellipsize(46), Is.StringMatching("Lorem ipsum dolor sit amet, consectetur …"));
+            Assert.That(toEllipsize.Ellipsize(46), Is.StringMatching("Lorem ipsum dolor sit amet, consectetur\u00A0\u2026"));
         }
 
         [Test]

--- a/src/Orchard.Tests/Utility/Extensions/StringExtensionsTests.cs
+++ b/src/Orchard.Tests/Utility/Extensions/StringExtensionsTests.cs
@@ -52,7 +52,7 @@ namespace Orchard.Tests.Utility.Extensions {
         [Test]
         public void Ellipsize_LongStringTruncatedToNearestWord() {
             const string toEllipsize = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sed purus quis purus orci aliquam.";
-            Assert.That(toEllipsize.Ellipsize(46), Is.StringMatching("Lorem ipsum dolor sit amet, consectetur&#160;&#8230;"));
+            Assert.That(toEllipsize.Ellipsize(46), Is.StringMatching("Lorem ipsum dolor sit amet, consectetur …"));
         }
 
         [Test]

--- a/src/Orchard/Mvc/Html/HtmlHelperExtensions.cs
+++ b/src/Orchard/Mvc/Html/HtmlHelperExtensions.cs
@@ -175,11 +175,11 @@ namespace Orchard.Mvc.Html {
         #region Ellipsize
 
         public static IHtmlString Ellipsize(this HtmlHelper htmlHelper, string text, int characterCount) {
-            return new HtmlString(htmlHelper.Encode(text).Ellipsize(characterCount));
+            return new HtmlString(htmlHelper.Encode(text.Ellipsize(characterCount)));
         }
 
         public static IHtmlString Ellipsize(this HtmlHelper htmlHelper, string text, int characterCount, string ellipsis) {
-            return new HtmlString(htmlHelper.Encode(text).Ellipsize(characterCount, ellipsis));
+            return new HtmlString(htmlHelper.Encode(text.Ellipsize(characterCount, ellipsis)));
         }
 
         #endregion
@@ -187,8 +187,7 @@ namespace Orchard.Mvc.Html {
         #region Excerpt
 
         public static MvcHtmlString Excerpt(this HtmlHelper html, string markup, int length) {
-
-            return MvcHtmlString.Create(markup.RemoveTags().Ellipsize(length));
+            return MvcHtmlString.Create(html.Encode(HttpUtility.HtmlDecode(markup.RemoveTags()).Ellipsize(length)));
         }
 
         #endregion

--- a/src/Orchard/Utility/Extensions/StringExtensions.cs
+++ b/src/Orchard/Utility/Extensions/StringExtensions.cs
@@ -26,7 +26,7 @@ namespace Orchard.Utility.Extensions {
         }
 
         public static string Ellipsize(this string text, int characterCount) {
-            return text.Ellipsize(characterCount, " …");
+            return text.Ellipsize(characterCount, "\u00A0\u2026");
         }
 
         public static string Ellipsize(this string text, int characterCount, string ellipsis, bool wordBoundary = false) {

--- a/src/Orchard/Utility/Extensions/StringExtensions.cs
+++ b/src/Orchard/Utility/Extensions/StringExtensions.cs
@@ -26,7 +26,7 @@ namespace Orchard.Utility.Extensions {
         }
 
         public static string Ellipsize(this string text, int characterCount) {
-            return text.Ellipsize(characterCount, "&#160;&#8230;");
+            return text.Ellipsize(characterCount, " …");
         }
 
         public static string Ellipsize(this string text, int characterCount, string ellipsis, bool wordBoundary = false) {


### PR DESCRIPTION
I fixed `Excerpt` and `Ellipsize` `HtmlHelperExtensions`'s methods.
I also updated  `Ellipsize` `StringExtensions`'s method as we can't assume it deals with HTML encoded strings, and the related test.