### PR TITLE
fix CommonMetadataOwner issue: german umlauts are displayed encoded

### DIFF
--- a/src/Orchard.Web/Core/Common/Views/CommonMetadataOwner.cshtml
+++ b/src/Orchard.Web/Core/Common/Views/CommonMetadataOwner.cshtml
@@ -11,4 +11,4 @@
     // owner isn't really who last modified this, is it?
     IUser owner = commonPart.As<CommonPart>() == null ? null : commonPart.As<CommonPart>().Owner;
 }
-@T("By {0}", owner == null ? T("unknown").ToString() : Convert.ToString(Html.ItemDisplayText(owner)))
+@T("By {0}", owner == null ? T("unknown").ToString() : Convert.ToString(Html.ItemDisplayText(owner, false)))


### PR DESCRIPTION
simple fix to display german umlauts user name correctly (e. g. ü instead of &#252;)