### PR TITLE
#6550: no required on client side if default value is set (InputField)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/InputFieldSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/InputFieldSettings.cshtml
@@ -81,7 +81,7 @@
     <div>
         <label for="@Html.FieldIdFor(m => m.DefaultValue)">@T("Default value")</label>
         @Html.TextBoxFor(m => m.DefaultValue, new { @class = "text large tokenized ui-autocomplete-input" })
-        <span class="hint">@T("A valid url as a default value, i.e. http://orchardproject.net, /content/file.pdf ... You can use tokens in this field. (optional)")</span>
+        <span class="hint">@T("Default value for the field. You can use tokens in this field. If there is no value given for the actual field, this will be filled in. (optional)")</span>
         @Html.ValidationMessageFor(m => m.DefaultValue)
     </div>
 </fieldset>

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Input.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Input.Edit.cshtml
@@ -1,12 +1,13 @@
-﻿@model Orchard.Fields.Fields.InputField
+@model Orchard.Fields.Fields.InputField
 @using Orchard.Utility.Extensions;
 @using Orchard.Fields.Settings;
 @{
     var settings = Model.PartFieldDefinition.Settings.GetModel<InputFieldSettings>();
+    var isRequired = settings.Required && String.IsNullOrEmpty(settings.DefaultValue);
 }
 <fieldset>
     <label for="@Html.FieldIdFor(m => m.Value)" @if(settings.Required) { <text>class="required"</text> }>@Model.DisplayName</label>
-    <input type="@settings.Type.ToString().ToLower()" id="@Html.FieldIdFor(m => m.Value)" name="@Html.FieldNameFor(m => m.Value)"@if(!String.IsNullOrWhiteSpace(settings.Title)) {<text> title="@settings.Title"</text>} value="@Model.Value"@if(settings.Required) {<text> required="required"</text> }@if(settings.AutoFocus) {<text> autofocus="autofocus"</text> }@if(settings.AutoComplete) {<text> autocomplete="on"</text> }@if(!string.IsNullOrWhiteSpace(settings.Placeholder)) {<text> placeholder="@settings.Placeholder"</text>}@if(!string.IsNullOrEmpty(settings.Pattern)) {<text> pattern="@settings.Pattern"</text>}@if(!string.IsNullOrEmpty(settings.EditorCssClass)) {<text> class="@settings.EditorCssClass"</text>} else {<text> class="text medium"</text>} @if(settings.MaxLength > 1) {<text> maxlength="@settings.MaxLength.ToString()"</text>} />
+    <input type="@settings.Type.ToString().ToLower()" id="@Html.FieldIdFor(m => m.Value)" name="@Html.FieldNameFor(m => m.Value)"@if(!String.IsNullOrWhiteSpace(settings.Title)) {<text> title="@settings.Title"</text>} value="@Model.Value"@if(isRequired) {<text> required="required"</text> }@if(settings.AutoFocus) {<text> autofocus="autofocus"</text> }@if(settings.AutoComplete) {<text> autocomplete="on"</text> }@if(!string.IsNullOrWhiteSpace(settings.Placeholder)) {<text> placeholder="@settings.Placeholder"</text>}@if(!string.IsNullOrEmpty(settings.Pattern)) {<text> pattern="@settings.Pattern"</text>}@if(!string.IsNullOrEmpty(settings.EditorCssClass)) {<text> class="@settings.EditorCssClass"</text>} else {<text> class="text medium"</text>} @if(settings.MaxLength > 1) {<text> maxlength="@settings.MaxLength.ToString()"</text>} />
     @Html.ValidationMessageFor(m => m.Value)
     @if (HasText(settings.Hint)) {
     <span class="hint">@settings.Hint</span>


### PR DESCRIPTION
Fixes partially #6550.

- Here, no need to change the InputFieldDriver.
- Just remove client required attribute (not the class) if a default value is set.
- And correct an hint text in the input field settings editor

Best