### PR TITLE
#6302: Fixes some issues when using Forms API checkboxes

### DIFF
--- a/src/Orchard.Web/Core/Shapes/Scripts/base.js
+++ b/src/Orchard.Web/Core/Shapes/Scripts/base.js
@@ -252,6 +252,35 @@
 
         });
     });
+    // Boolean checkboxes (data-boolean="true").
+    // Ensures that a value is always sent on submission.
+    // This by adding an hidden input when unchecked.
+    $(function () {
+        $('form').find('input:checkbox')
+            .filter(function () {
+                return $(this).data('boolean');
+            })
+            .change(function () {
+                var _this = $(this);
+                var name = _this.prop('name');
+                var next = _this.next('input[type = hidden]')
+                    .filter(function () {
+                        return $(this).prop('name') == name;
+                    });
+
+                if (_this.prop('checked')) {
+                    if (next.length)
+                        next.remove();
+                }
+                else if (!next.length) {
+                    _this.after($('<input>')
+                        .prop('name', name)
+                        .prop('type', 'hidden')
+                        .val('false'));
+                }
+            })
+            .change();
+    });
 })(jQuery);
 
 ///////////////////////////////////////////////////////////////

--- a/src/Orchard.Web/Modules/Orchard.Forms/Shapes/EditorShapes.cs
+++ b/src/Orchard.Web/Modules/Orchard.Forms/Shapes/EditorShapes.cs
@@ -282,7 +282,12 @@ namespace Orchard.Forms.Shapes {
             }
             if (Value != null) {
                 Value = Value is string ? Value : Display(Value);
-                tag.MergeAttribute("value", Convert.ToString(Value), false);
+                string value = Convert.ToString(Value);
+                tag.MergeAttribute("value", value, false);
+
+                if (Type == "checkbox" && value.ToLower() == "true") {
+                    tag.MergeAttribute("data-boolean", "true");
+                }
             }
             if (Checked.GetValueOrDefault()) {
                 tag.MergeAttribute("checked", "checked");


### PR DESCRIPTION
Fixes #6302 

In some scenarios, as soon as a form checkbox is saved as checked, it can't be saved again as unchecked (layout element editors in dev branch). In other scenarios, this happens if the checkbox is initially checked (e.g workflows activity editors).

this is due to the fact that, when a checkbox is unchecked, no value is sent on form submission.

Here, when a checkbox value is "true", it is marked as "boolean" and, if unchecked, an hidden input is added to send a "false" value on form submission.

Best