### PR TITLE
[Fixes #6454] Sets the height of the media library correctly

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Styles/orchard-medialibrary-admin.css
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Styles/orchard-medialibrary-admin.css
@@ -1,5 +1,5 @@
 .zone-content, #content, #main, #layout-content, #layout-main {
-    height: 100%;
+    height: auto;
     display: block;
     min-height: 400px;
     margin-bottom: 0;


### PR DESCRIPTION
Sets the height of the media library container to the height of the content (with padding)