### PR TITLE
#6091: ImageProfileManager.GetImageProfileUrl can take multiple customFilters

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/IImageProfileManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/IImageProfileManager.cs
@@ -7,5 +7,6 @@ namespace Orchard.MediaProcessing.Services {
         string GetImageProfileUrl(string path, string profileName, ContentItem contentItem);
         string GetImageProfileUrl(string path, string profileName, FilterRecord customFilter);
         string GetImageProfileUrl(string path, string profileName, FilterRecord customFilter, ContentItem contentItem);
+        string GetImageProfileUrl(string path, string profileName, ContentItem contentItem, params FilterRecord[] customFilters);
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
@@ -44,8 +44,8 @@ namespace Orchard.MediaProcessing.Services {
 
         public ILogger Logger { get; set; }
 
-        public string GetImageProfileUrl(string path, string profileName) {
-            return GetImageProfileUrl(path, profileName, null, null);
+          public string GetImageProfileUrl(string path, string profileName) {
+            return GetImageProfileUrl(path, profileName, null, new FilterRecord[] { });
         }
 
         public string GetImageProfileUrl(string path, string profileName, ContentItem contentItem) {
@@ -57,6 +57,10 @@ namespace Orchard.MediaProcessing.Services {
         }
 
         public string GetImageProfileUrl(string path, string profileName, FilterRecord customFilter, ContentItem contentItem) {
+            return GetImageProfileUrl(path, profileName, contentItem, customFilter);
+        }
+
+        public string GetImageProfileUrl(string path, string profileName, ContentItem contentItem, params FilterRecord[] customFilters) {
 
             // path is the publicUrl of the media, so it might contain url-encoded chars
 
@@ -108,7 +112,7 @@ namespace Orchard.MediaProcessing.Services {
 
                 ImageProfilePart profilePart;
 
-                if (customFilter == null) {
+                if (customFilters == null || !customFilters.Any()) {
                     profilePart = _profileService.GetImageProfileByName(profileName);
                     if (profilePart == null)
                         return String.Empty;
@@ -116,7 +120,9 @@ namespace Orchard.MediaProcessing.Services {
                 else {
                     profilePart = _services.ContentManager.New<ImageProfilePart>("ImageProfile");
                     profilePart.Name = profileName;
-                    profilePart.Filters.Add(customFilter);
+                    foreach (var customFilter in customFilters) { 
+                        profilePart.Filters.Add(customFilter);
+                    }
                 }
 
                 // prevent two requests from processing the same file at the same time


### PR DESCRIPTION
new method was added to `IImageProfileManager`. 
`string GetImageProfileUrl(string path, string profileName, ContentItem contentItem, params FilterRecord[] customFilters);`
