### PR TITLE
#6542: [1.10.x] Little issue with content picker

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/EditorTemplates/Parts.ContentMenuItem.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/EditorTemplates/Parts.ContentMenuItem.Edit.cshtml
@@ -20,8 +20,8 @@
         jQuery('#btn-@Html.FieldIdFor(m => m.ContentItemId)').trigger("orchard-admin-contentpicker-open", {
             callback: function(data) {
 
+                data = Array.isArray && Array.isArray(data) ? data[0] : data;
                 jQuery('#@Html.FieldIdFor(m => m.ContentItemId)').val(data.id);
-
                 jQuery('#title-@Html.FieldIdFor(m => m.ContentItemId)').text(data.displayText);
 
                 // define the menu text if it's empty


### PR DESCRIPTION
Fixes in one place #6542 

When using the new `Add Selected` button that allow to select multiple items in the content picker view, the returned data is not an item but an array of items. Some scripts that consume these data has been updated but not in all places.

Here, because a content menu item only needs one related item, if data is an array we only use the first one.

Best