### PR TITLE
Adding correct ETag support

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Models/CacheItem.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Models/CacheItem.cs
@@ -4,7 +4,7 @@ namespace Orchard.OutputCache.Models {
     [Serializable]
     public class CacheItem {
         // used for serialization compatibility
-        public static readonly string Version = "1";
+        public static readonly string Version = "2";
 
         public DateTime CachedOnUtc { get; set; }
         public int Duration { get; set; }
@@ -18,6 +18,7 @@ namespace Orchard.OutputCache.Models {
         public string Tenant { get; set; }
         public int StatusCode { get; set; }
         public string[] Tags { get; set; }
+        public string ETag { get; set; }
 
         public int ValidFor {
             get { return Duration; }

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultCacheStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultCacheStorageProvider.cs
@@ -16,6 +16,7 @@ namespace Orchard.OutputCache.Services {
         }
 
         public void Set(string key, CacheItem cacheItem) {
+            _workContext.HttpContext.Cache.Remove(key);
             _workContext.HttpContext.Cache.Add(
                 key,
                 cacheItem,


### PR DESCRIPTION
When an HTTP client contains a page locally and requests the same url again, it sends and `ETag` which is an identifier for the content of the page, with the request. If the server knows that the content hasn't changed, it can answer with `304` and no content. The goal is that there is not useless traffic between the server and the client.

Testing the feature:
- Send a request to any url
- Ensure the response contains a specific `ETag` header
- Send the same request, its headers should have a `If-None-Match: [ETAGVALUE]`
- The result should be coming from the cache, as a 304, with the same `ETag` header, and no body
- Send a `no-cache` request (CTRL+F5), the result should have a different `ETag`, and the full body

/cc @DanielStolt @Piedone for review