### PR TITLE
#6302: [1.10.x] checkboxes issues in form elements editors

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Framework/Drivers/FormsElementDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Framework/Drivers/FormsElementDriver.cs
@@ -78,6 +78,12 @@ namespace Orchard.Layouts.Framework.Drivers {
                 if (value != null) {
                     context.Element.Data[name] = value.AttemptedValue;
                 }
+                else if (formElementShape.Metadata.Type == "Checkbox") {
+                    var shapeValue = formElementShape.Value as string;
+                    if (shapeValue != null && shapeValue.ToLower() == "true") {
+                        context.Element.Data[name] = "false";
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #6302, fixes #6527. Here, a summary of related PRs and issues.

In a form element editor, if a checkbox is saved as checked, you can't save it again as unchecked. This comes from the fact that if unchecked no value is posted. I also had the same kind of issue with the CreateUser activity in worflows, but here only if i define (in the code) the checkbox as initially checked.

As proposed by @jersiovic here #6527 we could add an hidden input, as done by mvc helper. This works when you bind to a strongly typed model that has a bool property. Then, the value provider convert `true,false` to `true`. But layouts and worflows use different ways with dynamic data.

Indeed, we also needed to change a little how element data are updated. But we would also need to do the same for activities, and maybe elsewhere. So, for a more general solution, see #6308 where an hidden input is added on client side and only if needed. But need some jQuery code.

So, let me know if you think that #6308 is ok for a general solution, even with some jQuery (i could do a PR for 1.10.x). Note that the 2 PRs (#6308 and this one) can cohabite.

Otherwise, because right now the issue is only visible through layouts elements (as i've seen), that's why i propose this PR to fix it for elements and without any hidden input. Note that when applied, you can define again a checkbox that is initially checked (but only for layouts elements, e.g a dyn form).

Best