### PR TITLE
#6550: no required on client side if default value is set (EnumerationField)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
@@ -7,6 +7,7 @@ using Orchard.Localization;
 using Orchard.Tokens;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Orchard.Fields.Drivers {
     public class EnumerationFieldDriver : ContentFieldDriver<EnumerationField> {
@@ -52,6 +53,16 @@ namespace Orchard.Fields.Drivers {
         protected override DriverResult Editor(ContentPart part, EnumerationField field, IUpdateModel updater, dynamic shapeHelper) {
             if (updater.TryUpdateModel(field, GetPrefix(field, part), null, null)) {
                 var settings = field.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
+
+                if (field.SelectedValues.Length == 0 && !String.IsNullOrEmpty(settings.DefaultValue) && !String.IsNullOrWhiteSpace(settings.Options)) {
+                    field.Value = _tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } });
+
+                    string[] options = settings.Options.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                    var selectedValues = field.SelectedValues.ToList();
+                    selectedValues.RemoveAll(value => !options.Any(value.Equals));
+                    field.SelectedValues = selectedValues.ToArray();
+                }
+
                 if (settings.Required && field.SelectedValues.Length == 0) {
                     updater.AddModelError(field.Name, T("The field {0} is mandatory", T(field.DisplayName)));
                 }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
@@ -1,30 +1,31 @@
-﻿@model Orchard.Fields.Fields.EnumerationField
+@model Orchard.Fields.Fields.EnumerationField
 @using Orchard.Fields.Settings;
 @{
     var settings = Model.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
     string[] options = (!String.IsNullOrWhiteSpace(settings.Options)) ? settings.Options.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.None) : new string[] { T("Select an option").ToString() };
+    var isRequired = settings.Required && String.IsNullOrEmpty(settings.DefaultValue);
 }
 <fieldset>
     <label for="@Html.FieldIdFor(m => m.Value)" @if(settings.Required) { <text>class="required"</text> }>@Model.DisplayName</label>
     @switch (settings.ListMode) {
         case ListMode.Dropdown:
-            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.Value), settings.Required ? new {required = "required"} : null)
+            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.Value), isRequired ? new {required = "required"} : null)
             break;
         
         case ListMode.Radiobutton:
             foreach (var option in options) {
                 if (string.IsNullOrWhiteSpace(option)) {	
-                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.Value), settings.Required ? new {required = "required"} : null)<i>@T("unset")</i></label>      
+                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.Value), isRequired ? new {required = "required"} : null)<i>@T("unset")</i></label>      
 	            }
                 else {
-                    <label>@Html.RadioButton("Value", option, (option == Model.Value), settings.Required ? new {required = "required"} : null)@option</label>
+                    <label>@Html.RadioButton("Value", option, (option == Model.Value), isRequired ? new {required = "required"} : null)@option</label>
 	            }
             }
             break;
         
         case ListMode.Listbox:
             <input name="@Html.FieldNameFor(m => m.SelectedValues)" type="hidden" />
-            @Html.ListBoxFor(m => m.SelectedValues, new MultiSelectList(options, Model.SelectedValues), settings.Required ? new {required = "required"} : null)
+            @Html.ListBoxFor(m => m.SelectedValues, new MultiSelectList(options, Model.SelectedValues), isRequired ? new {required = "required"} : null)
             break;
 
         case ListMode.Checkbox:
@@ -34,7 +35,7 @@
                         index++;
                         if (!string.IsNullOrWhiteSpace(option)) {
                     <div>
-                        <input type="checkbox" name="@Html.FieldNameFor(m => m.SelectedValues)" value="@option" @((Model.SelectedValues != null && Model.SelectedValues.Contains(option)) ? "checked=\"checked\"" : "") class="check-box" id="@Html.FieldIdFor(m => m.SelectedValues)-@index" @if(settings.Required) {<text> required="required"</text> } />
+                        <input type="checkbox" name="@Html.FieldNameFor(m => m.SelectedValues)" value="@option" @((Model.SelectedValues != null && Model.SelectedValues.Contains(option)) ? "checked=\"checked\"" : "") class="check-box" id="@Html.FieldIdFor(m => m.SelectedValues)-@index" />
 	                    <label class="forcheckbox" for="@Html.FieldIdFor(m => m.SelectedValues)-@index">@T(option)</label>
                     </div>
                         }
@@ -45,5 +46,8 @@
     @Html.ValidationMessageFor(m => m.SelectedValues)
     @if (HasText(settings.Hint)) {
     <span class="hint">@settings.Hint</span>
+    }
+    @if (!String.IsNullOrWhiteSpace(settings.DefaultValue)) {
+        <span class="hint">@T("If no option is selected then the default value will be used.")</span>
     }
 </fieldset>


### PR DESCRIPTION
Fixes partially #6550. Sorry, more things to check here.

Unlike other fields, here the default value was not used in the Editor method that updates the model but in the other one, this on first creation to have a predefined value. Let me know if we need this  predefined values on other fields, or if we have to remove it here, or if it's case by case. Right now, i left it.

- Anyway, i also use the default value in the editor method that update the model, as with other fields. Then, when another submission happens with no selected option, we can re-use the default value (even it has been changed in the settings). And this before the required checking on server side.

- Before the required checking, I also needed to retain only the current valid options that are in the default value.

- As with other fields, I've added an hint message `If no option is selected then the default value will be used.`.

- I've removed the client required attributes if the options list uses checkboxes, because, if required and no default value set, you would be forced to check all checkboxes. Required checking is still done on server side.

Best