### PR TITLE
Added two optimisations to avoid duplicate work

### DIFF
--- a/src/Orchard/Environment/Features/FeatureManager.cs
+++ b/src/Orchard/Environment/Features/FeatureManager.cs
@@ -69,9 +69,10 @@ namespace Orchard.Environment.Features {
                 .ToDictionary(featureDescriptor => featureDescriptor,
                                 featureDescriptor => enabledFeatures.FirstOrDefault(shellFeature => shellFeature.Name == featureDescriptor.Id) != null);
 
+            //Fix for https://orchard.codeplex.com/workitem/21176 / https://github.com/OrchardCMS/Orchard/issues/6075 - added distinct to the end to ensure each feature is only listed once
             IEnumerable<string> featuresToEnable = featureIds
                 .Select(featureId => EnableFeature(featureId, availableFeatures, force)).ToList()
-                .SelectMany(ies => ies.Select(s => s));
+                .SelectMany(ies => ies.Select(s => s)).Distinct();
 
             if (featuresToEnable.Count() > 0) {
                 foreach (string featureId in featuresToEnable) {


### PR DESCRIPTION
Avoids many retrievals of ShellStateRecord and stops enabling the same
feature multiple times. This can significantly improve recipe execution
time for those recipes with large numbers of features with long
dependency chains.