### PR TITLE
[Fixes #6154] for Redis Message Bus Shell Restarts on Import

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MessageBus/Services/DistributedShellStarter.cs
+++ b/src/Orchard.Web/Modules/Orchard.MessageBus/Services/DistributedShellStarter.cs
@@ -8,7 +8,7 @@ using Orchard.Environment.Extensions;
 namespace Orchard.MessageBus.Services {
 
     public interface IDistributedShellStarter : ISingletonDependency {
-
+        bool IsStarting();
     }
 
     [OrchardFeature("Orchard.MessageBus.DistributedShellRestart")]
@@ -17,9 +17,13 @@ namespace Orchard.MessageBus.Services {
 
         private readonly IMessageBus _messageBus;
 
-        private static readonly object locker = new object();
+        private object locker = new object();
 
-        public static bool IsStarting { get; private set; }
+        public bool _isStarting { get; private set; }
+        
+        public bool IsStarting() {
+            return _isStarting;
+        }
         
         public readonly static string Channel = "ShellChanged";
 
@@ -44,7 +48,7 @@ namespace Orchard.MessageBus.Services {
                         lock (locker) { 
                             // Set a flag indicating that we are in the process of activating the shell. 
                             // This is used to prevent recursive message bus calls.
-                            IsStarting = true;
+                            _isStarting = true;
                             shellSettingsManagerEventHandler.Saved(shellSettings);
 
                             if(orchardHost != null) {
@@ -52,7 +56,7 @@ namespace Orchard.MessageBus.Services {
                                 startUpdatedShellsMethod.Invoke(orchardHost, null);
                             }
 
-                            IsStarting = false;
+                            _isStarting = false;
                         }
                     }
                 }

--- a/src/Orchard.Web/Modules/Orchard.MessageBus/Services/DistributedShellTrigger.cs
+++ b/src/Orchard.Web/Modules/Orchard.MessageBus/Services/DistributedShellTrigger.cs
@@ -8,16 +8,18 @@ namespace Orchard.MessageBus.Services {
     public class DistributedShellTrigger : IShellDescriptorManagerEventHandler, IShellSettingsManagerEventHandler {
     
         private readonly IMessageBus _messageBus;
+        private readonly IDistributedShellStarter _shellStarter;
         
-        public DistributedShellTrigger(IShellSettingsManager shellSettingsManager, IMessageBus messageBus, IShellSettingsManagerEventHandler shellSettingsManagerEventHandler) {
+        public DistributedShellTrigger(IShellSettingsManager shellSettingsManager, IMessageBus messageBus, IShellSettingsManagerEventHandler shellSettingsManagerEventHandler, IDistributedShellStarter shellStarter) {
             _messageBus = messageBus;
+            _shellStarter = shellStarter;
         }
 
         void IShellDescriptorManagerEventHandler.Changed(ShellDescriptor descriptor, string tenant) {
 
             // If this method was called as a result of a published message to 
             // start the shell, then prevent a recursive loop.
-            if(!DistributedShellStarter.IsStarting) {
+            if(!_shellStarter.IsStarting()) {
                 _messageBus.Publish(DistributedShellStarter.Channel, tenant);
             }
         }
@@ -26,7 +28,7 @@ namespace Orchard.MessageBus.Services {
 
             // If this method was called as a result of a published message to 
             // start the shell, then prevent a recursive loop.
-            if (!DistributedShellStarter.IsStarting) {
+            if (!_shellStarter.IsStarting()) {
                 _messageBus.Publish(DistributedShellStarter.Channel, settings.Name);
             }
         }


### PR DESCRIPTION
This fixes an issue where when using Redis Message Bus and importing a
recipe, multiple shell restarts are triggered on the root host.  This
results in an error being displayed after the import completes.