### PR TITLE
Get Auth status from WorkContext in OutputCacheFilter

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -386,7 +386,7 @@ namespace Orchard.OutputCache.Filters {
 
             // Vary by authentication state if configured.
             if (CacheSettings.VaryByAuthenticationState) {
-                result["auth"] = result["auth"] = _workContext.CurrentUser != null;
+                result["auth"] = _workContext.CurrentUser != null;
             }
 
             return result;

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -386,7 +386,7 @@ namespace Orchard.OutputCache.Filters {
 
             // Vary by authentication state if configured.
             if (CacheSettings.VaryByAuthenticationState) {
-                result["auth"] = filterContext.HttpContext.User.Identity.IsAuthenticated.ToString().ToLowerInvariant();
+                result["auth"] = result["auth"] = _workContext.CurrentUser != null;
             }
 
             return result;


### PR DESCRIPTION
Gets auth state from WorkContext as opposed to HttpContext.

Solves a potential issue for people who have swapped out the implementation of `IAuthenticationService.GetAuthenticatedUser()` where the output cache could think that the user was logged in when in fact they were not. For example: `GetAuthenticatedUser()` has been overridden to include additional auth checks to enforce business logic, these additional checks will not be performed without this change.