### PR TITLE
Update TaxonomyField.cshtml

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.cshtml
@@ -42,7 +42,9 @@
             }
         </ul>
             
-        @if (!Model.Terms.Any() && AuthorizedFor(Orchard.Taxonomies.Permissions.CreateTerm)) {
+         @if (Model.TaxonomyId == 0) {
+            <p>@T("Your haven't specified a taxonomy for {0}", Model.DisplayName)</p>
+        }else if (!Model.Terms.Any() && AuthorizedFor(Orchard.Taxonomies.Permissions.CreateTerm)) {
             <div class="no-terms">
                 @T("There are no terms defined for {0} yet.", Model.DisplayName)
                 <a href="@Url.Action("Index", "TermAdmin", new { taxonomyId = Model.TaxonomyId, area = "Orchard.Taxonomies" })">@T("Create some terms")</a>


### PR DESCRIPTION
Re-submit of #6160. Fixed a bug in the taxonomy field editor template that allows you to click on "create some terms" for a non-existent taxonomy. This situation occurs when you assign a taxonomy field to a content type but do not specify a taxonomy.