### PR TITLE
fixes #6046

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Scripts/LayoutDesignerHost.js
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Scripts/LayoutDesignerHost.js
@@ -135,5 +135,19 @@
                 e.preventDefault();
             });
         });
+
+        // prevents button default behaviour while designing a layout
+        var buttonsNo = 0;
+        setInterval(function() {
+            var buttons = $('.layout-designer button');
+            if (buttonsNo != buttons.size()) {
+                buttonsNo = buttons.size();
+                buttons.off('click');
+                buttons.on('click', function(e) {
+                    e.preventDefault();
+                    return false;
+                });
+            }
+        }, 100);
     });
 })(jQuery);

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Scripts/LayoutDesignerHost.js
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Scripts/LayoutDesignerHost.js
@@ -136,7 +136,7 @@
             });
         });
 
-        // prevents button default behaviour while designing a layout
+        // prevents button default behavior while designing a layout
         var buttonsNo = 0;
         setInterval(function() {
             var buttons = $('.layout-designer button');


### PR DESCRIPTION
fixes #6046 by preventing the default behavior of the buttons while designing a layout.

*I don't like this code, but I have tried everything else including `$(document).on` so to get rid of that `setInterval` stuff so the code be aware of any future button, but sadly this is the only jQuery code that works, probably some bugs in jQuery v1.11.x*