### PR TITLE
Fix 2 multitenant specflows issues on nightly build 1.9.x

### DIFF
--- a/src/Orchard.Specs/MultiTenancy.feature
+++ b/src/Orchard.Specs/MultiTenancy.feature
@@ -25,6 +25,7 @@ Scenario: A new tenant is created
         And I fill in 
             | name | value |
             | Name | Scott |
+            | RequestUrlPrefix | scott |
         And I hit "Save"
         And I am redirected
     Then I should see "<h3>Scott\s*</h3>"
@@ -37,6 +38,7 @@ Scenario: A new tenant is created with uninitialized state
         And I fill in 
             | name | value |
             | Name | Scott |
+            | RequestUrlPrefix | scott |
         And I hit "Save"
         And I am redirected
     Then I should see "<li class="tenant Uninitialized">"

--- a/src/Orchard.Specs/MultiTenancy.feature.cs
+++ b/src/Orchard.Specs/MultiTenancy.feature.cs
@@ -129,6 +129,9 @@ this.ScenarioSetup(scenarioInfo);
             table1.AddRow(new string[] {
                         "Name",
                         "Scott"});
+            table1.AddRow(new string[] {
+                        "RequestUrlPrefix",
+                        "scott"});
 #line 25
         testRunner.And("I fill in", ((string)(null)), table1, "And ");
 #line 28
@@ -163,6 +166,9 @@ this.ScenarioSetup(scenarioInfo);
             table2.AddRow(new string[] {
                         "Name",
                         "Scott"});
+            table2.AddRow(new string[] {
+                        "RequestUrlPrefix",
+                        "scott"});
 #line 37
         testRunner.And("I fill in", ((string)(null)), table2, "And ");
 #line 40


### PR DESCRIPTION
Since 1b8bcb8 where a host OR prefix is required when creating a tenant.

Notice that i've tested it on the dev branch but by applying the above commit. Then, indeed `ANewTenantIsCreated` and `ANewTenantIsCreatedWithUninitializedState` was failing.

After applying this fix, the 2 above specs passed.

Here, i've manually changed the Feature file and it's related Feature.cs file. Would i have had to use a tool to generate this file?

Best