### PR TITLE
Fix a problem in TagCloudService when maxcount < bucket number

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Tags/Services/TagCloudService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Tags/Services/TagCloudService.cs
@@ -81,12 +81,29 @@ namespace Orchard.Tags.Services {
                     }
 
                     // initialize centroids with a linear distribution
-                    var centroids = new int[buckets];
+                    var centroids = new double[buckets];
                     var maxCount = tagCounts.Any() ? tagCounts.Max(tc => tc.Count) : 0;
                     var minCount = tagCounts.Any() ? tagCounts.Min(tc => tc.Count) : 0;
-                    var maxDistance = maxCount - minCount;
-                    for (int i = 0; i < centroids.Length; i++) {
-                        centroids[i] = maxDistance/buckets * (i+1);
+                    double maxDistance = maxCount - minCount;
+                    if ( maxCount < buckets)
+                    {
+                        int i = 0;
+                        for (; i < buckets && i < maxCount;)
+                        {
+                            centroids[i] = minCount + i;
+                            i++;
+                        }
+                        for (; i < buckets; i++)
+                        {
+                            centroids[i] = int.MaxValue;
+                        }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < centroids.Length ; i++)
+                        {
+                            centroids[i] = minCount + maxDistance / buckets * i;
+                        }
                     }
 
                     var balanced = false;
@@ -113,7 +130,7 @@ namespace Orchard.Tags.Services {
                         for (int i = 0; i < buckets; i++) {
                             var target = tagCounts.Where(x => x.Bucket == i + 1).ToArray();
                             if (target.Any()) {
-                                centroids[i] = (int)target.Average(x => x.Count);
+                                centroids[i] = target.Average(x => x.Count);
                             }
                         }
                     }

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Module.txt
@@ -24,3 +24,8 @@ Features:
         Description: Enables widgets to be added as elements to layouts.
         Category: Layout
         Dependencies: Orchard.Layouts
+	Orchard.Widgets.LayerAlternates
+        Name: Widget Layer Alternates
+        Description: Create alternates based on Active layers.
+        Category: Design
+        Dependencies: Orchard.Widgets

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Filters\WidgetFilter.cs" />
     <Compile Include="ResourceManifest.cs" />
     <Compile Include="Conditions\ContentDisplayedRuleProvider.cs" />
+    <Compile Include="Services\LayerAlternatesFactory.cs" />
     <Compile Include="Services\RuleManager.cs" />
     <Compile Include="Services\DefaultLayerEvaluationService.cs" />
     <Compile Include="Services\ILayerEvaluationService.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/LayerAlternatesFactory.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/LayerAlternatesFactory.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orchard.DisplayManagement.Implementation;
+using Orchard.Environment.Extensions;
+using Orchard.Localization;
+using Orchard.Logging;
+using Orchard.Widgets.Models;
+using Orchard.ContentManagement;
+
+namespace Orchard.Widgets.Services
+{
+    [OrchardFeature("Orchard.Widgets.LayerAlternates")]
+    public class LayersAlternatesFactory : ShapeDisplayEvents
+    {
+        private readonly ILayerEvaluationService _layerEvaluationService;
+        private readonly Lazy<List<string>> _layersAlternates;
+        private readonly IOrchardServices _orchardServices;
+
+
+        public ILogger Logger { get; set; }
+        public Localizer T { get; set; }
+
+
+        public LayersAlternatesFactory(ILayerEvaluationService layerEvaluationService, IOrchardServices orchardServices)
+        {
+            _layerEvaluationService = layerEvaluationService;
+            _orchardServices = orchardServices;
+            Logger = NullLogger.Instance;
+            T = NullLocalizer.Instance;
+            _layersAlternates = new Lazy<List<string>>(() => {
+                int[] activeLayers = _layerEvaluationService.GetActiveLayerIds();
+
+                if (activeLayers == null || activeLayers.Length == 0)
+                {
+                    return null;
+                }
+
+                // Get Layer names and remove any ' ', '.'
+                var layers = _orchardServices.ContentManager.GetMany<LayerPart>(activeLayers, VersionOptions.Published, QueryHints.Empty)
+                        .Where(l => !l.Name.Equals("default", StringComparison.InvariantCultureIgnoreCase))
+                        .Select(l => l.Name.Replace(" ", "__").Replace(".", "_"))
+                        .ToArray();
+
+                var lyrs = Enumerable.Range(1, layers.Count()).Select(range => String.Join("__", layers.Take(range))).Union(layers).ToList();
+                return lyrs;
+            });
+        }
+
+        public override void Displaying(ShapeDisplayingContext context)
+        {
+
+            context.ShapeMetadata.OnDisplaying(displayedContext => {
+
+                if (_layersAlternates.Value == null || !_layersAlternates.Value.Any())
+                {
+                    return;
+                }
+
+                // prevent applying alternate again, c.f. https://github.com/OrchardCMS/Orchard/issues/2125
+                if (displayedContext.ShapeMetadata.Alternates.Any(x => x.Contains("__layer__")))
+                {
+                    return;
+                }
+
+                // appends Url alternates to current ones
+                displayedContext.ShapeMetadata.Alternates = displayedContext.ShapeMetadata.Alternates.SelectMany(
+                    alternate => new[] { alternate }.Union(_layersAlternates.Value.Select(a => alternate + "__layer__" + a))
+                    ).ToList();
+
+                // appends [ShapeType]__url__[Url] alternates
+                displayedContext.ShapeMetadata.Alternates = _layersAlternates.Value.Select(url => displayedContext.ShapeMetadata.Type + "__layer__" + url)
+                    .Union(displayedContext.ShapeMetadata.Alternates)
+                    .ToList();
+            });
+
+        }
+    }
+}


### PR DESCRIPTION
The TagCloud bucket parameter will always be correctly fixed by the TagCloudService with this fix, which also improves the actual process by using double in centroids