### PR TITLE
[Fixes #6430] Removes Imageset for Orchard.Alias UI

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Alias/AdminMenu.cs
+++ b/src/Orchard.Web/Modules/Orchard.Alias/AdminMenu.cs
@@ -11,7 +11,6 @@ namespace Orchard.Alias {
         public string MenuName { get { return "admin"; } }
 
         public void GetNavigation(NavigationBuilder builder) {
-            builder.AddImageSet("aliases");
             builder.Add(T("Aliases"), "1.4.1", menu => {
                 menu.LinkToFirstChild(true);
 


### PR DESCRIPTION
This removes the broken file reference for stylesheet `/Themes/TheAdmin/styles/menu.aliases-admin.css` generated by the Orchard.Alias UI feature.