### PR TITLE
New IsBackgroundHttpContext() extension helper.

### DIFF
--- a/src/Orchard/Mvc/Extensions/HttpContextBaseExtensions.cs
+++ b/src/Orchard/Mvc/Extensions/HttpContextBaseExtensions.cs
@@ -6,4 +6,10 @@ namespace Orchard.Mvc.Extensions {
             return httpContextBase == null || httpContextBase is MvcModule.HttpContextPlaceholder;
         }
     }
+
+    public static class HttpContextExtensions {
+        public static bool IsBackgroundHttpContext(this HttpContext httpContext) {
+            return HttpContextAccessor.IsBackgroundHttpContext(httpContext);
+        }
+    }
 }

--- a/src/Orchard/Mvc/HttpContextAccessor.cs
+++ b/src/Orchard/Mvc/HttpContextAccessor.cs
@@ -32,7 +32,7 @@ namespace Orchard.Mvc {
             _httpContext = httpContext;
         }
 
-        private static bool IsBackgroundHttpContext(HttpContext httpContext) {
+        internal static bool IsBackgroundHttpContext(HttpContext httpContext) {
             return httpContext == null || httpContext.Items.Contains(MvcModule.IsBackgroundHttpContextKey);
         }
 


### PR DESCRIPTION
As suggested by @sfmskywalker somewhere in this issue #6321 where he fixed it by using a private method that use the same code as an existing static method. So, he suggested to me to do this extension helper.

We already have the `IsBackgroundContext()` extension to check for a fake `HttpContextBase`. This one is to check for a fake `HttpContext`. Can be useful where `HttpContext.Current` is used directly. Then, for example, we could use this:

    if (HttpContext.Current.IsBackgroundHttpContext()) {

Best.