### PR TITLE
#6550: no required on client side if default value is set (BooleanField)

### DIFF
--- a/src/Orchard.Specs/Boolean.feature
+++ b/src/Orchard.Specs/Boolean.feature
@@ -65,8 +65,9 @@ Scenario: Creating and using Boolean fields
     # The value should be required
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
-            | name                                    | value |
-            | Fields[0].BooleanFieldSettings.Optional | false |
+            | name                                        | value    |
+            | Fields[0].BooleanFieldSettings.Optional     | false    |
+            | Fields[0].BooleanFieldSettings.DefaultValue | Neutral  |
         And I fill in 
             | name                                       | value  |
             | Fields[0].BooleanFieldSettings.NotSetLabel | May be |

--- a/src/Orchard.Specs/Boolean.feature.cs
+++ b/src/Orchard.Specs/Boolean.feature.cs
@@ -193,6 +193,9 @@ this.ScenarioSetup(scenarioInfo);
             table6.AddRow(new string[] {
                         "Fields[0].BooleanFieldSettings.Optional",
                         "false"});
+            table6.AddRow(new string[] {
+                        "Fields[0].BooleanFieldSettings.DefaultValue",
+                        "Neutral"});
 #line 67
         testRunner.And("I fill in", ((string)(null)), table6, "And ");
 #line hidden
@@ -202,7 +205,7 @@ this.ScenarioSetup(scenarioInfo);
             table7.AddRow(new string[] {
                         "Fields[0].BooleanFieldSettings.NotSetLabel",
                         "May be"});
-#line 70
+#line 71
         testRunner.And("I fill in", ((string)(null)), table7, "And ");
 #line hidden
             TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
@@ -211,11 +214,11 @@ this.ScenarioSetup(scenarioInfo);
             table8.AddRow(new string[] {
                         "Fields[0].BooleanFieldSettings.SelectionMode",
                         "Radiobutton"});
-#line 73
+#line 74
         testRunner.And("I fill in", ((string)(null)), table8, "And ");
-#line 76
-        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 77
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 78
         testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
@@ -224,11 +227,11 @@ this.ScenarioSetup(scenarioInfo);
             table9.AddRow(new string[] {
                         "Event.Active.Value",
                         ""});
-#line 78
+#line 79
         testRunner.And("I fill in", ((string)(null)), table9, "And ");
-#line 81
-        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 82
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 83
     testRunner.Then("I should see \"The field Active is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
@@ -48,7 +48,12 @@ namespace Orchard.Fields.Drivers {
             if (updater.TryUpdateModel(field, GetPrefix(field, part), null, null)) {
                 var settings = field.PartFieldDefinition.Settings.GetModel<BooleanFieldSettings>();
                 if (!settings.Optional && !field.Value.HasValue) {
-                    updater.AddModelError(field.Name, T("The field {0} is mandatory.", T(field.DisplayName)));
+                    if (settings.DefaultValue.HasValue) {
+                        field.Value = settings.DefaultValue;
+                    }
+                    else {
+                        updater.AddModelError(field.Name, T("The field {0} is mandatory.", T(field.DisplayName)));
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #6550.

- Here, there is no client required attribute. Maybe because, when required, with the controls you can use there is always a valid submitted value. This may change but I let it as before.
- However, the required checking (here if not `Optional`) is still done on server side. So, i've just added the ability to use the default value if not null (here not `Neutral`).
- And i've adapted the related unit test not to use the default value while it was expecting a `Mandatory` message. This by setting the default value to `Neutral`.

Note: After updating, all unit tests and specflows pass.

Best