### PR TITLE
Include jQuery-UI in the Orchard.Resources project and fix typo that prevents loading jQueryTimeEntry

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Resources/Orchard.Resources.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Resources/Orchard.Resources.csproj
@@ -822,6 +822,8 @@
     <Content Include="Styles\jquery-colorbox.min.css" />
     <Content Include="Styles\jquery-datetime-editor.css" />
     <Content Include="Styles\jquery-datetime-editor.min.css" />
+    <Content Include="Styles\jquery-ui.css" />
+    <Content Include="Styles\jquery-ui.min.css" />
     <Content Include="Styles\TimeEntry\jquery.timeentry.css" />
     <Content Include="Styles\TimeEntry\jquery.timeentry.min.css" />
     <Content Include="Web.config" />

--- a/src/Orchard.Web/Modules/Orchard.Resources/jQuery.cs
+++ b/src/Orchard.Web/Modules/Orchard.Resources/jQuery.cs
@@ -52,7 +52,7 @@ namespace Orchard.Resources {
             manifest.DefineStyle("jQueryCalendars_Picker").SetUrl("Calendars/jquery.calendars.picker.full.min.css", "Calendars/jquery.calendars.picker.full.css").SetDependencies("jQueryUI_Orchard").SetVersion("2.0.1");
 
             // jQuery Time Entry.
-            manifest.DefineScript("jQueryTimeEntry").SetUrl("TimeEntry/timejquery.timeentry.min.js", "TimeEntry/jquery.timeentry.js").SetDependencies("jQueryPlugin").SetVersion("2.0.1");
+            manifest.DefineScript("jQueryTimeEntry").SetUrl("TimeEntry/jquery.timeentry.min.js", "TimeEntry/jquery.timeentry.js").SetDependencies("jQueryPlugin").SetVersion("2.0.1");
             manifest.DefineStyle("jQueryTimeEntry").SetUrl("TimeEntry/jquery.timeentry.css").SetVersion("2.0.1");
 
             // jQuery Date/Time Editor Enhancements.


### PR DESCRIPTION
The jQuery-UI css files aren't included in the project, which means they don't get copied when doing a build.

The jQuery resource manifest file has a typo in the declaration for jQueryTimeEntry which prevents the minified version from being loaded.