### PR TITLE
Fixes #5593 : Allow disabling HtmlEncode on DynamicForms

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/FormElementDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/FormElementDriver.cs
@@ -83,7 +83,6 @@ namespace Orchard.DynamicForms.Drivers {
                         Name: "HtmlEncode",
                         Title: "Html Encode",
                         Value: "true",
-                        Checked: true,
                         Description: T("Check this option to automatically HTML encode submitted values to prevent code injection.")),
                     _CreateContent: shape.Checkbox(
                         Id: "CreateContent",

--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Elements/Form.cs
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Elements/Form.cs
@@ -33,7 +33,7 @@ namespace Orchard.DynamicForms.Elements {
         }
 
         public bool HtmlEncode {
-            get { return this.Retrieve(x => x.HtmlEncode, () => true); }
+            get { return this.Retrieve(x => x.HtmlEncode); }
             set { this.Store(x => x.HtmlEncode, value); }
         }
 


### PR DESCRIPTION
If we want to default encode form values, an alternative to this PR would be a checkbox to opt-out HtmlEncoding.
More, HtmlEncoded form values are not correctly diplayed in Form Submissions view.