### PR TITLE
#6550: [1.10.x] no client required if default set (input + link + date fields)

### DIFF
--- a/src/Orchard.Specs/DateTime.feature
+++ b/src/Orchard.Specs/DateTime.feature
@@ -89,9 +89,9 @@ Scenario: Creating and using Date fields
     # Required & Date and Time
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
-            | name                                    | value       |
-            | Fields[0].DateTimeFieldSettings.Display | DateAndTime |
-            | Fields[0].DateTimeFieldSettings.Required | true       |
+            | name                                     | value       |
+            | Fields[0].DateTimeFieldSettings.Display  | DateAndTime |
+            | Fields[0].DateTimeFieldSettings.Required | true        |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Event.EventDate.Editor.Date"
@@ -137,6 +137,68 @@ Scenario: Creating and using Date fields
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Event.EventDate.Editor.Date"
     When I hit "Save"
+    Then I should see "Date of the event is required."
+
+    # If not required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value       |
+            | Fields[0].DateTimeFieldSettings.Display     | DateAndTime |
+            | Fields[0].DateTimeFieldSettings.Required    | false       |
+            | Fields[0].DateTimeFieldSettings.Editor.Date | 01/31/2012  |
+            | Fields[0].DateTimeFieldSettings.Editor.Time | 11:00 AM    |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "Event.EventDate.Editor.Date"
+    When I fill in 
+            | name                        | value |
+            | Event.EventDate.Editor.Date |       |
+            | Event.EventDate.Editor.Time |       |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Date of the event" 
+        And I should see "1/31/2012 11:00"
+
+    # If required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value       |
+            | Fields[0].DateTimeFieldSettings.Display     | DateAndTime |
+            | Fields[0].DateTimeFieldSettings.Required    | true        |
+            | Fields[0].DateTimeFieldSettings.Editor.Date | 01/31/2012  |
+            | Fields[0].DateTimeFieldSettings.Editor.Time | 10:00 AM    |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "Event.EventDate.Editor.Date"
+    When I fill in 
+            | name                        | value |
+            | Event.EventDate.Editor.Date |       |
+            | Event.EventDate.Editor.Time |       |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Date of the event" 
+        And I should see "1/31/2012 10:00"
+
+    # If required and the default value is incomplete, the value should be required
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value       |
+            | Fields[0].DateTimeFieldSettings.Display     | DateAndTime |
+            | Fields[0].DateTimeFieldSettings.Required    | true        |
+            | Fields[0].DateTimeFieldSettings.Editor.Date |             |
+            | Fields[0].DateTimeFieldSettings.Editor.Time | 12:00 AM    |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "Event.EventDate.Editor.Date"
+    When I fill in 
+            | name                        | value |
+            | Event.EventDate.Editor.Date |       |
+            | Event.EventDate.Editor.Time |       |
+        And I hit "Save"
     Then I should see "Date of the event is required."
 
 Scenario: Creating and using date time fields in another culture

--- a/src/Orchard.Specs/DateTime.feature.cs
+++ b/src/Orchard.Specs/DateTime.feature.cs
@@ -350,77 +350,58 @@ this.ScenarioSetup(scenarioInfo);
     testRunner.When("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line 140
     testRunner.Then("I should see \"Date of the event is required.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-            this.ScenarioCleanup();
-        }
-        
-        [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Creating and using date time fields in another culture")]
-        public virtual void CreatingAndUsingDateTimeFieldsInAnotherCulture()
-        {
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Creating and using date time fields in another culture", ((string[])(null)));
-#line 142
-this.ScenarioSetup(scenarioInfo);
-#line 145
-    testRunner.Given("I have installed Orchard", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
-#line 146
-        testRunner.And("I have installed \"Orchard.Fields\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 147
-        testRunner.And("I have the file \"Content\\orchard.core.po\" in \"Core\\App_Data\\Localization\\fr-FR\\or" +
-                    "chard.core.po\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 148
-    testRunner.When("I go to \"Admin/ContentTypes\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 149
-    testRunner.Then("I should see \"<a[^>]*>.*?Create new type</a>\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 150
-    testRunner.When("I go to \"Admin/ContentTypes/Create\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 143
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
             TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
                         "name",
                         "value"});
             table15.AddRow(new string[] {
-                        "DisplayName",
-                        "Event"});
+                        "Fields[0].DateTimeFieldSettings.Display",
+                        "DateAndTime"});
             table15.AddRow(new string[] {
-                        "Name",
-                        "Event"});
-#line 151
+                        "Fields[0].DateTimeFieldSettings.Required",
+                        "false"});
+            table15.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Editor.Date",
+                        "01/31/2012"});
+            table15.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Editor.Time",
+                        "11:00 AM"});
+#line 144
         testRunner.And("I fill in", ((string)(null)), table15, "And ");
-#line 155
-        testRunner.And("I hit \"Create\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 156
-        testRunner.And("I go to \"Admin/ContentTypes/\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 157
-    testRunner.Then("I should see \"Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 160
-    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 161
-        testRunner.And("I follow \"Add Field\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 150
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 151
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 152
+    testRunner.Then("I should see \"Event.EventDate.Editor.Date\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             TechTalk.SpecFlow.Table table16 = new TechTalk.SpecFlow.Table(new string[] {
                         "name",
                         "value"});
             table16.AddRow(new string[] {
-                        "DisplayName",
-                        "Date of the event"});
+                        "Event.EventDate.Editor.Date",
+                        ""});
             table16.AddRow(new string[] {
-                        "Name",
-                        "EventDate"});
-            table16.AddRow(new string[] {
-                        "FieldTypeName",
-                        "DateTimeField"});
-#line 162
-        testRunner.And("I fill in", ((string)(null)), table16, "And ");
-#line 167
+                        "Event.EventDate.Editor.Time",
+                        ""});
+#line 153
+    testRunner.When("I fill in", ((string)(null)), table16, "When ");
+#line 157
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 168
+#line 158
         testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 169
-    testRunner.Then("I should see \"The \\\"Date of the event\\\" field has been added.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 172
-    testRunner.When("I have \"fr-FR\" as the default culture", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 173
-        testRunner.And("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 159
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 160
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 161
+    testRunner.Then("I should see \"Date of the event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 162
+        testRunner.And("I should see \"1/31/2012 11:00\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 165
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
             TechTalk.SpecFlow.Table table17 = new TechTalk.SpecFlow.Table(new string[] {
                         "name",
@@ -431,47 +412,208 @@ this.ScenarioSetup(scenarioInfo);
             table17.AddRow(new string[] {
                         "Fields[0].DateTimeFieldSettings.Required",
                         "true"});
-#line 174
+            table17.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Editor.Date",
+                        "01/31/2012"});
+            table17.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Editor.Time",
+                        "10:00 AM"});
+#line 166
         testRunner.And("I fill in", ((string)(null)), table17, "And ");
-#line 178
+#line 172
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 179
-    testRunner.When("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 173
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 174
+    testRunner.Then("I should see \"Event.EventDate.Editor.Date\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             TechTalk.SpecFlow.Table table18 = new TechTalk.SpecFlow.Table(new string[] {
                         "name",
                         "value"});
             table18.AddRow(new string[] {
                         "Event.EventDate.Editor.Date",
-                        "01/31/2012"});
+                        ""});
             table18.AddRow(new string[] {
                         "Event.EventDate.Editor.Time",
-                        "12:00 AM"});
-#line 180
-        testRunner.And("I fill in", ((string)(null)), table18, "And ");
-#line 184
+                        ""});
+#line 175
+    testRunner.When("I fill in", ((string)(null)), table18, "When ");
+#line 179
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 185
-    testRunner.Then("I should see \"Date of the event could not be parsed as a valid date and time\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 186
-    testRunner.When("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 180
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 181
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 182
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 183
+    testRunner.Then("I should see \"Date of the event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 184
+        testRunner.And("I should see \"1/31/2012 10:00\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 187
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
             TechTalk.SpecFlow.Table table19 = new TechTalk.SpecFlow.Table(new string[] {
                         "name",
                         "value"});
             table19.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Display",
+                        "DateAndTime"});
+            table19.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Required",
+                        "true"});
+            table19.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Editor.Date",
+                        ""});
+            table19.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Editor.Time",
+                        "12:00 AM"});
+#line 188
+        testRunner.And("I fill in", ((string)(null)), table19, "And ");
+#line 194
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 195
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 196
+    testRunner.Then("I should see \"Event.EventDate.Editor.Date\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            TechTalk.SpecFlow.Table table20 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table20.AddRow(new string[] {
+                        "Event.EventDate.Editor.Date",
+                        ""});
+            table20.AddRow(new string[] {
+                        "Event.EventDate.Editor.Time",
+                        ""});
+#line 197
+    testRunner.When("I fill in", ((string)(null)), table20, "When ");
+#line 201
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 202
+    testRunner.Then("I should see \"Date of the event is required.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Creating and using date time fields in another culture")]
+        public virtual void CreatingAndUsingDateTimeFieldsInAnotherCulture()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Creating and using date time fields in another culture", ((string[])(null)));
+#line 204
+this.ScenarioSetup(scenarioInfo);
+#line 207
+    testRunner.Given("I have installed Orchard", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 208
+        testRunner.And("I have installed \"Orchard.Fields\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 209
+        testRunner.And("I have the file \"Content\\orchard.core.po\" in \"Core\\App_Data\\Localization\\fr-FR\\or" +
+                    "chard.core.po\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 210
+    testRunner.When("I go to \"Admin/ContentTypes\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 211
+    testRunner.Then("I should see \"<a[^>]*>.*?Create new type</a>\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 212
+    testRunner.When("I go to \"Admin/ContentTypes/Create\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table21 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table21.AddRow(new string[] {
+                        "DisplayName",
+                        "Event"});
+            table21.AddRow(new string[] {
+                        "Name",
+                        "Event"});
+#line 213
+        testRunner.And("I fill in", ((string)(null)), table21, "And ");
+#line 217
+        testRunner.And("I hit \"Create\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 218
+        testRunner.And("I go to \"Admin/ContentTypes/\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 219
+    testRunner.Then("I should see \"Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 222
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 223
+        testRunner.And("I follow \"Add Field\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table22 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table22.AddRow(new string[] {
+                        "DisplayName",
+                        "Date of the event"});
+            table22.AddRow(new string[] {
+                        "Name",
+                        "EventDate"});
+            table22.AddRow(new string[] {
+                        "FieldTypeName",
+                        "DateTimeField"});
+#line 224
+        testRunner.And("I fill in", ((string)(null)), table22, "And ");
+#line 229
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 230
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 231
+    testRunner.Then("I should see \"The \\\"Date of the event\\\" field has been added.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 234
+    testRunner.When("I have \"fr-FR\" as the default culture", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 235
+        testRunner.And("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table23 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table23.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Display",
+                        "DateAndTime"});
+            table23.AddRow(new string[] {
+                        "Fields[0].DateTimeFieldSettings.Required",
+                        "true"});
+#line 236
+        testRunner.And("I fill in", ((string)(null)), table23, "And ");
+#line 240
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 241
+    testRunner.When("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table24 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table24.AddRow(new string[] {
+                        "Event.EventDate.Editor.Date",
+                        "01/31/2012"});
+            table24.AddRow(new string[] {
+                        "Event.EventDate.Editor.Time",
+                        "12:00 AM"});
+#line 242
+        testRunner.And("I fill in", ((string)(null)), table24, "And ");
+#line 246
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 247
+    testRunner.Then("I should see \"Date of the event could not be parsed as a valid date and time\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 248
+    testRunner.When("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table25 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table25.AddRow(new string[] {
                         "Event.EventDate.Editor.Date",
                         "31/01/2012"});
-            table19.AddRow(new string[] {
+            table25.AddRow(new string[] {
                         "Event.EventDate.Editor.Time",
                         "18:00"});
-#line 187
-        testRunner.And("I fill in", ((string)(null)), table19, "And ");
-#line 191
+#line 249
+        testRunner.And("I fill in", ((string)(null)), table25, "And ");
+#line 253
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 192
+#line 254
         testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 193
+#line 255
     testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();

--- a/src/Orchard.Specs/Input.feature
+++ b/src/Orchard.Specs/Input.feature
@@ -128,3 +128,59 @@ Scenario: Creating and using Input fields
     When I go to "Admin/Contents/List"
     Then I should see "Contact:" 
         And I should see "contact@orchardproject.net"
+
+    # If not required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                      | value                       |
+            | Fields[0].InputFieldSettings.Required     | false                       |
+            | Fields[0].InputFieldSettings.DefaultValue | contact1@orchardproject.net |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name                | value |
+            | Event.Contact.Value |       |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Contact:" 
+        And I should see "contact1@orchardproject.net"
+
+    # If required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                      | value                       |
+            | Fields[0].InputFieldSettings.Required     | true                        |
+            | Fields[0].InputFieldSettings.DefaultValue | contact2@orchardproject.net |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name                | value |
+            | Event.Contact.Value |       |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Contact:" 
+        And I should see "contact2@orchardproject.net"
+
+    # If required and no default value, the required attribute should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                      | value |
+            | Fields[0].InputFieldSettings.Required     | true  |
+            | Fields[0].InputFieldSettings.DefaultValue |       |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "required=\"required\""
+
+    # If required and a default value is set, the required attribute should not be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                      | value                      |
+            | Fields[0].InputFieldSettings.Required     | true                       |
+            | Fields[0].InputFieldSettings.DefaultValue | contact@orchardproject.net |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should not see "required=\"required\""

--- a/src/Orchard.Specs/Input.feature.cs
+++ b/src/Orchard.Specs/Input.feature.cs
@@ -297,6 +297,124 @@ this.ScenarioSetup(scenarioInfo);
     testRunner.Then("I should see \"Contact:\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 130
         testRunner.And("I should see \"contact@orchardproject.net\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 133
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table13.AddRow(new string[] {
+                        "Fields[0].InputFieldSettings.Required",
+                        "false"});
+            table13.AddRow(new string[] {
+                        "Fields[0].InputFieldSettings.DefaultValue",
+                        "contact1@orchardproject.net"});
+#line 134
+        testRunner.And("I fill in", ((string)(null)), table13, "And ");
+#line 138
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 139
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table14.AddRow(new string[] {
+                        "Event.Contact.Value",
+                        ""});
+#line 140
+        testRunner.And("I fill in", ((string)(null)), table14, "And ");
+#line 143
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 144
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 145
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 146
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 147
+    testRunner.Then("I should see \"Contact:\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 148
+        testRunner.And("I should see \"contact1@orchardproject.net\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 151
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table15.AddRow(new string[] {
+                        "Fields[0].InputFieldSettings.Required",
+                        "true"});
+            table15.AddRow(new string[] {
+                        "Fields[0].InputFieldSettings.DefaultValue",
+                        "contact2@orchardproject.net"});
+#line 152
+        testRunner.And("I fill in", ((string)(null)), table15, "And ");
+#line 156
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 157
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table16 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table16.AddRow(new string[] {
+                        "Event.Contact.Value",
+                        ""});
+#line 158
+        testRunner.And("I fill in", ((string)(null)), table16, "And ");
+#line 161
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 162
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 163
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 164
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 165
+    testRunner.Then("I should see \"Contact:\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 166
+        testRunner.And("I should see \"contact2@orchardproject.net\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 169
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table17 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table17.AddRow(new string[] {
+                        "Fields[0].InputFieldSettings.Required",
+                        "true"});
+            table17.AddRow(new string[] {
+                        "Fields[0].InputFieldSettings.DefaultValue",
+                        ""});
+#line 170
+        testRunner.And("I fill in", ((string)(null)), table17, "And ");
+#line 174
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 175
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 176
+    testRunner.Then("I should see \"required=\\\"required\\\"\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 179
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table18 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table18.AddRow(new string[] {
+                        "Fields[0].InputFieldSettings.Required",
+                        "true"});
+            table18.AddRow(new string[] {
+                        "Fields[0].InputFieldSettings.DefaultValue",
+                        "contact@orchardproject.net"});
+#line 180
+        testRunner.And("I fill in", ((string)(null)), table18, "And ");
+#line 184
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 185
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 186
+    testRunner.Then("I should not see \"required=\\\"required\\\"\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/Orchard.Specs/Link.feature
+++ b/src/Orchard.Specs/Link.feature
@@ -68,3 +68,65 @@ Scenario: Creating and using Link fields
             | Event.SiteUrl.Value |       |
         And I hit "Save"
     Then I should see "Url is required for Site Url."
+
+    # If not required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                     | value                         |
+            | Fields[0].LinkFieldSettings.Required     | false                         |
+            | Fields[0].LinkFieldSettings.DefaultValue | http://www.orchardproject.net |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name                | value |
+            | Event.SiteUrl.Value |       |
+        And I fill in
+            | name               | value    |
+            | Event.SiteUrl.Text | Orchard1 |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Site Url:" 
+        And I should see "<a href=\"http://www.orchardproject.net\">Orchard1</a>"
+
+    # If required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                     | value                         |
+            | Fields[0].LinkFieldSettings.Required     | true                          |
+            | Fields[0].LinkFieldSettings.DefaultValue | http://www.orchardproject.net |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name                | value |
+            | Event.SiteUrl.Value |       |
+        And I fill in
+            | name               | value    |
+            | Event.SiteUrl.Text | Orchard2 |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Site Url:" 
+        And I should see "<a href=\"http://www.orchardproject.net\">Orchard2</a>"
+
+    # If required and no default value, the required attribute should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                     | value |
+            | Fields[0].LinkFieldSettings.Required     | true  |
+            | Fields[0].LinkFieldSettings.DefaultValue |       |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "required=\"required\""
+
+    # If required and a default value is set, the required attribute should not be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                     | value                         |
+            | Fields[0].LinkFieldSettings.Required     | true                          |
+            | Fields[0].LinkFieldSettings.DefaultValue | http://www.orchardproject.net |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should not see "required=\"required\""

--- a/src/Orchard.Specs/Link.feature.cs
+++ b/src/Orchard.Specs/Link.feature.cs
@@ -204,6 +204,142 @@ this.ScenarioSetup(scenarioInfo);
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 70
     testRunner.Then("I should see \"Url is required for Site Url.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 73
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table8.AddRow(new string[] {
+                        "Fields[0].LinkFieldSettings.Required",
+                        "false"});
+            table8.AddRow(new string[] {
+                        "Fields[0].LinkFieldSettings.DefaultValue",
+                        "http://www.orchardproject.net"});
+#line 74
+        testRunner.And("I fill in", ((string)(null)), table8, "And ");
+#line 78
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 79
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table9.AddRow(new string[] {
+                        "Event.SiteUrl.Value",
+                        ""});
+#line 80
+        testRunner.And("I fill in", ((string)(null)), table9, "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table10 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table10.AddRow(new string[] {
+                        "Event.SiteUrl.Text",
+                        "Orchard1"});
+#line 83
+        testRunner.And("I fill in", ((string)(null)), table10, "And ");
+#line 86
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 87
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 88
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 89
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 90
+    testRunner.Then("I should see \"Site Url:\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 91
+        testRunner.And("I should see \"<a href=\\\"http://www.orchardproject.net\\\">Orchard1</a>\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 94
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table11.AddRow(new string[] {
+                        "Fields[0].LinkFieldSettings.Required",
+                        "true"});
+            table11.AddRow(new string[] {
+                        "Fields[0].LinkFieldSettings.DefaultValue",
+                        "http://www.orchardproject.net"});
+#line 95
+        testRunner.And("I fill in", ((string)(null)), table11, "And ");
+#line 99
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 100
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table12.AddRow(new string[] {
+                        "Event.SiteUrl.Value",
+                        ""});
+#line 101
+        testRunner.And("I fill in", ((string)(null)), table12, "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table13.AddRow(new string[] {
+                        "Event.SiteUrl.Text",
+                        "Orchard2"});
+#line 104
+        testRunner.And("I fill in", ((string)(null)), table13, "And ");
+#line 107
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 108
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 109
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 110
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 111
+    testRunner.Then("I should see \"Site Url:\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 112
+        testRunner.And("I should see \"<a href=\\\"http://www.orchardproject.net\\\">Orchard2</a>\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 115
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table14.AddRow(new string[] {
+                        "Fields[0].LinkFieldSettings.Required",
+                        "true"});
+            table14.AddRow(new string[] {
+                        "Fields[0].LinkFieldSettings.DefaultValue",
+                        ""});
+#line 116
+        testRunner.And("I fill in", ((string)(null)), table14, "And ");
+#line 120
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 121
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 122
+    testRunner.Then("I should see \"required=\\\"required\\\"\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 125
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table15.AddRow(new string[] {
+                        "Fields[0].LinkFieldSettings.Required",
+                        "true"});
+            table15.AddRow(new string[] {
+                        "Fields[0].LinkFieldSettings.DefaultValue",
+                        "http://www.orchardproject.net"});
+#line 126
+        testRunner.And("I fill in", ((string)(null)), table15, "And ");
+#line 130
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 131
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 132
+    testRunner.Then("I should not see \"required=\\\"required\\\"\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
@@ -132,31 +132,41 @@ namespace Orchard.Fields.Drivers {
                 var showDate = settings.Display == DateTimeFieldDisplays.DateAndTime || settings.Display == DateTimeFieldDisplays.DateOnly;
                 var showTime = settings.Display == DateTimeFieldDisplays.DateAndTime || settings.Display == DateTimeFieldDisplays.TimeOnly;
 
+                DateTime? value = null;
+                var IsParseError = false;
+
+                // If required and one field is missing, don't try to parse data.
                 if (settings.Required && ((showDate && String.IsNullOrWhiteSpace(viewModel.Editor.Date)) || (showTime && String.IsNullOrWhiteSpace(viewModel.Editor.Time)))) {
-                    updater.AddModelError(GetPrefix(field, part), T("{0} is required.", field.DisplayName));
+                    // And use the default value only if all required fields are empty.
+                    if (!showDate || !showTime || (String.IsNullOrWhiteSpace(viewModel.Editor.Date) && String.IsNullOrWhiteSpace(viewModel.Editor.Time))) {
+                        value = settings.DefaultValue;
+                    }
                 }
                 else {
                     try {
                         var utcDateTime = DateLocalizationServices.ConvertFromLocalizedString(viewModel.Editor.Date, viewModel.Editor.Time, options);
-                        
-                        if (utcDateTime.HasValue) {
-                            // Hackish workaround to make sure a time-only field with an entered time equivalent to
-                            // 00:00 UTC doesn't get stored as a full DateTime.MinValue in the database, resulting
-                            // in it being interpreted as an empty value when subsequently retrieved.
-                            if (settings.Display == DateTimeFieldDisplays.TimeOnly && utcDateTime.Value == DateTime.MinValue) {
-                                field.DateTime = utcDateTime.Value.AddDays(1);
-                            }
-                            else {
-                                field.DateTime = utcDateTime.Value;
-                            }
-                        } else {
-                            field.DateTime = settings.DefaultValue.HasValue ? settings.DefaultValue.Value : DateTime.MinValue;
-                        }
+                        value = utcDateTime.HasValue ? utcDateTime : settings.DefaultValue;
                     }
                     catch {
+                        IsParseError = true;
                         updater.AddModelError(GetPrefix(field, part), T("{0} could not be parsed as a valid date and time.", field.DisplayName));
                     }
                 }
+
+                if (!IsParseError) {
+                    // Hackish workaround to make sure a time-only field with an entered time equivalent to
+                    // 00:00 UTC doesn't get stored as a full DateTime.MinValue in the database, resulting
+                    // in it being interpreted as an empty value when subsequently retrieved.
+                    if (value.HasValue && settings.Display == DateTimeFieldDisplays.TimeOnly && value == DateTime.MinValue) {
+                        value = value.Value.AddDays(1);
+                    }
+
+                    if (settings.Required && (!value.HasValue || (settings.Display != DateTimeFieldDisplays.TimeOnly && value.Value.Date == DateTime.MinValue))) {
+                        updater.AddModelError(GetPrefix(field, part), T("{0} is required.", field.DisplayName));
+                    }
+                }
+
+                field.DateTime = value.HasValue ? value.Value : DateTime.MinValue;
             }
 
             return Editor(part, field, shapeHelper);

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/InputFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/InputFieldDriver.cs
@@ -46,11 +46,11 @@ namespace Orchard.Fields.Drivers {
             if (updater.TryUpdateModel(field, GetPrefix(field, part), null, null)) {
                 var settings = field.PartFieldDefinition.Settings.GetModel<InputFieldSettings>();
 
-                if (field.Value == null && !String.IsNullOrEmpty(settings.DefaultValue)) {
+                if (String.IsNullOrWhiteSpace(field.Value) && !String.IsNullOrWhiteSpace(settings.DefaultValue)) {
                      field.Value = _tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } });
                 }
 
-                if (settings.Required && string.IsNullOrWhiteSpace(field.Value)) {
+                if (settings.Required && String.IsNullOrWhiteSpace(field.Value)) {
                     updater.AddModelError(GetPrefix(field, part), T("The field {0} is mandatory.", T(field.DisplayName)));
                 }
             }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/LinkFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/LinkFieldDriver.cs
@@ -46,21 +46,21 @@ namespace Orchard.Fields.Drivers {
             if (updater.TryUpdateModel(field, GetPrefix(field, part), null, null)) {
                 var settings = field.PartFieldDefinition.Settings.GetModel<LinkFieldSettings>();
 
-                if (String.IsNullOrEmpty(field.Value) && !String.IsNullOrEmpty(settings.DefaultValue)) {
+                if (String.IsNullOrWhiteSpace(field.Value) && !String.IsNullOrWhiteSpace(settings.DefaultValue)) {
                    field.Value = _tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } });
                 }
 
-                if(!String.IsNullOrEmpty(settings.TextDefaultValue) && String.IsNullOrWhiteSpace(field.Text)) {
+                if(!String.IsNullOrWhiteSpace(settings.TextDefaultValue) && String.IsNullOrWhiteSpace(field.Text)) {
                     field.Text = _tokenizer.Replace(settings.TextDefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } });
                 }
 
-                if (settings.Required && string.IsNullOrWhiteSpace(field.Value)) {
+                if (settings.Required && String.IsNullOrWhiteSpace(field.Value)) {
                     updater.AddModelError(GetPrefix(field, part), T("Url is required for {0}", field.DisplayName));
                 }
-                else if (!string.IsNullOrWhiteSpace(field.Value) && !Uri.IsWellFormedUriString(field.Value, UriKind.RelativeOrAbsolute)) {
+                else if (!String.IsNullOrWhiteSpace(field.Value) && !Uri.IsWellFormedUriString(field.Value, UriKind.RelativeOrAbsolute)) {
                     updater.AddModelError(GetPrefix(field, part), T("{0} is an invalid url.", field.Value));
                 }
-                else if (settings.LinkTextMode == LinkTextMode.Required && string.IsNullOrWhiteSpace(field.Text)) {
+                else if (settings.LinkTextMode == LinkTextMode.Required && String.IsNullOrWhiteSpace(field.Text)) {
                     updater.AddModelError(GetPrefix(field, part), T("Text is required for {0}.", field.DisplayName));
                 }
             }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/InputFieldSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/InputFieldSettings.cshtml
@@ -81,7 +81,7 @@
     <div>
         <label for="@Html.FieldIdFor(m => m.DefaultValue)">@T("Default value")</label>
         @Html.TextBoxFor(m => m.DefaultValue, new { @class = "text large tokenized ui-autocomplete-input" })
-        <span class="hint">@T("A valid url as a default value, i.e. http://orchardproject.net, /content/file.pdf ... You can use tokens in this field. (optional)")</span>
+        <span class="hint">@T("Default value for the field. You can use tokens in this field. If there is no value given for the actual field, this will be filled in. (optional)")</span>
         @Html.ValidationMessageFor(m => m.DefaultValue)
     </div>
 </fieldset>

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Input.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Input.Edit.cshtml
@@ -3,13 +3,14 @@
 @using Orchard.Fields.Settings;
 @{
     var settings = Model.PartFieldDefinition.Settings.GetModel<InputFieldSettings>();
+    var isRequired = settings.Required && String.IsNullOrWhiteSpace(settings.DefaultValue);
 }
 <fieldset>
-    <label for="@Html.FieldIdFor(m => m.Value)" @if(settings.Required) { <text>class="required"</text> }>@Model.DisplayName</label>
-    <input type="@settings.Type.ToString().ToLower()" id="@Html.FieldIdFor(m => m.Value)" name="@Html.FieldNameFor(m => m.Value)"@if(!String.IsNullOrWhiteSpace(settings.Title)) {<text> title="@settings.Title"</text>} value="@Model.Value"@if(settings.Required) {<text> required="required"</text> }@if(settings.AutoFocus) {<text> autofocus="autofocus"</text> }@if(settings.AutoComplete) {<text> autocomplete="on"</text> }@if(!string.IsNullOrWhiteSpace(settings.Placeholder)) {<text> placeholder="@settings.Placeholder"</text>}@if(!string.IsNullOrEmpty(settings.Pattern)) {<text> pattern="@settings.Pattern"</text>}@if(!string.IsNullOrEmpty(settings.EditorCssClass)) {<text> class="@settings.EditorCssClass"</text>} else {<text> class="text medium"</text>} @if(settings.MaxLength > 1) {<text> maxlength="@settings.MaxLength.ToString()"</text>} />
+    <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text>  }>@Model.DisplayName</label>
+    <input type="@settings.Type.ToString().ToLower()" id="@Html.FieldIdFor(m => m.Value)" name="@Html.FieldNameFor(m => m.Value)" @if (!String.IsNullOrWhiteSpace(settings.Title)) { <text> title="@settings.Title" </text> } value="@Model.Value" @if (isRequired) { <text> required="required" </text>  } @if (settings.AutoFocus) { <text> autofocus="autofocus" </text>  } @if (settings.AutoComplete) { <text> autocomplete="on" </text>  } @if (!String.IsNullOrWhiteSpace(settings.Placeholder)) { <text> placeholder="@settings.Placeholder" </text> } @if (!String.IsNullOrWhiteSpace(settings.Pattern)) { <text> pattern="@settings.Pattern" </text> } @if (!String.IsNullOrWhiteSpace(settings.EditorCssClass)) { <text> class="@settings.EditorCssClass" </text> } else { <text> class="text medium" </text> } @if (settings.MaxLength > 1) { <text> maxlength="@settings.MaxLength.ToString()" </text> } />
     @Html.ValidationMessageFor(m => m.Value)
     @if (HasText(settings.Hint)) {
-    <span class="hint">@settings.Hint</span>
+        <span class="hint">@settings.Hint</span>
     }
     @if (!String.IsNullOrWhiteSpace(settings.DefaultValue)) {
         <span class="hint">@T("If the field is left empty then the default value will be used.")</span>

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Link.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Link.Edit.cshtml
@@ -2,7 +2,7 @@
 @using Orchard.Fields.Settings;
 @{
     var settings = Model.PartFieldDefinition.Settings.GetModel<LinkFieldSettings>();
-    string target = string.Empty;
+    string target = String.Empty;
     switch (settings.TargetMode) {
         case TargetMode.NewWindow:
             target = "_blank";
@@ -13,18 +13,21 @@
         case TargetMode.Top:
             target = "_top";
             break;
-	}
+    }
+
+    var isRequired = settings.Required && String.IsNullOrWhiteSpace(settings.DefaultValue);
+    var isTextRequired = settings.LinkTextMode == LinkTextMode.Required && String.IsNullOrWhiteSpace(settings.TextDefaultValue);
 }
 <fieldset>
     <label for="@Html.FieldIdFor(m => m.Value)">@Model.DisplayName</label>
     @if (HasText(settings.Hint)) {
-    <span class="hint">@settings.Hint</span>
+        <span class="hint">@settings.Hint</span>
     }
     <div class="editor-label">
-        <label for="@Html.FieldIdFor(m => m.Value)" @if(settings.Required) { <text>class="required"</text> }>@T("Url")</label>
+        <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text>  }>@T("Url")</label>
     </div>
     <div class="editor-field">
-        @Html.TextBoxFor(m => m.Value, new { @class = "text large" })
+        @(isRequired ? Html.TextBoxFor(m => m.Value, new { @class = "text large", required = "required" }) : Html.TextBoxFor(m => m.Value, new { @class = "text large" }))
         <span class="hint">@T("A valid url, i.e. http://orchardproject.net, /content/file.pdf, ...")</span>
     </div>
     @if (!String.IsNullOrWhiteSpace(settings.DefaultValue)) {
@@ -32,10 +35,10 @@
     }
     @if (settings.LinkTextMode == LinkTextMode.Optional || settings.LinkTextMode == LinkTextMode.Required) {
         <div class="editor-label">
-            <label for="@Html.FieldIdFor(m => m.Text)" @if(settings.LinkTextMode == LinkTextMode.Required) { <text>class="required"</text> }>@T("Text")</label>
+            <label for="@Html.FieldIdFor(m => m.Text)" @if (settings.LinkTextMode == LinkTextMode.Required) { <text> class="required" </text>  }>@T("Text")</label>
         </div>
         <div class="editor-field">
-            @Html.TextBoxFor(m => m.Text, new { @class = "text medium" })
+            @(isTextRequired ? Html.TextBoxFor(m => m.Text, new { @class = "text medium", required = "required" }) : Html.TextBoxFor(m => m.Text, new { @class = "text medium" }))
             @if (!String.IsNullOrWhiteSpace(settings.TextDefaultValue)) {
                 <span class="hint">@T("If the field is left empty then the default value will be used.")</span>
             }
@@ -44,13 +47,13 @@
             }
         </div>
     }
-    
+
     @if (settings.TargetMode == TargetMode.UserChoice) {
         <div class="editor-label">
             <label for="@Html.FieldIdFor(m => m.Target)">@T("Target")</label>
         </div>
         <div class="editor-field">
-            @Html.TextBoxFor(m => m.Target, new { @class = "text"})
+            @Html.TextBoxFor(m => m.Target, new { @class = "text" })
             <span class="hint">@T("A valid HTML target attribute value. e.g., _blank, _parent, _top, or an anchor. ")</span>
         </div>
     }


### PR DESCRIPTION
Fixes partially #6550. (todo: enum + boolean fields)

**DateTimeField** (many options to check here)

- There is no client required attribute because of the DateTimeEditor.
- As before, if required and one field is missing, editor data are not parsed.
- But, now, before adding an error, we try to use the default value.

**Special case:** When both Date and Time are required, we consider that both input fields are required. But we use the default value only if all required fields are empty. If not, there is an error message as before, input fields need to be completed or completely cleared to use the default.

Note: The DateTime.Feature spec pass.

**InputField**

- Here, no need to change the InputFieldDriver.
- Just remove client required attribute (not the class) if a default value is set.
- And correct an hint text in the input field settings editor

**LinkField**

- Here also, no need to change the LinkFieldDriver.
- But here, the client required attribute (not the class) was never used.
- So, this attribute is added to the url and link text inputs, unless a default value is set.

Best