### PR TITLE
Fixed bad assumption about HttpContext

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Providers/ImportActions/ExecuteRecipeAction.cs
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Providers/ImportActions/ExecuteRecipeAction.cs
@@ -153,7 +153,9 @@ namespace Orchard.ImportExport.Providers.ImportActions {
             PrepareRecipe(recipeDocument);
 
             // Sets the request timeout to a configurable amount of seconds to give enough time to execute custom recipes.
-            _orchardServices.WorkContext.HttpContext.Server.ScriptTimeout = RecipeExecutionTimeout;
+            if (_orchardServices.WorkContext.HttpContext != null) {
+                _orchardServices.WorkContext.HttpContext.Server.ScriptTimeout = RecipeExecutionTimeout;
+            }
 
             // Suspend background task execution.
             _sweepGenerator.Terminate();


### PR DESCRIPTION
Fixes #6181 

When running Import/Export at the console it would fail due to a null HttpContext.

* Added a guard clause as  HttpContext is not available when running at console
