### PR TITLE
DefaultJsonDeserializer using JSON.NET: Allowing deserializing into any JSON token type

### DIFF
--- a/src/Orchard/Services/DefaultJsonConverter.cs
+++ b/src/Orchard/Services/DefaultJsonConverter.cs
@@ -15,7 +15,7 @@ namespace Orchard.Services {
         }
 
         public dynamic Deserialize(string json) {
-            dynamic result = JObject.Parse(json);
+            dynamic result = JToken.Parse(json);
             return result;
         }
 


### PR DESCRIPTION
This PR is a very simple change that would allow the use of `DefaultJsonConverter.Deserialize()` to parse a JSON string that may be of types other than a JSON object.

Since the current code uses JObject.Parse(), it can only handle JSON Objects.
http://www.newtonsoft.com/json/help/html/ParseJsonObject.htm

    // Works
    _jsonConverter.Deserialize("{\"key1\": \"value\", \"key2\": 5}");
    // These don't work
    _jsonConverter.Deserialize("[0, \"foo\", 2]");
    _jsonConverter.Deserialize("100");
    _jsonConverter.Deserialize("null");
    _jsonConverter.Deserialize("\"hello, world\"");

My suggestion uses JToken.Parse(), which handles any kind of JSON token.
http://www.newtonsoft.com/json/help/html/ParseJsonAny.htm

    // Works
    _jsonConverter.Deserialize("{\"key1\": \"value\", \"key2\": 5}");
    // Now Works Too
    _jsonConverter.Deserialize("[0, \"foo\", 2]");
    _jsonConverter.Deserialize("100");
    _jsonConverter.Deserialize("null");
    _jsonConverter.Deserialize("\"hello, world\"");

This does not break existing code because JObject is a subclass of JToken.