### PR TITLE
#6550: no required on client side if default value is set (NumericField)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
@@ -64,47 +64,41 @@ namespace Orchard.Fields.Drivers {
 
                 var settings = field.PartFieldDefinition.Settings.GetModel<NumericFieldSettings>();
 
-                if (settings.Required && String.IsNullOrWhiteSpace(viewModel.Value)) {
-                    updater.AddModelError(GetPrefix(field, part), T("The field {0} is mandatory.", T(field.DisplayName)));
+                if (String.IsNullOrWhiteSpace(viewModel.Value) && !String.IsNullOrEmpty(settings.DefaultValue)) {
+                    viewModel.Value = _tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } });
                 }
 
-                if (!settings.Required && String.IsNullOrWhiteSpace(viewModel.Value)) {
-                    if (settings.DefaultValue != null) {
-                        if (Decimal.TryParse(_tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } }), NumberStyles.Any, _cultureInfo.Value, out value)
-                            && Math.Round(value, settings.Scale) == value
-                            && !String.IsNullOrEmpty(settings.DefaultValue)) {
-                            field.Value = value;
-                        }
-                    }
-                    else {
-                        field.Value = null;
+                field.Value = null;
+
+                if (String.IsNullOrWhiteSpace(viewModel.Value)) {
+                    if (settings.Required) {
+                        updater.AddModelError(GetPrefix(field, part), T("The field {0} is mandatory.", T(field.DisplayName)));
                     }
                 }
-                else if (Decimal.TryParse(viewModel.Value, NumberStyles.Any, _cultureInfo.Value, out value)) { 
-                    field.Value = value;
+                else if (!Decimal.TryParse(viewModel.Value, NumberStyles.Any, _cultureInfo.Value, out value)) {
+                    updater.AddModelError(GetPrefix(field, part), T("{0} or its default value is an invalid number", field.DisplayName));
                 }
                 else {
-                    updater.AddModelError(GetPrefix(field, part), T("{0} is an invalid number", field.DisplayName));
-                    field.Value = null;
-                }
 
-                if (settings.Minimum.HasValue && field.Value.HasValue && field.Value.Value < settings.Minimum.Value) {
-                    updater.AddModelError(GetPrefix(field, part), T("The value must be greater than {0}", settings.Minimum.Value));
-                }
+                    field.Value = value;
 
-                if (settings.Maximum.HasValue && field.Value.HasValue && field.Value.Value > settings.Maximum.Value) {
-                    updater.AddModelError(GetPrefix(field, part), T("The value must be less than {0}", settings.Maximum.Value));
-                }
-
-                // checking the number of decimals
-                if(field.Value.HasValue && Math.Round(field.Value.Value, settings.Scale) != field.Value.Value) {
-                    if(settings.Scale == 0) {
-                        updater.AddModelError(GetPrefix(field, part), T("The field {0} must be an integer", field.DisplayName));    
+                    if (settings.Minimum.HasValue && value < settings.Minimum.Value) {
+                        updater.AddModelError(GetPrefix(field, part), T("The value must be greater than {0}", settings.Minimum.Value));
                     }
-                    else {
-                        updater.AddModelError(GetPrefix(field, part), T("Invalid number of digits for {0}, max allowed: {1}", field.DisplayName, settings.Scale));
+
+                    if (settings.Maximum.HasValue && value > settings.Maximum.Value) {
+                        updater.AddModelError(GetPrefix(field, part), T("The value must be less than {0}", settings.Maximum.Value));
                     }
-                    
+
+                    // checking the number of decimals
+                    if (Math.Round(value, settings.Scale) != value) {
+                        if (settings.Scale == 0) {
+                            updater.AddModelError(GetPrefix(field, part), T("The field {0} must be an integer", field.DisplayName));
+                        }
+                        else {
+                            updater.AddModelError(GetPrefix(field, part), T("Invalid number of digits for {0}, max allowed: {1}", field.DisplayName, settings.Scale));
+                        }
+                    }
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Numeric.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Numeric.Edit.cshtml
@@ -1,15 +1,32 @@
-﻿@model Orchard.Fields.ViewModels.NumericFieldViewModel
+@model Orchard.Fields.ViewModels.NumericFieldViewModel
 @using System.Globalization
 @using Orchard.Fields.Settings;
 
+@{
+    var isRequired = Model.Settings.Required && String.IsNullOrEmpty(Model.Settings.DefaultValue);
+    var hasValue = !String.IsNullOrEmpty(Model.Value);
+
+    var attributes = new Dictionary<string, object>();
+    attributes.Add("class", "text-small"); attributes.Add("type", "text");
+    attributes.Add("min", Model.Settings.Minimum.HasValue ? Model.Settings.Minimum.Value : 0);
+    attributes.Add("max", Model.Settings.Maximum.HasValue ? Model.Settings.Maximum.Value : 1000000);
+    attributes.Add("step", Math.Pow(10, 0 - Model.Settings.Scale).ToString(CultureInfo.InvariantCulture));
+
+    if (isRequired) {
+        attributes.Add("required", "required");
+    }
+
+    if (hasValue) {
+        attributes.Add("Value", Model.Value);
+    }
+}
+
 <fieldset>
-    <label for="@Html.FieldIdFor(m => m.Value)" @if(Model.Settings.Required) { <text>class="required"</text> }>@Model.Field.DisplayName</label>
-    @(Model.Settings.Required 
-	        ? Html.TextBoxFor(m => m.Value, new {@class = "text-small", type = "text", min = (Model.Settings.Minimum.HasValue) ? Model.Settings.Minimum.Value : 0, max = (Model.Settings.Maximum.HasValue) ? Model.Settings.Maximum.Value : 1000000, step = Math.Pow(10, 0 - Model.Settings.Scale).ToString(CultureInfo.InvariantCulture), required = "required"}) 
-	        : Html.TextBoxFor(m => m.Value, new {@class = "text-small", type = "text", min = (Model.Settings.Minimum.HasValue) ? Model.Settings.Minimum.Value : 0, max = (Model.Settings.Maximum.HasValue) ? Model.Settings.Maximum.Value : 1000000, step = Math.Pow(10, 0 - Model.Settings.Scale).ToString(CultureInfo.InvariantCulture)}))
+    <label for="@Html.FieldIdFor(m => m.Value)" @if (Model.Settings.Required) { <text> class="required" </text>    }>@Model.Field.DisplayName</label>
+    @Html.TextBoxFor(m => m.Value, attributes)
     @Html.ValidationMessageFor(m => m.Value)
     @if (HasText(Model.Settings.Hint)) {
-    <span class="hint">@Model.Settings.Hint</span>
+        <span class="hint">@Model.Settings.Hint</span>
     }
     @if (!String.IsNullOrWhiteSpace(Model.Settings.DefaultValue)) {
         <span class="hint">@T("If the field is left empty then the default value will be used.")</span>


### PR DESCRIPTION
Fixes partially #6550. There are quite many things to check here. If ok, i'll do it for TextField...

I first thought it was not so useful because we can say to just uncheck the required option. But see below.

- If required and a default value: no required on client, still with the red star, and still required on server.
- If a default value is used, control and conversion are done by the same code, as for an user input.
- When a default value is a valid number but not validated (limits / scale), it's value is seen on the postback view. This by using in the view a `Value` attribute. Let me know if you think it's ok.
- But, as before, if the default value is not a valid number, there is no direct way to show it on the postback view. So, i've adapted the error message: `{0} or its default value is an invalid number`.

**Note**: The Numeric.Feature spec pass.

Best