### PR TITLE
#6550: [1.10.x] no required on client side if default value is set (NumericField)

### DIFF
--- a/src/Orchard.Specs/Numeric.feature
+++ b/src/Orchard.Specs/Numeric.feature
@@ -97,3 +97,103 @@ Scenario: Creating and using numeric fields
         And I hit "Save"
     Then I should see "The value &#39;a&#39; is not valid for Minimum."
         And I should see "The value &#39;b&#39; is not valid for Maximum."
+
+    # The value should be validated
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value |
+            | Fields[0].NumericFieldSettings.Required     | false |
+            | Fields[0].NumericFieldSettings.DefaultValue | 4     |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name               | value |
+            | Event.Guests.Value |   a   |
+        And I hit "Save"
+    Then I should see "Guests or its default value is an invalid number"
+
+    # If not required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value |
+            | Fields[0].NumericFieldSettings.Required     | false |
+            | Fields[0].NumericFieldSettings.DefaultValue | 4     |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name               | value |
+            | Event.Guests.Value |       |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Guests:" 
+        And I should see "4"
+
+    # If required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value |
+            | Fields[0].NumericFieldSettings.Required     | true  |
+            | Fields[0].NumericFieldSettings.DefaultValue | 5     |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name               | value |
+            | Event.Guests.Value |       |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Guests:" 
+        And I should see "5"
+
+    # The default value should be validated
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value |
+            | Fields[0].NumericFieldSettings.Required     | false |
+            | Fields[0].NumericFieldSettings.DefaultValue | a     |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name               | value |
+            | Event.Guests.Value |       |
+        And I hit "Save"
+    Then I should see "Guests or its default value is an invalid number"
+
+    # The default value should be bound
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value |
+            | Fields[0].NumericFieldSettings.Required     | false |
+            | Fields[0].NumericFieldSettings.Minimum      | -10   |
+            | Fields[0].NumericFieldSettings.Maximum      | 100   |
+            | Fields[0].NumericFieldSettings.DefaultValue | -20   |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name               | value |
+            | Event.Guests.Value |       |
+        And I hit "Save"
+    Then I should see "The value must be greater than -10"
+
+    # If required and no default value, the required attribute should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value |
+            | Fields[0].NumericFieldSettings.Required     | true  |
+            | Fields[0].NumericFieldSettings.DefaultValue |       |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "required=\"required\""
+
+    # If required and a default value is set, the required attribute should not be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value |
+            | Fields[0].NumericFieldSettings.Required     | true  |
+            | Fields[0].NumericFieldSettings.DefaultValue | 6     |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should not see "required=\"required\""

--- a/src/Orchard.Specs/Numeric.feature.cs
+++ b/src/Orchard.Specs/Numeric.feature.cs
@@ -265,6 +265,223 @@ this.ScenarioSetup(scenarioInfo);
     testRunner.Then("I should see \"The value &#39;a&#39; is not valid for Minimum.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 99
         testRunner.And("I should see \"The value &#39;b&#39; is not valid for Maximum.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 102
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table11.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.Required",
+                        "false"});
+            table11.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.DefaultValue",
+                        "4"});
+#line 103
+        testRunner.And("I fill in", ((string)(null)), table11, "And ");
+#line 107
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 108
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table12.AddRow(new string[] {
+                        "Event.Guests.Value",
+                        "a"});
+#line 109
+        testRunner.And("I fill in", ((string)(null)), table12, "And ");
+#line 112
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 113
+    testRunner.Then("I should see \"Guests or its default value is an invalid number\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 116
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table13.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.Required",
+                        "false"});
+            table13.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.DefaultValue",
+                        "4"});
+#line 117
+        testRunner.And("I fill in", ((string)(null)), table13, "And ");
+#line 121
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 122
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table14.AddRow(new string[] {
+                        "Event.Guests.Value",
+                        ""});
+#line 123
+        testRunner.And("I fill in", ((string)(null)), table14, "And ");
+#line 126
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 127
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 128
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 129
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 130
+    testRunner.Then("I should see \"Guests:\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 131
+        testRunner.And("I should see \"4\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 134
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table15.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.Required",
+                        "true"});
+            table15.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.DefaultValue",
+                        "5"});
+#line 135
+        testRunner.And("I fill in", ((string)(null)), table15, "And ");
+#line 139
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 140
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table16 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table16.AddRow(new string[] {
+                        "Event.Guests.Value",
+                        ""});
+#line 141
+        testRunner.And("I fill in", ((string)(null)), table16, "And ");
+#line 144
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 145
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 146
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 147
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 148
+    testRunner.Then("I should see \"Guests:\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 149
+        testRunner.And("I should see \"5\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 152
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table17 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table17.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.Required",
+                        "false"});
+            table17.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.DefaultValue",
+                        "a"});
+#line 153
+        testRunner.And("I fill in", ((string)(null)), table17, "And ");
+#line 157
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 158
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table18 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table18.AddRow(new string[] {
+                        "Event.Guests.Value",
+                        ""});
+#line 159
+        testRunner.And("I fill in", ((string)(null)), table18, "And ");
+#line 162
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 163
+    testRunner.Then("I should see \"Guests or its default value is an invalid number\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 166
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table19 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table19.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.Required",
+                        "false"});
+            table19.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.Minimum",
+                        "-10"});
+            table19.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.Maximum",
+                        "100"});
+            table19.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.DefaultValue",
+                        "-20"});
+#line 167
+        testRunner.And("I fill in", ((string)(null)), table19, "And ");
+#line 173
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 174
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table20 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table20.AddRow(new string[] {
+                        "Event.Guests.Value",
+                        ""});
+#line 175
+        testRunner.And("I fill in", ((string)(null)), table20, "And ");
+#line 178
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 179
+    testRunner.Then("I should see \"The value must be greater than -10\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 182
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table21 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table21.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.Required",
+                        "true"});
+            table21.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.DefaultValue",
+                        ""});
+#line 183
+        testRunner.And("I fill in", ((string)(null)), table21, "And ");
+#line 187
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 188
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 189
+    testRunner.Then("I should see \"required=\\\"required\\\"\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 192
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table22 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table22.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.Required",
+                        "true"});
+            table22.AddRow(new string[] {
+                        "Fields[0].NumericFieldSettings.DefaultValue",
+                        "6"});
+#line 193
+        testRunner.And("I fill in", ((string)(null)), table22, "And ");
+#line 197
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 198
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 199
+    testRunner.Then("I should not see \"required=\\\"required\\\"\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
@@ -64,47 +64,41 @@ namespace Orchard.Fields.Drivers {
 
                 var settings = field.PartFieldDefinition.Settings.GetModel<NumericFieldSettings>();
 
-                if (settings.Required && String.IsNullOrWhiteSpace(viewModel.Value)) {
-                    updater.AddModelError(GetPrefix(field, part), T("The field {0} is mandatory.", T(field.DisplayName)));
+                if (String.IsNullOrWhiteSpace(viewModel.Value) && !String.IsNullOrWhiteSpace(settings.DefaultValue)) {
+                    viewModel.Value = _tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } });
                 }
 
-                if (!settings.Required && String.IsNullOrWhiteSpace(viewModel.Value)) {
-                    if (settings.DefaultValue != null) {
-                        if (Decimal.TryParse(_tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } }), NumberStyles.Any, _cultureInfo.Value, out value)
-                            && Math.Round(value, settings.Scale) == value
-                            && !String.IsNullOrEmpty(settings.DefaultValue)) {
-                            field.Value = value;
-                        }
-                    }
-                    else {
-                        field.Value = null;
+                field.Value = null;
+
+                if (String.IsNullOrWhiteSpace(viewModel.Value)) {
+                    if (settings.Required) {
+                        updater.AddModelError(GetPrefix(field, part), T("The field {0} is mandatory.", T(field.DisplayName)));
                     }
                 }
-                else if (Decimal.TryParse(viewModel.Value, NumberStyles.Any, _cultureInfo.Value, out value)) { 
-                    field.Value = value;
+                else if (!Decimal.TryParse(viewModel.Value, NumberStyles.Any, _cultureInfo.Value, out value)) {
+                    updater.AddModelError(GetPrefix(field, part), T("{0} or its default value is an invalid number", field.DisplayName));
                 }
                 else {
-                    updater.AddModelError(GetPrefix(field, part), T("{0} is an invalid number", field.DisplayName));
-                    field.Value = null;
-                }
 
-                if (settings.Minimum.HasValue && field.Value.HasValue && field.Value.Value < settings.Minimum.Value) {
-                    updater.AddModelError(GetPrefix(field, part), T("The value must be greater than {0}", settings.Minimum.Value));
-                }
+                    field.Value = value;
 
-                if (settings.Maximum.HasValue && field.Value.HasValue && field.Value.Value > settings.Maximum.Value) {
-                    updater.AddModelError(GetPrefix(field, part), T("The value must be less than {0}", settings.Maximum.Value));
-                }
-
-                // checking the number of decimals
-                if(field.Value.HasValue && Math.Round(field.Value.Value, settings.Scale) != field.Value.Value) {
-                    if(settings.Scale == 0) {
-                        updater.AddModelError(GetPrefix(field, part), T("The field {0} must be an integer", field.DisplayName));    
+                    if (settings.Minimum.HasValue && value < settings.Minimum.Value) {
+                        updater.AddModelError(GetPrefix(field, part), T("The value must be greater than {0}", settings.Minimum.Value));
                     }
-                    else {
-                        updater.AddModelError(GetPrefix(field, part), T("Invalid number of digits for {0}, max allowed: {1}", field.DisplayName, settings.Scale));
+
+                    if (settings.Maximum.HasValue && value > settings.Maximum.Value) {
+                        updater.AddModelError(GetPrefix(field, part), T("The value must be less than {0}", settings.Maximum.Value));
                     }
-                    
+
+                    // checking the number of decimals
+                    if (Math.Round(value, settings.Scale) != value) {
+                        if (settings.Scale == 0) {
+                            updater.AddModelError(GetPrefix(field, part), T("The field {0} must be an integer", field.DisplayName));
+                        }
+                        else {
+                            updater.AddModelError(GetPrefix(field, part), T("Invalid number of digits for {0}, max allowed: {1}", field.DisplayName, settings.Scale));
+                        }
+                    }
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Numeric.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Numeric.Edit.cshtml
@@ -2,14 +2,31 @@
 @using System.Globalization
 @using Orchard.Fields.Settings;
 
+@{
+    var isRequired = Model.Settings.Required && String.IsNullOrWhiteSpace(Model.Settings.DefaultValue);
+    var hasValue = !String.IsNullOrWhiteSpace(Model.Value);
+
+    var attributes = new Dictionary<string, object>();
+    attributes.Add("class", "text-small"); attributes.Add("type", "text");
+    attributes.Add("min", Model.Settings.Minimum.HasValue ? Model.Settings.Minimum.Value : 0);
+    attributes.Add("max", Model.Settings.Maximum.HasValue ? Model.Settings.Maximum.Value : 1000000);
+    attributes.Add("step", Math.Pow(10, 0 - Model.Settings.Scale).ToString(CultureInfo.InvariantCulture));
+
+    if (isRequired) {
+        attributes.Add("required", "required");
+    }
+
+    if (hasValue) {
+        attributes.Add("Value", Model.Value);
+    }
+}
+
 <fieldset>
-    <label for="@Html.FieldIdFor(m => m.Value)" @if(Model.Settings.Required) { <text>class="required"</text> }>@Model.Field.DisplayName</label>
-    @(Model.Settings.Required 
-	        ? Html.TextBoxFor(m => m.Value, new {@class = "text-small", type = "text", min = (Model.Settings.Minimum.HasValue) ? Model.Settings.Minimum.Value : 0, max = (Model.Settings.Maximum.HasValue) ? Model.Settings.Maximum.Value : 1000000, step = Math.Pow(10, 0 - Model.Settings.Scale).ToString(CultureInfo.InvariantCulture), required = "required"}) 
-	        : Html.TextBoxFor(m => m.Value, new {@class = "text-small", type = "text", min = (Model.Settings.Minimum.HasValue) ? Model.Settings.Minimum.Value : 0, max = (Model.Settings.Maximum.HasValue) ? Model.Settings.Maximum.Value : 1000000, step = Math.Pow(10, 0 - Model.Settings.Scale).ToString(CultureInfo.InvariantCulture)}))
+    <label for="@Html.FieldIdFor(m => m.Value)" @if (Model.Settings.Required) { <text> class="required" </text>     }>@Model.Field.DisplayName</label>
+    @Html.TextBoxFor(m => m.Value, attributes)
     @Html.ValidationMessageFor(m => m.Value)
     @if (HasText(Model.Settings.Hint)) {
-    <span class="hint">@Model.Settings.Hint</span>
+        <span class="hint">@Model.Settings.Hint</span>
     }
     @if (!String.IsNullOrWhiteSpace(Model.Settings.DefaultValue)) {
         <span class="hint">@T("If the field is left empty then the default value will be used.")</span>


### PR DESCRIPTION
Fixes partially #6550.

- If required and a default value: no required on client, still with the red star, and still required on server.
- If a default value is used, control and conversion are done by the same code, as for an user input.
- When a default value is a valid number but not validated (limits / scale), it's value is seen on the postback view. This by using in the view a `Value` attribute. Let me know if you think it's ok.
- But, as before, if the default value is not a valid number, there is no direct way to show it on the postback view. So, i've adapted the error message: `{0} or its default value is an invalid number`.

**Note**: The Numeric.Feature spec pass.

Best