### PR TITLE
Invalidate new media profile cache

### DIFF
--- a/src/Orchard.Tests/Mvc/Html/HtmlHelperExtensionsTests.cs
+++ b/src/Orchard.Tests/Mvc/Html/HtmlHelperExtensionsTests.cs
@@ -217,7 +217,7 @@ namespace Orchard.Tests.Mvc.Html {
             var html = new HtmlHelper(viewContext, viewDataContainer.Object);
 
             //act
-            var result = html.Excerpt("<p>foo &amp; bar</p>", 5);
+            var result = html.Excerpt("<p>foo &amp; bar</p>", 7);
 
             //assert
             Assert.AreEqual("foo &amp;&#160;\u2026", result.ToString());

--- a/src/Orchard.Tests/Mvc/Html/HtmlHelperExtensionsTests.cs
+++ b/src/Orchard.Tests/Mvc/Html/HtmlHelperExtensionsTests.cs
@@ -193,5 +193,35 @@ namespace Orchard.Tests.Mvc.Html {
             Assert.AreEqual(@"<label for=""prefix_SomeString"">bar</label>", result.ToString());
         }
         private class FooController : Controller { }
+
+        [Test]
+        public void Ellipsize_DontCutHtmlEncodedChars() {
+            //arrange
+            var viewContext = new ViewContext();
+            var viewDataContainer = new Mock<IViewDataContainer>();
+            var html = new HtmlHelper(viewContext, viewDataContainer.Object);
+
+            //act
+            var result = html.Ellipsize("foo & bar", 5);
+
+            //assert
+            Assert.AreEqual("foo &amp;&#160;\u2026", result.ToString());
+
+        }
+
+        [Test]
+        public void Excerpt_DontCutHtmlEncodedChars() {
+            //arrange
+            var viewContext = new ViewContext();
+            var viewDataContainer = new Mock<IViewDataContainer>();
+            var html = new HtmlHelper(viewContext, viewDataContainer.Object);
+
+            //act
+            var result = html.Excerpt("<p>foo &amp; bar</p>", 5);
+
+            //assert
+            Assert.AreEqual("foo &amp;&#160;\u2026", result.ToString());
+
+        }
     }
 }

--- a/src/Orchard.Tests/Utility/Extensions/StringExtensionsTests.cs
+++ b/src/Orchard.Tests/Utility/Extensions/StringExtensionsTests.cs
@@ -52,7 +52,7 @@ namespace Orchard.Tests.Utility.Extensions {
         [Test]
         public void Ellipsize_LongStringTruncatedToNearestWord() {
             const string toEllipsize = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sed purus quis purus orci aliquam.";
-            Assert.That(toEllipsize.Ellipsize(46), Is.StringMatching("Lorem ipsum dolor sit amet, consectetur …"));
+            Assert.That(toEllipsize.Ellipsize(46), Is.StringMatching("Lorem ipsum dolor sit amet, consectetur\u00A0\u2026"));
         }
 
         [Test]

--- a/src/Orchard.Tests/Utility/Extensions/StringExtensionsTests.cs
+++ b/src/Orchard.Tests/Utility/Extensions/StringExtensionsTests.cs
@@ -52,7 +52,7 @@ namespace Orchard.Tests.Utility.Extensions {
         [Test]
         public void Ellipsize_LongStringTruncatedToNearestWord() {
             const string toEllipsize = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sed purus quis purus orci aliquam.";
-            Assert.That(toEllipsize.Ellipsize(46), Is.StringMatching("Lorem ipsum dolor sit amet, consectetur&#160;&#8230;"));
+            Assert.That(toEllipsize.Ellipsize(46), Is.StringMatching("Lorem ipsum dolor sit amet, consectetur …"));
         }
 
         [Test]

--- a/src/Orchard.Web/Core/Contents/AdminMenu.cs
+++ b/src/Orchard.Web/Core/Contents/AdminMenu.cs
@@ -22,6 +22,7 @@ namespace Orchard.Core.Contents {
             var contentTypeDefinitions = _contentDefinitionManager.ListTypeDefinitions().OrderBy(d => d.Name);
             builder.AddImageSet("content")
                 .Add(T("Content"), "1.4", menu => menu
+                    .Permission(Permissions.EditOwnContent)
                     .Add(T("Content Items"), "1", item => item.Action("List", "Admin", new { area = "Contents", id = "" }).LocalNav()));
             var contentTypes = contentTypeDefinitions.Where(ctd => ctd.Settings.GetModel<ContentTypeSettings>().Creatable).OrderBy(ctd => ctd.DisplayName);
             if (contentTypes.Any()) {

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Handlers/ImageProfilePartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Handlers/ImageProfilePartHandler.cs
@@ -1,11 +1,23 @@
-﻿using Orchard.ContentManagement.Handlers;
+﻿using Orchard.Caching;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
 using Orchard.Data;
 using Orchard.MediaProcessing.Models;
 
 namespace Orchard.MediaProcessing.Handlers {
     public class ImageProfilePartHandler : ContentHandler {
-        public ImageProfilePartHandler(IRepository<ImageProfilePartRecord> repository) {
+        private readonly ISignals _signals;
+
+        public ImageProfilePartHandler(IRepository<ImageProfilePartRecord> repository, ISignals signals)
+        {
+            _signals = signals;
             Filters.Add(StorageFilter.For(repository));
+        }
+
+        protected override void Published(PublishContentContext context)
+        {
+            _signals.Trigger("MediaProcessing_Published_" + context.ContentItem.As<ImageProfilePart>().Name);
+            base.Published(context);
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileService.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileService.cs
@@ -33,6 +33,7 @@ namespace Orchard.MediaProcessing.Services {
         public ImageProfilePart GetImageProfileByName(string name) {
 
             var profileId = _cacheManager.Get("ProfileId_" + name, true, ctx => {
+                ctx.Monitor(_signals.When("MediaProcessing_Published_" + name));
                 var profile = _contentManager.Query<ImageProfilePart, ImageProfilePartRecord>()
                     .Where(x => x.Name == name)
                     .Slice(0, 1)

--- a/src/Orchard.Web/Modules/Orchard.Tokens/Providers/TextTokens.cs
+++ b/src/Orchard.Web/Modules/Orchard.Tokens/Providers/TextTokens.cs
@@ -35,7 +35,7 @@ namespace Orchard.Tokens.Providers {
                 // {Text.Format:<formatstring>}
                 .Token(
                     token => FilterTokenParam("Format:", token),
-                    (token, d) => String.Format(d, token))
+                    (token, d) => String.Format(token, d))
                 // {Text.TrimEnd:<chars|number>}
                 .Token(token => FilterTokenParam("TrimEnd:", token), TrimEnd)
                 .Token("UrlEncode", HttpUtility.UrlEncode)
@@ -54,7 +54,7 @@ namespace Orchard.Tokens.Providers {
             return token.StartsWith(tokenName, StringComparison.OrdinalIgnoreCase) ? token.Substring(tokenName.Length) : null;
         }
 
-        private static string TrimEnd(string token, string param) {
+        private static string TrimEnd(string param, string token) {
             if (String.IsNullOrEmpty(param)) {
                 return token;
             }

--- a/src/Orchard.Web/Modules/Orchard.Tokens/Tests/Orchard.Tokens.Tests.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Tokens/Tests/Orchard.Tokens.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="StubClock.cs" />
     <Compile Include="StubOrchardServices.cs" />
     <Compile Include="StubWorkContextAccessor.cs" />
+    <Compile Include="TextTokenTests.cs" />
     <Compile Include="UserTokenTests.cs" />
     <Compile Include="TokenManagerTests.cs" />
     <Compile Include="TestTokenProvider.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Tokens/Tests/TextTokenTests.cs
+++ b/src/Orchard.Web/Modules/Orchard.Tokens/Tests/TextTokenTests.cs
@@ -1,0 +1,121 @@
+﻿using System.Web;
+using Autofac;
+using NUnit.Framework;
+using Orchard.Tokens.Implementation;
+using Orchard.Tokens.Providers;
+
+namespace Orchard.Tokens.Tests {
+    [TestFixture]
+    public class TextTokenTests {
+        private IContainer _container;
+        private ITokenizer _tokenizer;
+
+        [SetUp]
+        public void Init() {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<Tokenizer>().As<ITokenizer>();
+            builder.RegisterType<TokenManager>().As<ITokenManager>();
+            builder.RegisterType<TextTokens>().As<ITokenProvider>();
+            builder.RegisterType<TestTokenProvider>().As<ITokenProvider>();
+            _container = builder.Build();
+            _tokenizer = _container.Resolve<ITokenizer>();
+        }
+
+        [Test]
+        public void TestLimitWhenStringShorterThanLimit() {
+            var str = "foo bar baz";
+            var result = _tokenizer.Replace("{Text.Limit:" + (str.Length + 1) + "}", new { Text = str });
+            Assert.That(result, Is.EqualTo("foo bar baz"));
+        }
+
+        [Test]
+        public void TestLimitWhenStringLengthEqualsLimit() {
+            var str = "foo bar baz";
+            var result = _tokenizer.Replace("{Text.Limit:" + str.Length + "}", new { Text = str });
+            Assert.That(result, Is.EqualTo("foo bar baz"));
+        }
+
+        [Test]
+        public void TestLimitWhenStringLongerThanLimit() {
+            var str = "foo bar baz";
+            var result = _tokenizer.Replace("{Text.Limit:" + (str.Length - 1) + "}", new { Text = str });
+            Assert.That(result, Is.EqualTo("foo bar ba"));
+        }
+
+        [Test]
+        public void TestLimitWhenStringEmpty() {
+            var str = "";
+            var result = _tokenizer.Replace("{Text.Limit:" + (str.Length - 1) + "}", new { Text = str });
+            Assert.That(result, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void TestLimitWhenEllipsisSpecifed() {
+            var str = "foo bar baz";
+            var result = _tokenizer.Replace("{Text.Limit:" + (str.Length - 1) + ",...}", new { Text = str });
+            Assert.That(result, Is.EqualTo("foo bar ba..."));
+        }
+
+        [Test]
+        public void TestFormat() {
+            var str = "bar";
+            var result = _tokenizer.Replace("{Text.Format:foo {0} baz}", new { Text = str });
+            Assert.That(result, Is.EqualTo("foo bar baz"));
+        }
+
+        [Test]
+        public void TestTrimEnd() {
+            var str = "foo          ";
+            var result = _tokenizer.Replace("{Text.TrimEnd: }", new { Text = str });
+            Assert.That(result, Is.EqualTo("foo"));
+        }
+
+        [Test]
+        public void TestTrimEndNumber() {
+            var str = "foobarbaz";
+            var result = _tokenizer.Replace("{Text.TrimEnd:3}", new { Text = str });
+            Assert.That(result, Is.EqualTo("foobar"));
+        }
+
+        [Test]
+        public void TestTrimEndWhenEmptyArg() {
+            var str = "foobarbaz";
+            var result = _tokenizer.Replace("{Text.TrimEnd:}", new { Text = str });
+            Assert.That(result, Is.EqualTo("foobarbaz"));
+        }
+
+        [TestCase("foo<bar", "foo%3cbar")]
+        [TestCase("foo>bar", "foo%3ebar")]
+        [TestCase("foo'bar", "foo%27bar")]
+        [TestCase("foo\"bar", "foo%22bar")]
+        [TestCase("foo bar", "foo+bar")]
+        public void TestUrlEncode(string str, string expected) {
+            var result = _tokenizer.Replace("{Text.UrlEncode}", new { Text = str });
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [TestCase("foo<bar", "foo&lt;bar")]
+        [TestCase("foo>bar", "foo&gt;bar")]
+        [TestCase("foo&bar", "foo&amp;bar")]
+        [TestCase("foo\"bar", "foo&quot;bar")]
+        [TestCase("foo'bar", "foo&#39;bar")]
+        public void TestHtmlEncode(string str, string expected) {
+            var result = _tokenizer.Replace("{Text.HtmlEncode}", new { Text = str }, new ReplaceOptions { Encoding = ReplaceOptions.NoEncode });
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void TestJavaScriptEncode() {
+            var str = "f\"oo<bar>ba'z";
+            var result = _tokenizer.Replace("{Text.JavaScriptEncode}", new { Text = str }, new ReplaceOptions { Encoding = ReplaceOptions.NoEncode });
+            Assert.That(result, Is.EqualTo(HttpUtility.JavaScriptStringEncode(str)));
+        }
+
+        [Test]
+        public void TestLineEncode() {
+            var str = "foo" + System.Environment.NewLine + "bar" + System.Environment.NewLine + "baz";
+            var result = _tokenizer.Replace("{Text.LineEncode}", new { Text = str }, new ReplaceOptions { Encoding = ReplaceOptions.NoEncode });
+            Assert.That(result, Is.EqualTo("foo<br />bar<br />baz"));
+        }
+    }
+}

--- a/src/Orchard/ContentManagement/DefaultContentQuery.cs
+++ b/src/Orchard/ContentManagement/DefaultContentQuery.cs
@@ -92,7 +92,7 @@ namespace Orchard.ContentManagement {
         }
 
         private void ForType(params string[] contentTypeNames) {
-            if (contentTypeNames != null && contentTypeNames.Length != 0) {
+            if (contentTypeNames != null) {
                 var contentTypeIds = contentTypeNames.Select(GetContentTypeRecordId).ToArray();
                 // don't use the IN operator if not needed for performance reasons
                 if (contentTypeNames.Length == 1) {

--- a/src/Orchard/Mvc/Html/HtmlHelperExtensions.cs
+++ b/src/Orchard/Mvc/Html/HtmlHelperExtensions.cs
@@ -183,11 +183,11 @@ namespace Orchard.Mvc.Html {
         #region Ellipsize
 
         public static IHtmlString Ellipsize(this HtmlHelper htmlHelper, string text, int characterCount) {
-            return new HtmlString(htmlHelper.Encode(text).Ellipsize(characterCount));
+            return new HtmlString(htmlHelper.Encode(text.Ellipsize(characterCount)));
         }
 
         public static IHtmlString Ellipsize(this HtmlHelper htmlHelper, string text, int characterCount, string ellipsis) {
-            return new HtmlString(htmlHelper.Encode(text).Ellipsize(characterCount, ellipsis));
+            return new HtmlString(htmlHelper.Encode(text.Ellipsize(characterCount, ellipsis)));
         }
 
         #endregion
@@ -195,8 +195,7 @@ namespace Orchard.Mvc.Html {
         #region Excerpt
 
         public static MvcHtmlString Excerpt(this HtmlHelper html, string markup, int length) {
-
-            return MvcHtmlString.Create(markup.RemoveTags().Ellipsize(length));
+            return MvcHtmlString.Create(html.Encode(HttpUtility.HtmlDecode(markup.RemoveTags()).Ellipsize(length)));
         }
 
         #endregion

--- a/src/Orchard/Utility/Extensions/StringExtensions.cs
+++ b/src/Orchard/Utility/Extensions/StringExtensions.cs
@@ -25,7 +25,7 @@ namespace Orchard.Utility.Extensions {
         }
 
         public static string Ellipsize(this string text, int characterCount) {
-            return text.Ellipsize(characterCount, "&#160;&#8230;");
+            return text.Ellipsize(characterCount, " …");
         }
 
         public static string Ellipsize(this string text, int characterCount, string ellipsis, bool wordBoundary = false) {

--- a/src/Orchard/Utility/Extensions/StringExtensions.cs
+++ b/src/Orchard/Utility/Extensions/StringExtensions.cs
@@ -25,7 +25,7 @@ namespace Orchard.Utility.Extensions {
         }
 
         public static string Ellipsize(this string text, int characterCount) {
-            return text.Ellipsize(characterCount, " …");
+            return text.Ellipsize(characterCount, "\u00A0\u2026");
         }
 
         public static string Ellipsize(this string text, int characterCount, string ellipsis, bool wordBoundary = false) {


### PR DESCRIPTION
Fixes #6051 Added a signal that is triggered when a new profile is published. This trigger causes the cached value for the new profile to be invalidated.