### PR TITLE
Delete the CamelFriendly function call to DisplayName.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.Autocomplete.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.Autocomplete.cshtml
@@ -70,7 +70,7 @@
             
     @if (!Model.HasTerms && AuthorizedFor(Orchard.Taxonomies.Permissions.CreateTerm)) {
         <div class="no-terms">
-            @T("There are no terms defined for {0} yet.", Model.DisplayName.CamelFriendly())
+            @T("There are no terms defined for {0} yet.", Model.DisplayName)
             <a href="@Url.Action("Index", "TermAdmin", new { taxonomyId = Model.TaxonomyId, area = "Orchard.Taxonomies" })">@T("Create some terms")</a>
         </div>        
     }


### PR DESCRIPTION
The CamelFriendly function is designed for Technical Name. The DisplayName needs to be displayed as it is.