### PR TITLE
fix display glitch in admin packaging/gallery/modules

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Packaging/Styles/orchard-packaging-admin.css
+++ b/src/Orchard.Web/Modules/Orchard.Packaging/Styles/orchard-packaging-admin.css
@@ -11,7 +11,7 @@
     float:left;
 }
 .extensionName.installed {
-    background: url("images/installed.gif") no-repeat 0px 8px #fff;
+    background: url("images/installed.gif") no-repeat 0px 8px;
     padding:0 0 0 60px;
 }
 .contentItems .related {


### PR DESCRIPTION
Previously when it was on an alt bg colour or mouse hover you could see the background:

![image](https://cloud.githubusercontent.com/assets/1038062/13164305/181c7172-d6ac-11e5-8e52-935e8bed6713.png)

This fixes it so that it displays like this:

![image](https://cloud.githubusercontent.com/assets/1038062/13164313/237f53ae-d6ac-11e5-8159-25dfce9176cc.png)
