### PR TITLE
#6302: forms checkboxes issues in layouts elements editors

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Framework/Drivers/FormsElementDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Framework/Drivers/FormsElementDriver.cs
@@ -78,6 +78,12 @@ namespace Orchard.Layouts.Framework.Drivers {
                 if (value != null) {
                     context.Element.Data[name] = value.AttemptedValue;
                 }
+                else if (formElementShape.Metadata.Type == "Checkbox") {
+                    var shapeValue = formElementShape.Value as string;
+                    if (shapeValue != null && shapeValue.ToLower() == "true") {
+                        context.Element.Data[name] = "false";
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #6302 

1. This only concerns the layouts module in dev, where as soon as a checkbox is saved as checked, it can't be saved again as unchecked (here, whatever the initial state of the checkbox).

2. This doen't solve the same kind of issue that could happen elsewhere, as tried in the worflows module, but here only if a forms checkbox is initially checked (this is not the case right now). For a more general solution, see a possible fix with this PR #6308 that uses some jquery code.

So, right now, these issues are visible only in the layouts module. That's why i propose this PR to fix at least these issues for the layouts module.

Best