### PR TITLE
Replaces #6535 to target 1.10: Issue with TextField default values

### DIFF
--- a/src/Orchard.Web/Core/Common/Drivers/TextFieldDriver.cs
+++ b/src/Orchard.Web/Core/Common/Drivers/TextFieldDriver.cs
@@ -72,6 +72,7 @@ namespace Orchard.Core.Common.Drivers {
                                         () => shapeHelper.EditorTemplate(TemplateName: "Fields.Common.Text.Edit", Model: viewModel, Prefix: GetPrefix(field, part)));
                 }
 
+                field.Value = viewModel.Text;
                 var settings = field.PartFieldDefinition.Settings.GetModel<TextFieldSettings>();
 
                 if (String.IsNullOrEmpty(field.Value) && !String.IsNullOrEmpty(settings.DefaultValue)) {

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/TextFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/TextFieldDriver.cs
@@ -19,7 +19,7 @@ namespace Orchard.Fields.Drivers {
         protected override DriverResult Editor(ContentPart part, TextField field, IUpdateModel updater, dynamic shapeHelper) {
             var settings = field.PartFieldDefinition.Settings.GetModel<TextFieldSettings>();
 
-            if (String.IsNullOrEmpty(field.Value) && !String.IsNullOrEmpty(settings.DefaultValue)) {
+            if (!String.IsNullOrEmpty(settings.DefaultValue) && (String.IsNullOrEmpty(field.Value) || field.Value.Equals(settings.DefaultValue))) {
                 field.Value = _tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } });
             }
 


### PR DESCRIPTION
Replaces #6535 to target 1.10.

**Issues**

1. **When you 1st create** e.g a page that has a text field that has a default value. If you input a non empty string and publish, then the default value is used (not your input). The 2nd time it's ok.

2. Idem but leaving the input empty, then the default value is used, ok, but if it's a token, the token itself is returned, it is not resolved. The 2nd time it's ok.

3. If i only fix 1. (see below), then the default value is never tokenized.

Note: To allow default values tokenization, a 2nd `TextField` driver has been added  in `Orchard.Fields`.

**Fixes**

1. In the original driver i've re-integrated `field.Value = viewModel.Text;`.

2. In the 2nd driver, if the default is not null and the value is equals to the default, then the default is tokenized. if it's not a token, the same value is returned by the tokenizer.

Best.