### PR TITLE
New feature bringing alternates based on current active layers

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Widgets/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Module.txt
@@ -24,3 +24,8 @@ Features:
         Description: Enables widgets to be added as elements to layouts.
         Category: Layout
         Dependencies: Orchard.Layouts
+	Orchard.Widgets.LayerAlternates
+        Name: Widget Layer Alternates
+        Description: Create alternates based on Active layers.
+        Category: Design
+        Dependencies: Orchard.Widgets

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Filters\WidgetFilter.cs" />
     <Compile Include="ResourceManifest.cs" />
     <Compile Include="Conditions\ContentDisplayedRuleProvider.cs" />
+    <Compile Include="Services\LayerAlternatesFactory.cs" />
     <Compile Include="Services\RuleManager.cs" />
     <Compile Include="Services\DefaultLayerEvaluationService.cs" />
     <Compile Include="Services\ILayerEvaluationService.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/LayerAlternatesFactory.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/LayerAlternatesFactory.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orchard.DisplayManagement.Implementation;
+using Orchard.Environment.Extensions;
+using Orchard.Localization;
+using Orchard.Logging;
+using Orchard.Widgets.Models;
+using Orchard.ContentManagement;
+
+namespace Orchard.Widgets.Services
+{
+    [OrchardFeature("Orchard.Widgets.LayerAlternates")]
+    public class LayersAlternatesFactory : ShapeDisplayEvents
+    {
+        private readonly ILayerEvaluationService _layerEvaluationService;
+        private readonly Lazy<List<string>> _layersAlternates;
+        private readonly IOrchardServices _orchardServices;
+
+
+        public ILogger Logger { get; set; }
+        public Localizer T { get; set; }
+
+
+        public LayersAlternatesFactory(ILayerEvaluationService layerEvaluationService, IOrchardServices orchardServices)
+        {
+            _layerEvaluationService = layerEvaluationService;
+            _orchardServices = orchardServices;
+            Logger = NullLogger.Instance;
+            T = NullLocalizer.Instance;
+            _layersAlternates = new Lazy<List<string>>(() => {
+                int[] activeLayers = _layerEvaluationService.GetActiveLayerIds();
+
+                if (activeLayers == null || activeLayers.Length == 0)
+                {
+                    return null;
+                }
+
+                // Get Layer names and remove any ' ', '.'
+                var layers = _orchardServices.ContentManager.GetMany<LayerPart>(activeLayers, VersionOptions.Published, QueryHints.Empty)
+                        .Where(l => !l.Name.Equals("default", StringComparison.InvariantCultureIgnoreCase))
+                        .Select(l => l.Name.Replace(" ", "__").Replace(".", "_"))
+                        .ToArray();
+
+                var lyrs = Enumerable.Range(1, layers.Count()).Select(range => String.Join("__", layers.Take(range))).Union(layers).ToList();
+                return lyrs;
+            });
+        }
+
+        public override void Displaying(ShapeDisplayingContext context)
+        {
+
+            context.ShapeMetadata.OnDisplaying(displayedContext => {
+
+                if (_layersAlternates.Value == null || !_layersAlternates.Value.Any())
+                {
+                    return;
+                }
+
+                // prevent applying alternate again, c.f. https://github.com/OrchardCMS/Orchard/issues/2125
+                if (displayedContext.ShapeMetadata.Alternates.Any(x => x.Contains("__layer__")))
+                {
+                    return;
+                }
+
+                // appends Url alternates to current ones
+                displayedContext.ShapeMetadata.Alternates = displayedContext.ShapeMetadata.Alternates.SelectMany(
+                    alternate => new[] { alternate }.Union(_layersAlternates.Value.Select(a => alternate + "__layer__" + a))
+                    ).ToList();
+
+                // appends [ShapeType]__url__[Url] alternates
+                displayedContext.ShapeMetadata.Alternates = _layersAlternates.Value.Select(url => displayedContext.ShapeMetadata.Type + "__layer__" + url)
+                    .Union(displayedContext.ShapeMetadata.Alternates)
+                    .ToList();
+            });
+
+        }
+    }
+}


### PR DESCRIPTION
It adds a new feature to widgets and, when enabled, new alternates are added to complement existing one, using a process identical to Url Alternates.
It selects the active layers for the requested url and brings new alternates with the -layer-  prefix.
Examples:
Lets suppose that you created a layer named 'blogs first', you could then use
Menu-layer-blogs-first.cshtml
Layout-layer-blogs-first.cshtml

The default layer is no used, but the authenticated or anonymous layer could also be used.
A mix of the different layers is also proposed as in
Menu-layer-anonymous-blogs-first.cshtml

Very useful.