### PR TITLE
#6193: TokenFilters Cohabitation

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Tokens/Implementation/Tokenizer.cs
+++ b/src/Orchard.Web/Modules/Orchard.Tokens/Implementation/Tokenizer.cs
@@ -53,7 +53,9 @@ namespace Orchard.Tokens.Implementation {
             var replacements = Evaluate(options.Predicate == null ? tokens : tokens.Where(options.Predicate), data);
 
             return replacements.Aggregate(tokenset.Item1,
-                (current, replacement) => current.Replace((hashMode ? "#{" : "{") + replacement.Key + "}", (options.Encoding ?? ReplaceOptions.NoEncode)(replacement.Key, replacement.Value)));
+                (current, replacement) => replacement.Value == null ? 
+                current : current.Replace((hashMode ? "#{" : "{") + replacement.Key + "}",
+                (options.Encoding ?? ReplaceOptions.NoEncode)(replacement.Key, replacement.Value)));
         }
 
         private static Tuple<string, IEnumerable<string>> Parse(string text, bool hashMode) {


### PR DESCRIPTION
Fixes #6193 

For the 2 versions of TokenFilter (for content part / element), context data are not passed in the same way and can be empty. Then, a first running filter can kill the token.

So the need to null check the token replacement value.

Best