### PR TITLE
Improving output cache performance

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -122,7 +122,7 @@ namespace Orchard.OutputCache.Filters {
 
                     Logger.Debug("Item '{0}' was found in cache.", _cacheKey);
                     
-                    if(cacheItem.IsValid(_now)) {
+                    if (cacheItem.IsValid(_now)) {
                         Logger.Debug("Cached item is valid: {0}", _cacheKey);
                         ServeCachedItem(filterContext, cacheItem);
                         return;
@@ -131,7 +131,7 @@ namespace Orchard.OutputCache.Filters {
                         Logger.Debug("Cached item is invalid: {0}", _cacheKey);
 
                         // If the cached item is in its grace period 
-                        // and there are no current renderer, this request renders the new content
+                        // and there is no current renderer, this request renders the new content.
                         if (cacheItem.IsInGracePeriod(_now) &&
                             !_state.Renderers.ContainsKey(_cacheKey)) {
                             Logger.Debug("Item '{0}' is in grace period and not currently being rendered; rendering item...", _cacheKey);

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Orchard.OutputCache.csproj
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Orchard.OutputCache.csproj
@@ -115,11 +115,13 @@
     <Compile Include="Services\DefaultTagCache.cs" />
     <Compile Include="Services\ICacheControlStrategy.cs" />
     <Compile Include="Services\IDisplayedContentItemHandler.cs" />
+    <Compile Include="Services\IOutputCacheFilterState.cs" />
     <Compile Include="Services\ITagCache.cs" />
     <Compile Include="Services\DefaultCacheStorageProvider.cs" />
     <Compile Include="Services\ICacheService.cs" />
     <Compile Include="Services\IOutputCacheStorageProvider.cs" />
     <Compile Include="Models\CacheSettings.cs" />
+    <Compile Include="Services\OutputCacheFilterState.cs" />
     <Compile Include="ViewModels\StatisticsViewModel.cs" />
     <Compile Include="ViewModels\IndexViewModel.cs" />
     <Compile Include="Models\CacheRouteConfig.cs" />

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Services/CacheService.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Services/CacheService.cs
@@ -99,7 +99,7 @@ namespace Orchard.OutputCache.Services {
         }
 
         public IEnumerable<CacheRouteConfig> GetRouteConfigs() {
-            return _cacheManager.Get(RouteConfigsCacheKey, true,
+            return _cacheManager.Get(RouteConfigsCacheKey,
                 ctx => {
                     ctx.Monitor(_signals.When(RouteConfigsCacheKey));
                     return _repository.Fetch(c => true).Select(c => new CacheRouteConfig { RouteKey = c.RouteKey, Duration = c.Duration, GraceTime = c.GraceTime }).ToReadOnlyCollection();

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultCacheStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultCacheStorageProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Orchard.OutputCache.Models;
 using Orchard.Environment.Configuration;
+using Orchard.Logging;
 
 namespace Orchard.OutputCache.Services {
     public class DefaultCacheStorageProvider : IOutputCacheStorageProvider {
@@ -15,7 +16,11 @@ namespace Orchard.OutputCache.Services {
             _tenantName = shellSettings.Name;
         }
 
+        public ILogger Logger { get; set; }
+         
         public void Set(string key, CacheItem cacheItem) {
+            Logger.Debug("Set {0}", key);
+
             _workContext.HttpContext.Cache.Remove(key);
             _workContext.HttpContext.Cache.Add(
                 key,
@@ -28,10 +33,14 @@ namespace Orchard.OutputCache.Services {
         }
 
         public void Remove(string key) {
+            Logger.Debug("Remove {0}", key);
+
             _workContext.HttpContext.Cache.Remove(key);
         }
 
         public void RemoveAll() {
+            Logger.Debug("RemoveAll");
+
             var items = GetCacheItems(0, 100).ToList();
             while (items.Any()) {
                 foreach (var item in items) {
@@ -42,10 +51,14 @@ namespace Orchard.OutputCache.Services {
         }
 
         public CacheItem GetCacheItem(string key) {
+            Logger.Debug("GetCacheItem {0}", key);
+
             return _workContext.HttpContext.Cache.Get(key) as CacheItem;
         }
 
         public IEnumerable<CacheItem> GetCacheItems(int skip, int count) {
+            Logger.Debug("GetCacheItems");
+
             // the ASP.NET cache can also contain other types of items
             return _workContext.HttpContext.Cache.AsParallel()
                         .Cast<DictionaryEntry>()
@@ -57,6 +70,8 @@ namespace Orchard.OutputCache.Services {
         }
 
         public int GetCacheItemsCount() {
+            Logger.Debug("GetCacheItemsCount");
+
             return _workContext.HttpContext.Cache.AsParallel()
                         .Cast<DictionaryEntry>()
                         .Select(x => x.Value)

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Services/IOutputCacheFilterState.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Services/IOutputCacheFilterState.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Orchard.OutputCache.Models;
+
+namespace Orchard.OutputCache.Services {
+    public interface IOutputCacheFilterState : ISingletonDependency {
+        
+        /// <summary>
+        /// Tasks that are currently rendering pages
+        /// </summary>
+        ConcurrentDictionary<string, TaskCompletionSource<CacheItem>> Renderers { get; }
+
+        /// <summary>
+        /// Tasks that are currently retrieving cached items
+        /// </summary>
+        ConcurrentDictionary<string, TaskCompletionSource<CacheItem>> Cachers { get; }
+
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Services/OutputCacheFilterState.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Services/OutputCacheFilterState.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Orchard.OutputCache.Models;
+
+namespace Orchard.OutputCache.Services {
+    public class OutputCacheFilterState : IOutputCacheFilterState {
+        public OutputCacheFilterState() {
+            Cachers = new ConcurrentDictionary<string, TaskCompletionSource<CacheItem>>();
+            Renderers = new ConcurrentDictionary<string, TaskCompletionSource<CacheItem>>();
+        }
+
+        public ConcurrentDictionary<string, TaskCompletionSource<CacheItem>> Cachers { get; private set; }
+
+        public ConcurrentDictionary<string, TaskCompletionSource<CacheItem>> Renderers { get; private set; }
+    }
+}


### PR DESCRIPTION
- Preventing multiple requests from requesting the same cache item concurrently
- Using TaskCompletionSource to synchronize workers instead of locks