### PR TITLE
#6550: no required on client side if default value is set (DateTimeField)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
@@ -133,7 +133,12 @@ namespace Orchard.Fields.Drivers {
                 var showTime = settings.Display == DateTimeFieldDisplays.DateAndTime || settings.Display == DateTimeFieldDisplays.TimeOnly;
 
                 if (settings.Required && ((showDate && String.IsNullOrWhiteSpace(viewModel.Editor.Date)) || (showTime && String.IsNullOrWhiteSpace(viewModel.Editor.Time)))) {
-                    updater.AddModelError(GetPrefix(field, part), T("{0} is required.", field.DisplayName));
+                    if (settings.DefaultValue.HasValue) {
+                        field.DateTime = settings.DefaultValue.Value;
+                    }
+                    else {
+                        updater.AddModelError(GetPrefix(field, part), T("{0} is required.", field.DisplayName));
+                    }
                 }
                 else {
                     try {
@@ -149,7 +154,8 @@ namespace Orchard.Fields.Drivers {
                             else {
                                 field.DateTime = utcDateTime.Value;
                             }
-                        } else {
+                        }
+                        else {
                             field.DateTime = settings.DefaultValue.HasValue ? settings.DefaultValue.Value : DateTime.MinValue;
                         }
                     }


### PR DESCRIPTION
Fixes partially #6550.

- Here, as much as possible, i let it as before.
- There is no client required attribute because of the DateTimeEditor.
- So, if required, i've just added the ability to use the default value.

Note: Unit tests and specflows pass.

Best