### PR TITLE
#6550: [1.10.x] no client required if default set (enum + boolean fields)

### DIFF
--- a/src/Orchard.Specs/Boolean.feature
+++ b/src/Orchard.Specs/Boolean.feature
@@ -65,8 +65,9 @@ Scenario: Creating and using Boolean fields
     # The value should be required
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
-            | name                                    | value |
-            | Fields[0].BooleanFieldSettings.Optional | false |
+            | name                                        | value    |
+            | Fields[0].BooleanFieldSettings.Optional     | false    |
+            | Fields[0].BooleanFieldSettings.DefaultValue | Neutral  |
         And I fill in 
             | name                                       | value  |
             | Fields[0].BooleanFieldSettings.NotSetLabel | May be |

--- a/src/Orchard.Specs/Boolean.feature
+++ b/src/Orchard.Specs/Boolean.feature
@@ -53,7 +53,7 @@ Scenario: Creating and using Boolean fields
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Check if the event is active"
     
-    # The default value should be selected
+    # The default value should be used on creation
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value |
@@ -81,3 +81,22 @@ Scenario: Creating and using Boolean fields
             | Event.Active.Value |       |
         And I hit "Save"
     Then I should see "The field Active is mandatory."
+	
+    # If required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                        | value |
+            | Fields[0].BooleanFieldSettings.Optional     | false |
+            | Fields[0].BooleanFieldSettings.DefaultValue | True  |
+        And I fill in 
+            | name                                         | value         |
+            | Fields[0].BooleanFieldSettings.SelectionMode | Dropdown list |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+        And I fill in 
+            | name               | value |
+            | Event.Active.Value |       |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+        And I should see "selected=\"selected\" value=\"true\""

--- a/src/Orchard.Specs/Boolean.feature.cs
+++ b/src/Orchard.Specs/Boolean.feature.cs
@@ -193,6 +193,9 @@ this.ScenarioSetup(scenarioInfo);
             table6.AddRow(new string[] {
                         "Fields[0].BooleanFieldSettings.Optional",
                         "false"});
+            table6.AddRow(new string[] {
+                        "Fields[0].BooleanFieldSettings.DefaultValue",
+                        "Neutral"});
 #line 67
         testRunner.And("I fill in", ((string)(null)), table6, "And ");
 #line hidden
@@ -202,7 +205,7 @@ this.ScenarioSetup(scenarioInfo);
             table7.AddRow(new string[] {
                         "Fields[0].BooleanFieldSettings.NotSetLabel",
                         "May be"});
-#line 70
+#line 71
         testRunner.And("I fill in", ((string)(null)), table7, "And ");
 #line hidden
             TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
@@ -211,11 +214,11 @@ this.ScenarioSetup(scenarioInfo);
             table8.AddRow(new string[] {
                         "Fields[0].BooleanFieldSettings.SelectionMode",
                         "Radiobutton"});
-#line 73
+#line 74
         testRunner.And("I fill in", ((string)(null)), table8, "And ");
-#line 76
-        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 77
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 78
         testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
@@ -224,11 +227,11 @@ this.ScenarioSetup(scenarioInfo);
             table9.AddRow(new string[] {
                         "Event.Active.Value",
                         ""});
-#line 78
+#line 79
         testRunner.And("I fill in", ((string)(null)), table9, "And ");
-#line 81
-        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 82
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 83
     testRunner.Then("I should see \"The field Active is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();

--- a/src/Orchard.Specs/Boolean.feature.cs
+++ b/src/Orchard.Specs/Boolean.feature.cs
@@ -233,6 +233,50 @@ this.ScenarioSetup(scenarioInfo);
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 83
     testRunner.Then("I should see \"The field Active is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 86
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table10 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table10.AddRow(new string[] {
+                        "Fields[0].BooleanFieldSettings.Optional",
+                        "false"});
+            table10.AddRow(new string[] {
+                        "Fields[0].BooleanFieldSettings.DefaultValue",
+                        "True"});
+#line 87
+        testRunner.And("I fill in", ((string)(null)), table10, "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table11.AddRow(new string[] {
+                        "Fields[0].BooleanFieldSettings.SelectionMode",
+                        "Dropdown list"});
+#line 91
+        testRunner.And("I fill in", ((string)(null)), table11, "And ");
+#line 94
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 95
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table12.AddRow(new string[] {
+                        "Event.Active.Value",
+                        ""});
+#line 96
+        testRunner.And("I fill in", ((string)(null)), table12, "And ");
+#line 99
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 100
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 101
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 102
+        testRunner.And("I should see \"selected=\\\"selected\\\" value=\\\"true\\\"\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/Orchard.Specs/Enumeration.feature
+++ b/src/Orchard.Specs/Enumeration.feature
@@ -107,3 +107,95 @@ Scenario: Creating and using Enumeration fields
         And I go to "Admin/Contents/Create/Event"
         And I hit "Save"
     Then I should see "The field Location is mandatory."
+    
+    # The default value should be used on creation
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                            | value    |
+            | Fields[0].EnumerationFieldSettings.Options      | Seattle  |
+            | Fields[0].EnumerationFieldSettings.ListMode     | Dropdown |
+            | Fields[0].EnumerationFieldSettings.DefaultValue | Seattle  |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "selected=\"selected">Seattle"
+    
+    # If not required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                            | value          |
+            | Fields[0].EnumerationFieldSettings.Required     | false          |
+            | Fields[0].EnumerationFieldSettings.Options      | Boston         |
+            | Fields[0].EnumerationFieldSettings.ListMode     | Checkbox       |
+            | Fields[0].EnumerationFieldSettings.DefaultValue | foo;Boston;bar |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "Location"
+    When I fill in 
+            | name                          | value |
+            | Event.Location.SelectedValues |       |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Location:" 
+        And I should see "Boston"
+    
+    # If required and no value, the default value should be used
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                            | value           |
+            | Fields[0].EnumerationFieldSettings.Required     | true            |
+            | Fields[0].EnumerationFieldSettings.Options      | Phoenix         |
+            | Fields[0].EnumerationFieldSettings.ListMode     | Checkbox        |
+            | Fields[0].EnumerationFieldSettings.DefaultValue | foo;Phoenix;bar |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "Location"
+    When I fill in 
+            | name                          | value |
+            | Event.Location.SelectedValues |       |
+        And I hit "Save"
+        And I am redirected
+    Then I should see "Your Event has been created."
+    When I go to "Admin/Contents/List"
+    Then I should see "Location:" 
+        And I should see "Phoenix"
+
+    # If required and the default value is not valid, the value should be required
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                            | value    |
+            | Fields[0].EnumerationFieldSettings.Required     | true     |
+            | Fields[0].EnumerationFieldSettings.Options      | Phoenix  |
+            | Fields[0].EnumerationFieldSettings.ListMode     | Checkbox |
+            | Fields[0].EnumerationFieldSettings.DefaultValue | foo;bar  |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "Location"
+    When I fill in 
+            | name                          | value |
+            | Event.Location.SelectedValues |       |
+        And I hit "Save"
+    Then I should see "The field Location is mandatory."
+	
+    # If required and no default value, the list box should have the required attribute
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                            | value   |
+            | Fields[0].EnumerationFieldSettings.Required     | true    |
+            | Fields[0].EnumerationFieldSettings.ListMode     | Listbox |
+            | Fields[0].EnumerationFieldSettings.DefaultValue |         |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should see "required=\"required\""
+	
+    # If required and a default value is set, the list box should not have the required attribute
+    When I go to "Admin/ContentTypes/Edit/Event"
+        And I fill in 
+            | name                                            | value   |
+            | Fields[0].EnumerationFieldSettings.Required     | true    |
+            | Fields[0].EnumerationFieldSettings.ListMode     | Listbox |
+            | Fields[0].EnumerationFieldSettings.DefaultValue | Phoenix |
+        And I hit "Save"
+        And I go to "Admin/Contents/Create/Event"
+    Then I should not see "required=\"required\""

--- a/src/Orchard.Specs/Enumeration.feature.cs
+++ b/src/Orchard.Specs/Enumeration.feature.cs
@@ -273,6 +273,208 @@ this.ScenarioSetup(scenarioInfo);
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 109
     testRunner.Then("I should see \"The field Location is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 112
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table11.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.Options",
+                        "Seattle"});
+            table11.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Dropdown"});
+            table11.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.DefaultValue",
+                        "Seattle"});
+#line 113
+        testRunner.And("I fill in", ((string)(null)), table11, "And ");
+#line 118
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 119
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 120
+    testRunner.Then("I should see \"selected=\\\"selected\">Seattle\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 123
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table12.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.Required",
+                        "false"});
+            table12.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.Options",
+                        "Boston"});
+            table12.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Checkbox"});
+            table12.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.DefaultValue",
+                        "foo;Boston;bar"});
+#line 124
+        testRunner.And("I fill in", ((string)(null)), table12, "And ");
+#line 130
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 131
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 132
+    testRunner.Then("I should see \"Location\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table13.AddRow(new string[] {
+                        "Event.Location.SelectedValues",
+                        ""});
+#line 133
+    testRunner.When("I fill in", ((string)(null)), table13, "When ");
+#line 136
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 137
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 138
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 139
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 140
+    testRunner.Then("I should see \"Location:\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 141
+        testRunner.And("I should see \"Boston\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 144
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table14.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.Required",
+                        "true"});
+            table14.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.Options",
+                        "Phoenix"});
+            table14.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Checkbox"});
+            table14.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.DefaultValue",
+                        "foo;Phoenix;bar"});
+#line 145
+        testRunner.And("I fill in", ((string)(null)), table14, "And ");
+#line 151
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 152
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 153
+    testRunner.Then("I should see \"Location\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table15.AddRow(new string[] {
+                        "Event.Location.SelectedValues",
+                        ""});
+#line 154
+    testRunner.When("I fill in", ((string)(null)), table15, "When ");
+#line 157
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 158
+        testRunner.And("I am redirected", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 159
+    testRunner.Then("I should see \"Your Event has been created.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 160
+    testRunner.When("I go to \"Admin/Contents/List\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 161
+    testRunner.Then("I should see \"Location:\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 162
+        testRunner.And("I should see \"Phoenix\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 165
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table16 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table16.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.Required",
+                        "true"});
+            table16.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.Options",
+                        "Phoenix"});
+            table16.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Checkbox"});
+            table16.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.DefaultValue",
+                        "foo;bar"});
+#line 166
+        testRunner.And("I fill in", ((string)(null)), table16, "And ");
+#line 172
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 173
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 174
+    testRunner.Then("I should see \"Location\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            TechTalk.SpecFlow.Table table17 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table17.AddRow(new string[] {
+                        "Event.Location.SelectedValues",
+                        ""});
+#line 175
+    testRunner.When("I fill in", ((string)(null)), table17, "When ");
+#line 178
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 179
+    testRunner.Then("I should see \"The field Location is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 182
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table18 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table18.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.Required",
+                        "true"});
+            table18.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Listbox"});
+            table18.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.DefaultValue",
+                        ""});
+#line 183
+        testRunner.And("I fill in", ((string)(null)), table18, "And ");
+#line 188
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 189
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 190
+    testRunner.Then("I should see \"required=\\\"required\\\"\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 193
+    testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+            TechTalk.SpecFlow.Table table19 = new TechTalk.SpecFlow.Table(new string[] {
+                        "name",
+                        "value"});
+            table19.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.Required",
+                        "true"});
+            table19.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Listbox"});
+            table19.AddRow(new string[] {
+                        "Fields[0].EnumerationFieldSettings.DefaultValue",
+                        "Phoenix"});
+#line 194
+        testRunner.And("I fill in", ((string)(null)), table19, "And ");
+#line 199
+        testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 200
+        testRunner.And("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 201
+    testRunner.Then("I should not see \"required=\\\"required\\\"\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
@@ -48,7 +48,12 @@ namespace Orchard.Fields.Drivers {
             if (updater.TryUpdateModel(field, GetPrefix(field, part), null, null)) {
                 var settings = field.PartFieldDefinition.Settings.GetModel<BooleanFieldSettings>();
                 if (!settings.Optional && !field.Value.HasValue) {
-                    updater.AddModelError(field.Name, T("The field {0} is mandatory.", T(field.DisplayName)));
+                    if (settings.DefaultValue.HasValue) {
+                        field.Value = settings.DefaultValue;
+                    }
+                    else {
+                        updater.AddModelError(field.Name, T("The field {0} is mandatory.", T(field.DisplayName)));
+                    }
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
@@ -7,6 +7,7 @@ using Orchard.Localization;
 using Orchard.Tokens;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Orchard.Fields.Drivers {
     public class EnumerationFieldDriver : ContentFieldDriver<EnumerationField> {
@@ -40,7 +41,7 @@ namespace Orchard.Fields.Drivers {
                 () => {
                     if (field.Value == null) {
                         var settings = field.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
-                        if (!String.IsNullOrEmpty(settings.DefaultValue)) {
+                        if (!String.IsNullOrWhiteSpace(settings.DefaultValue)) {
                             field.Value = _tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } });
                         }
                     }
@@ -52,6 +53,16 @@ namespace Orchard.Fields.Drivers {
         protected override DriverResult Editor(ContentPart part, EnumerationField field, IUpdateModel updater, dynamic shapeHelper) {
             if (updater.TryUpdateModel(field, GetPrefix(field, part), null, null)) {
                 var settings = field.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
+
+                if (field.SelectedValues.Length == 0 && !String.IsNullOrWhiteSpace(settings.DefaultValue) && !String.IsNullOrWhiteSpace(settings.Options)) {
+                    field.Value = _tokenizer.Replace(settings.DefaultValue, new Dictionary<string, object> { { "Content", part.ContentItem } });
+
+                    string[] options = settings.Options.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                    var selectedValues = field.SelectedValues.ToList();
+                    selectedValues.RemoveAll(value => !options.Any(value.Equals));
+                    field.SelectedValues = selectedValues.ToArray();
+                }
+
                 if (settings.Required && field.SelectedValues.Length == 0) {
                     updater.AddModelError(field.Name, T("The field {0} is mandatory", T(field.DisplayName)));
                 }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
@@ -3,47 +3,49 @@
 @{
     var settings = Model.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
     string[] options = (!String.IsNullOrWhiteSpace(settings.Options)) ? settings.Options.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.None) : new string[] { T("Select an option").ToString() };
+    var isRequired = settings.Required && String.IsNullOrWhiteSpace(settings.DefaultValue);
 }
 <fieldset>
-    <label for="@Html.FieldIdFor(m => m.Value)" @if(settings.Required) { <text>class="required"</text> }>@Model.DisplayName</label>
+    <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text>  }>@Model.DisplayName</label>
     @switch (settings.ListMode) {
         case ListMode.Dropdown:
-            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.Value), settings.Required ? new {required = "required"} : null)
+            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.Value), isRequired ? new { required = "required" } : null)
             break;
-        
+
         case ListMode.Radiobutton:
             foreach (var option in options) {
-                if (string.IsNullOrWhiteSpace(option)) {	
-                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.Value), settings.Required ? new {required = "required"} : null)<i>@T("unset")</i></label>      
-	            }
+                if (string.IsNullOrWhiteSpace(option)) {
+                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.Value), isRequired ? new { required = "required" } : null)<i>@T("unset")</i></label>            }
                 else {
-                    <label>@Html.RadioButton("Value", option, (option == Model.Value), settings.Required ? new {required = "required"} : null)@option</label>
-	            }
+                    <label>@Html.RadioButton("Value", option, (option == Model.Value), isRequired ? new { required = "required" } : null)@option</label>         }
             }
             break;
-        
+
         case ListMode.Listbox:
             <input name="@Html.FieldNameFor(m => m.SelectedValues)" type="hidden" />
-            @Html.ListBoxFor(m => m.SelectedValues, new MultiSelectList(options, Model.SelectedValues), settings.Required ? new {required = "required"} : null)
+            @Html.ListBoxFor(m => m.SelectedValues, new MultiSelectList(options, Model.SelectedValues), isRequired ? new { required = "required" } : null)
             break;
 
         case ListMode.Checkbox:
             int index = 0;
             <input name="@Html.FieldNameFor(m => m.SelectedValues)" type="hidden" />
-                    foreach (var option in options) {
-                        index++;
-                        if (!string.IsNullOrWhiteSpace(option)) {
+            foreach (var option in options) {
+                index++;
+                if (!string.IsNullOrWhiteSpace(option)) {
                     <div>
-                        <input type="checkbox" name="@Html.FieldNameFor(m => m.SelectedValues)" value="@option" @((Model.SelectedValues != null && Model.SelectedValues.Contains(option)) ? "checked=\"checked\"" : "") class="check-box" id="@Html.FieldIdFor(m => m.SelectedValues)-@index" @if(settings.Required) {<text> required="required"</text> } />
-	                    <label class="forcheckbox" for="@Html.FieldIdFor(m => m.SelectedValues)-@index">@T(option)</label>
+                        <input type="checkbox" name="@Html.FieldNameFor(m => m.SelectedValues)" value="@option" @((Model.SelectedValues != null && Model.SelectedValues.Contains(option)) ? "checked=\"checked\"" : "") class="check-box" id="@Html.FieldIdFor(m => m.SelectedValues)-@index" />
+                        <label class="forcheckbox" for="@Html.FieldIdFor(m => m.SelectedValues)-@index">@T(option)</label>
                     </div>
-                        }
-                    }
-                    break;
+                }
+            }
+            break;
     }
-    
+
     @Html.ValidationMessageFor(m => m.SelectedValues)
     @if (HasText(settings.Hint)) {
-    <span class="hint">@settings.Hint</span>
+        <span class="hint">@settings.Hint</span>
+    }
+    @if (!String.IsNullOrWhiteSpace(settings.DefaultValue)) {
+        <span class="hint">@T("If no option is selected then the default value will be used.")</span>
     }
 </fieldset>


### PR DESCRIPTION
Fixes #6550. (with other related PRs)

Note: i didn't have a look on other custom fields as TaxonomyField... Only those in Orchard.Fields.

**EnumerationField**

Unlike other fields, here the default value was not used in the Editor method that updates the model but in the other one, this on first creation to have a predefined value. Let me know if we need this on other fields, or if it's case by case. Right now, i left it.

- Anyway, i also use the default value in the editor method that update the model, as with other fields. Then, when another submission happens with no selected option, we can re-use the default value (even it has been changed in the settings). And this before the required checking on server side.

- When using the default value, we retain only its valid options (according to the options settings).

- I've added the hint message `If no option is selected then the default value will be used.`.

- I've removed the client required attributes when checkboxes are used, because, if required and no default value is set, `you are forced to check all checkboxes on client side`.

Enumeration feature spec pass.

**BooleanField**

- Here, there is no client required attribute. Maybe because, when required, with the controls you can use there is always a valid submitted value. This may change but I let it as before.
- However, the required checking (here if not `Optional`) is still done on server side. So, i've just added the ability to use the default value if not null (here not `Neutral`).
- And i've adapted the related feature specflow not to use the default value while it was expecting a `Mandatory` message. This by setting the default value to `Neutral`.

Best