### PR TITLE
Removing duplicate fields from content parts fails

### DIFF
--- a/src/Orchard/ContentManagement/MetaData/Builders/ContentPartDefinitionBuilder.cs
+++ b/src/Orchard/ContentManagement/MetaData/Builders/ContentPartDefinitionBuilder.cs
@@ -43,7 +43,7 @@ namespace Orchard.ContentManagement.MetaData.Builders {
         }
 
         public ContentPartDefinitionBuilder RemoveField(string fieldName) {
-            var existingField = _fields.SingleOrDefault(x => x.Name == fieldName);
+            var existingField = _fields.FirstOrDefault(x => x.Name == fieldName);
             if (existingField != null) {
                 _fields.Remove(existingField);
             }


### PR DESCRIPTION
SingleOrDefault will throw an error when removing fields with the same name.  Should be FirstOrDefault as it is on line 64