### PR TITLE
Fixes Layout OnIndexing when using a snippet element

### DIFF
--- a/src/Orchard/DisplayManagement/Implementation/DefaultDisplayManager.cs
+++ b/src/Orchard/DisplayManagement/Implementation/DefaultDisplayManager.cs
@@ -11,7 +11,6 @@ using Orchard.DisplayManagement.Shapes;
 using Orchard.Localization;
 using Orchard.Logging;
 using Orchard.Mvc;
-using Orchard.Mvc.Extensions;
 
 namespace Orchard.DisplayManagement.Implementation {
     public class DefaultDisplayManager : IDisplayManager {
@@ -62,7 +61,9 @@ namespace Orchard.DisplayManagement.Implementation {
                 return CoerceHtmlString(context.Value);
 
             var workContext = _workContextAccessor.GetContext();
-            var shapeTable = !_httpContextAccessor.Current().IsBackgroundContext()
+            // CurrentTheme is now available in the background, so here we no longer use IsBackgroundContext().
+            // We only do a null check, so we can render in the background a view that only exists in the theme.
+            var shapeTable = _httpContextAccessor.Current() != null
                 ? _shapeTableLocator.Value.Lookup(workContext.CurrentTheme.Id)
                 : _shapeTableLocator.Value.Lookup(null);
 


### PR DESCRIPTION
Notice that this is already done in `ContentDisplayBase.cs`. But when using a snippet element, the same update needs to be done in `DefaultDisplayManager`.

Because we provide a fake context in the background, sometimes we have to replace `HttpContext != null` with `!HttpContext.IsBackgroundContext()` when it doesn't make sense to do anything.

Here we have to do the opposite to retrieve the `CurrentTheme` needed to find the snippet razor view. So, i've replaced `IsBackgroundContext()` with `!= null`. Notice that the null check may be useless, but i keep it as done in `ContentDisplayBase.cs`.

Best.