### PR TITLE
Fix media-library-picker.js

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Scripts/media-library-picker.js
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Scripts/media-library-picker.js
@@ -21,12 +21,15 @@
         
         var refreshIds = function() {
             var id = element.find('.selected-ids');
-            id.val('');
-            element.find(".media-library-picker-item").each(function() {
-                id.val(id.val() + "," + $(this).attr("data-id"));
+            var ids = [];
+
+            element.find(".media-library-picker-item").each(function () {
+                ids.push($(this).attr("data-id"));
             });
 
-            var itemsCount = element.find(".media-library-picker-item").length;
+            id.val(ids.join());
+
+            var itemsCount = ids.length;
             
             if(!multiple && itemsCount > 0) {
                 addButton.hide();


### PR DESCRIPTION
Stops `media-library-picker.js` starting media ids list with a comma.
There is no issue with `MediaLibraryPickerField` as it uses `StringSplitOptions.RemoveEmptyEntries`, but it's an issue if you use `MediaLibraryPicker` shape and expect a single id.

The fix slightly reduces DOM access, it should not be bad.