### PR TITLE
#6550: no required on client side if default value is set (LinkField)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Link.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Link.Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@model Orchard.Fields.Fields.LinkField
+@model Orchard.Fields.Fields.LinkField
 @using Orchard.Fields.Settings;
 @{
     var settings = Model.PartFieldDefinition.Settings.GetModel<LinkFieldSettings>();
@@ -13,7 +13,10 @@
         case TargetMode.Top:
             target = "_top";
             break;
-	}
+    }
+
+    var isRequired = settings.Required && String.IsNullOrEmpty(settings.DefaultValue);
+    var isTextRequired = settings.LinkTextMode == LinkTextMode.Required && String.IsNullOrEmpty(settings.TextDefaultValue);
 }
 <fieldset>
     <label for="@Html.FieldIdFor(m => m.Value)">@Model.DisplayName</label>
@@ -24,7 +27,7 @@
         <label for="@Html.FieldIdFor(m => m.Value)" @if(settings.Required) { <text>class="required"</text> }>@T("Url")</label>
     </div>
     <div class="editor-field">
-        @Html.TextBoxFor(m => m.Value, new { @class = "text large" })
+        @(isRequired ? Html.TextBoxFor(m => m.Value, new { @class = "text large", required = "required" }) : Html.TextBoxFor(m => m.Value, new { @class = "text large" }))
         <span class="hint">@T("A valid url, i.e. http://orchardproject.net, /content/file.pdf, ...")</span>
     </div>
     @if (!String.IsNullOrWhiteSpace(settings.DefaultValue)) {
@@ -35,7 +38,7 @@
             <label for="@Html.FieldIdFor(m => m.Text)" @if(settings.LinkTextMode == LinkTextMode.Required) { <text>class="required"</text> }>@T("Text")</label>
         </div>
         <div class="editor-field">
-            @Html.TextBoxFor(m => m.Text, new { @class = "text medium" })
+            @(isTextRequired ? Html.TextBoxFor(m => m.Text, new { @class = "text medium", required = "required" }) : Html.TextBoxFor(m => m.Text, new { @class = "text medium" }))
             @if (!String.IsNullOrWhiteSpace(settings.TextDefaultValue)) {
                 <span class="hint">@T("If the field is left empty then the default value will be used.")</span>
             }


### PR DESCRIPTION
Fixes partially #6550.

- Here also, no need to change the LinkFieldDriver.
- But here, the client required attribute (not the class) was never used.
- So, this attribute is added to the url and link text inputs, unless a default value is set.

Best