### PR TITLE
Fixed issue  #1978

### DIFF
--- a/src/Orchard/Localization/LocalizedString.cs
+++ b/src/Orchard/Localization/LocalizedString.cs
@@ -78,5 +78,9 @@ namespace Orchard.Localization {
             return string.Equals(_localized, that._localized);
         }
 
+        public override object InitializeLifetimeService() {
+            // never expire the cross-AppDomain lease on this object
+            return null;
+        }
     }
 }

--- a/src/Orchard/Logging/OrchardLog4netLogger.cs
+++ b/src/Orchard/Logging/OrchardLog4netLogger.cs
@@ -415,5 +415,9 @@ namespace Orchard.Logging {
             }
         }
 
+        public override object InitializeLifetimeService() {
+            // never expire the cross-AppDomain lease on this object
+            return null;
+        }
     }
 }

--- a/src/Tools/Orchard/Host/CommandHost.cs
+++ b/src/Tools/Orchard/Host/CommandHost.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Remoting;
+using System.Runtime.Remoting.Lifetime;
 using System.Security;
 using System.Web.Hosting;
 using Orchard.Parameters;
@@ -32,8 +34,23 @@ namespace Orchard.Host {
 
         [SecurityCritical]
         public override object InitializeLifetimeService() {
-            // never expire the license
+           // never expire the cross-AppDomain lease on this object
             return null;
+        }
+
+        private static void ExtendLifeTimeLeases(TextReader input, TextWriter output) {
+            // Orchard objects passed as parameters into this AppDomain should derive from MarshalByRefObject and have
+            // infinite lease timeouts by means of their InitializeLifetimeService overrides.  For the input/output 
+            // stream objects we approximate that behavior by immediately renewing the lease for 30 days.
+            ExtendLifeTimeLease(input);
+            ExtendLifeTimeLease(output);
+        }
+
+        private static void ExtendLifeTimeLease(MarshalByRefObject obj) {
+            if (RemotingServices.IsObjectOutOfAppDomain(obj)) {
+                var lease = (ILease)RemotingServices.GetLifetimeService(obj);
+                lease.Renew(TimeSpan.FromDays(30));
+            }
         }
 
         [SecuritySafeCritical]
@@ -42,18 +59,21 @@ namespace Orchard.Host {
         }
 
         public CommandReturnCodes StartSession(TextReader input, TextWriter output) {
+            ExtendLifeTimeLeases(input, output);
             _agent = CreateAgent();
             return StartHost(_agent, input, output);
         }
 
         public void StopSession(TextReader input, TextWriter output) {
             if (_agent != null) {
+                ExtendLifeTimeLeases(input, output);
                 StopHost(_agent, input, output);
                 _agent = null;
             }
         }
 
         public CommandReturnCodes RunCommand(TextReader input, TextWriter output, Logger logger, OrchardParameters args) {
+            ExtendLifeTimeLeases(input, output);
             var agent = CreateAgent();
             CommandReturnCodes result = (CommandReturnCodes)agent.GetType().GetMethod("RunSingleCommand").Invoke(agent, new object[] { 
                 input,
@@ -66,6 +86,7 @@ namespace Orchard.Host {
         }
 
         public CommandReturnCodes RunCommandInSession(TextReader input, TextWriter output, Logger logger, OrchardParameters args) {
+            ExtendLifeTimeLeases(input, output);
             CommandReturnCodes result = (CommandReturnCodes)_agent.GetType().GetMethod("RunCommand").Invoke(_agent, new object[] { 
                 input,
                 output,
@@ -77,6 +98,7 @@ namespace Orchard.Host {
         }
 
         public CommandReturnCodes RunCommands(TextReader input, TextWriter output, Logger logger, IEnumerable<ResponseLine> responseLines) {
+            ExtendLifeTimeLeases(input, output);
             var agent = CreateAgent();
 
             CommandReturnCodes result = StartHost(agent, input, output);

--- a/src/Tools/Orchard/Host/CommandHost.cs
+++ b/src/Tools/Orchard/Host/CommandHost.cs
@@ -34,7 +34,7 @@ namespace Orchard.Host {
 
         [SecurityCritical]
         public override object InitializeLifetimeService() {
-           // never expire the cross-AppDomain lease on this object
+            // never expire the cross-AppDomain lease on this object
             return null;
         }
 

--- a/src/Tools/Orchard/Logger.cs
+++ b/src/Tools/Orchard/Logger.cs
@@ -17,5 +17,10 @@ namespace Orchard {
                 _output.WriteLine(format, args);
             }
         }
+
+        public override object InitializeLifetimeService() {
+            // never expire the cross-AppDomain lease on this object
+            return null;
+        }
     }
 }

--- a/src/Tools/Orchard/OrchardParameters.cs
+++ b/src/Tools/Orchard/OrchardParameters.cs
@@ -10,5 +10,10 @@ namespace Orchard {
         public IList<string> Arguments { get; set; }
         public IList<string> ResponseFiles { get; set; }
         public IDictionary<string, string> Switches { get; set; }
+
+        public override object InitializeLifetimeService() {
+            // never expire the cross-AppDomain lease on this object
+            return null;
+        }
     }
 }

--- a/src/Tools/Orchard/ResponseFiles/ResponseFileReader.cs
+++ b/src/Tools/Orchard/ResponseFiles/ResponseFileReader.cs
@@ -10,6 +10,11 @@ namespace Orchard.ResponseFiles {
         public string LineText { get; set; }
         public int LineNumber { get; set; }
         public string[] Args { get; set; }
+
+        public override object InitializeLifetimeService() {
+            // never expire the cross-AppDomain lease on this object
+            return null;
+        }
     }
 
     public class ResponseFileReader {


### PR DESCRIPTION
Long-running Orchard commands crashed the command line due to expired leases on remote proxies for MarshalByRef parameters passed in cross-AppDomain calls.