### PR TITLE
Trying to revert a famous PR, sorry

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/DefaultLayerEvaluationService.cs
@@ -42,7 +42,7 @@ namespace Orchard.Widgets.Services{
             // Once the Condition Engine is done:
             // Get Layers and filter by zone and rule
             // NOTE: .ForType("Layer") is faster than .Query<LayerPart, LayerPartRecord>()
-            var activeLayers = _orchardServices.ContentManager.Query<LayerPart>().WithQueryHints(new QueryHints().ExpandParts<LayerPart>()).ForType("Layer").List();
+            var activeLayers = _orchardServices.ContentManager.Query<LayerPart>().ForType("Layer").List();
 
             var activeLayerIds = new List<int>();
             foreach (var activeLayer in activeLayers) {


### PR DESCRIPTION
Sorry for trying to revert this PR related to the awesome presentation of Chris Payne at Harvest where a `QueryHints()` with `ExpandParts()` was added to access the layer parts...

But after the query, as mentioned in a meeting by Sébastien, a previous version was used with access to the LayerPartRecord `activeLayer.Record.LayerRule`. But now, because the LayerRule is in the infoset, we only use `activeLayer.LayerRule`.

So, this PR requested by @sebastienros 

Note1: the substance of the Harvest presentation remains fully relevant.
Note2: not tested but validated by Sébastien. If wrong it's not my PR.

Best