### PR TITLE
Incorrect data being returned for nonexistent primitive datatypes

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Redis/Caching/RedisCacheStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.Redis/Caching/RedisCacheStorageProvider.cs
@@ -38,7 +38,7 @@ namespace Orchard.Redis.Caching {
         public object Get<T>(string key) {
             var json = Database.StringGet(GetLocalizedKey(key));
             if(String.IsNullOrEmpty(json)) {
-                return default(T);
+                return null;
             }
             return JsonConvert.DeserializeObject<T>(json);
         }


### PR DESCRIPTION
default(T) returns non null value for primitive datatypes, this causes `CachingExtensions.Get<T>` never to call the factory method.