### PR TITLE
#6550: no required on client side if default value is set (TextField)

### DIFF
--- a/src/Orchard.Web/Core/Common/Drivers/TextFieldDriver.cs
+++ b/src/Orchard.Web/Core/Common/Drivers/TextFieldDriver.cs
@@ -58,28 +58,20 @@ namespace Orchard.Core.Common.Drivers {
 
         protected override DriverResult Editor(ContentPart part, TextField field, IUpdateModel updater, dynamic shapeHelper) {
 
-            var viewModel = new TextFieldDriverViewModel {
-                Field = field,
-                Text = field.Value,
-                Settings = field.PartFieldDefinition.Settings.GetModel<TextFieldSettings>(),
-                ContentItem = part.ContentItem
-            };
+            var viewModel = new TextFieldDriverViewModel();
 
             if (updater.TryUpdateModel(viewModel, GetPrefix(field, part), null, null)) {
-                if (viewModel.Settings.Required && string.IsNullOrWhiteSpace(viewModel.Text)) {
-                    updater.AddModelError("Text", T("The field {0} is mandatory", T(field.DisplayName)));
-                    return ContentShape("Fields_Common_Text_Edit", GetDifferentiator(field, part),
-                                        () => shapeHelper.EditorTemplate(TemplateName: "Fields.Common.Text.Edit", Model: viewModel, Prefix: GetPrefix(field, part)));
+
+                var settings = field.PartFieldDefinition.Settings.GetModel<TextFieldSettings>();
+
+                if (String.IsNullOrWhiteSpace(viewModel.Text) && !String.IsNullOrEmpty(settings.DefaultValue)) {
+                    viewModel.Text = settings.DefaultValue;
                 }
 
                 field.Value = viewModel.Text;
-                var settings = field.PartFieldDefinition.Settings.GetModel<TextFieldSettings>();
 
-                if (String.IsNullOrEmpty(field.Value) && !String.IsNullOrEmpty(settings.DefaultValue)) {
-                    field.Value = settings.DefaultValue;
-                }
-                else {
-                    field.Value = viewModel.Text;
+                if (String.IsNullOrWhiteSpace(field.Value) && settings.Required) {
+                    updater.AddModelError(GetPrefix(field, part), T("The field {0} is mandatory.", T(field.DisplayName)));
                 }
             }
 

--- a/src/Orchard.Web/Core/Common/Views/EditorTemplates/Fields.Common.Text.Edit.cshtml
+++ b/src/Orchard.Web/Core/Common/Views/EditorTemplates/Fields.Common.Text.Edit.cshtml
@@ -1,16 +1,18 @@
-﻿@model Orchard.Core.Common.ViewModels.TextFieldDriverViewModel
-
+@model Orchard.Core.Common.ViewModels.TextFieldDriverViewModel
+@{ 
+    var isRequired = Model.Settings.Required && String.IsNullOrEmpty(Model.Settings.DefaultValue);
+}
 <fieldset>
-    <label for="@Html.FieldIdFor(m => m.Text)" @if(Model.Settings.Required) { <text>class="required"</text> }>@Model.Field.DisplayName</label>
+    <label for="@Html.FieldIdFor(m => m.Text)" @if (Model.Settings.Required) { <text> class="required" </text>   }>@Model.Field.DisplayName</label>
     @if (String.IsNullOrWhiteSpace(Model.Settings.Flavor)) {
-        @(Model.Settings.Required ? Html.TextBoxFor(m => m.Text, new {@class = "text", required = "required"}) : Html.TextBoxFor(m => m.Text, new {@class = "text"}))
+        @(isRequired ? Html.TextBoxFor(m => m.Text, new { @class = "text", required = "required" }) : Html.TextBoxFor(m => m.Text, new { @class = "text" }))
         @Html.ValidationMessageFor(m => m.Text)
     }
     else {
-       @Display.Body_Editor(Text: Model.Text, EditorFlavor: Model.Settings.Flavor, Required: Model.Settings.Required, ContentItem: Model.ContentItem)
+        @Display.Body_Editor(Text: Model.Text, EditorFlavor: Model.Settings.Flavor, Required: isRequired, ContentItem: Model.ContentItem)
     }
     @if (HasText(Model.Settings.Hint)) {
-    <span class="hint">@Model.Settings.Hint</span>
+        <span class="hint">@Model.Settings.Hint</span>
     }
     @if (!String.IsNullOrWhiteSpace(Model.Settings.DefaultValue)) {
         <span class="hint">@T("If the field is left empty then the default value will be used.")</span>


### PR DESCRIPTION
Fixes partially #6550. Sorry for doing this field by field but maybe easier to check all options and talk about special cases.

- I first thought it was not so useful because we can just say to uncheck the required option. But here, if required and a default value is set, then no required on client side, but still with the required class to have the red star, and still required on server side.

- **Special case**: The default value is tokenized in a 2nd driver and the result can be empty. So, do you think it's worth to check the required option also in this 2nd driver?

Best