### PR TITLE
Added PULL_REQUEST_TEMPLATE.md and ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+**Expected behavior and actual behavior:** 
+
+
+**Steps to reproduce the problem:** 
+
+
+**Specifications like the version of the project, browser, etc:**
+
+
+**I've ensured that:**
+
+- [ ] The issue has not already been raised on GitHub
+- [ ] The issue has not already been resolved on the latest version of dev branch

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+**Adds/Fixes Issue #** 
+
+**Changes made:** 
+
+**I've ensured that:**
+
+- [ ] Coding standards are correct (formatting, naming, braces, etc...)
+- [ ] There are no unused references, classes, declarations etc...
+- [ ] Tests have been added (where applicable)
+- [ ] I've thoroughly tested the changes myself before raising this PR
+- [ ] I am raising this PR against the appropriate branch


### PR DESCRIPTION
GitHub recently added the ability to specify Pull Request and/or Issue templates, to guide contributors on specifying details with their submissions. This is a proposed template using this new feature.

**Feature details:** https://github.com/blog/2111-issue-and-pull-request-templates
**Documentation:** https://help.github.com/articles/creating-an-issue-template-for-your-repository/