### PR TITLE
fixes #5706 - standardize order on Properties, Validation, Bindings

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/BindingsElementDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/BindingsElementDriver.cs
@@ -37,7 +37,7 @@ namespace Orchard.DynamicForms.Drivers {
 
             var bindingsEditor = context.ShapeFactory.EditorTemplate(TemplateName: "FormBindings", Model: viewModel);
 
-            bindingsEditor.Metadata.Position = "Bindings:10";
+            bindingsEditor.Metadata.Position = "Bindings:20";
             
             return Editor(context, bindingsEditor);
         }


### PR DESCRIPTION
fixes #5706 - standardize order on Properties, Validation, Bindings

previously validation and bindings tabs sometimes switched places

I checked every ootb form element and they all show the correct order with this change