### PR TITLE
Fixes #5907 convert modules admin page to use css flexbox

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Modules/styles/orchard-modules-admin.css
+++ b/src/Orchard.Web/Modules/Orchard.Modules/styles/orchard-modules-admin.css
@@ -6,18 +6,21 @@ html.dyn #main ul.features button { display:none; }
 .features.detail-view .category > ul {
     border:1px solid #EAEAEA;
     margin-bottom:2em;
+	display: flex;
+	flex-direction: column;
 }
 .features.summary-view .category {
-    overflow:hidden;
     padding-bottom:1em;
 }
+
+.features.summary-view .category > ul {
+	display: flex;
+	flex-wrap: wrap;
+}
+
 .features.summary-view .feature {
     border:1px solid #EAEAEA;
-    display:block;
-    float:left;
-    height:6em;
     margin:0 .5% 1% .5%;
-    position:relative;
     width:32%;
 }
 


### PR DESCRIPTION
Fixes #5907 convert modules admin page to use css flexbox

Summary view now stretches when needed on a per row basis and keeps alignment:

![image](https://cloud.githubusercontent.com/assets/1038062/13163968/5cd43352-d6a9-11e5-8b3d-6e689d9d447d.png)

Previously "Depends on" would be cut off for long lists like Blogs.

Detail view is converted to column flexbox as well:

![image](https://cloud.githubusercontent.com/assets/1038062/13163982/8e1c5dd6-d6a9-11e5-884a-dfaa925159f9.png)

I artificially inflated the Blog dependencies to confirm that it expands correctly.
