### PR TITLE
#6192: Uses Lazy IWorkContextStateProvider in 1.9.x, as done in the dev branch.

### DIFF
--- a/src/Orchard/Environment/WorkContextImplementation.cs
+++ b/src/Orchard/Environment/WorkContextImplementation.cs
@@ -8,11 +8,11 @@ namespace Orchard.Environment {
     class WorkContextImplementation : WorkContext {
         readonly IComponentContext _componentContext;
         readonly ConcurrentDictionary<string, Func<object>> _stateResolvers = new ConcurrentDictionary<string, Func<object>>();
-        readonly IEnumerable<IWorkContextStateProvider> _workContextStateProviders;
+        readonly IEnumerable<Lazy<IWorkContextStateProvider>> _workContextStateProviders;
 
         public WorkContextImplementation(IComponentContext componentContext) {
             _componentContext = componentContext;
-            _workContextStateProviders = componentContext.Resolve<IEnumerable<IWorkContextStateProvider>>();
+            _workContextStateProviders = componentContext.Resolve<IEnumerable<Lazy<IWorkContextStateProvider>>>();
         }
 
         public override T Resolve<T>() {
@@ -29,7 +29,7 @@ namespace Orchard.Environment {
         }
 
         Func<object> FindResolverForState<T>(string name) {
-            var resolver = _workContextStateProviders.Select(wcsp => wcsp.Get<T>(name)).FirstOrDefault(value => !Equals(value, default(T)));
+            var resolver = _workContextStateProviders.Select(wcsp => wcsp.Value.Get<T>(name)).FirstOrDefault(value => !Equals(value, default(T)));
 
             if (resolver == null) {
                 return () => default(T);


### PR DESCRIPTION
Fixes #6192

Already done in the dev branch, but because it fixes an issue if applied to 1.9.x.

Best
