### PR TITLE
Treatment null value for params argument inside ImageProfileManager

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
@@ -57,7 +57,8 @@ namespace Orchard.MediaProcessing.Services {
         }
 
         public string GetImageProfileUrl(string path, string profileName, FilterRecord customFilter, ContentItem contentItem) {
-            return GetImageProfileUrl(path, profileName, contentItem, customFilter);
+            var customFilters = customFilter != null ? new FilterRecord[] { customFilter } : null;
+            return GetImageProfileUrl(path, profileName, contentItem, customFilters);
         }
 
         public string GetImageProfileUrl(string path, string profileName, ContentItem contentItem, params FilterRecord[] customFilters) {


### PR DESCRIPTION
Treatment null value for params argument. (When null value of nullable type T is passed as params argument that it will be converted to array of type T with one null member).

Without it Display.MediaUrl(Profile: "ProfileName", Path: "image-path.jpg") which call GetImageProfileUrl with null customFilter doesn't work.