### PR TITLE
[1.10.x] Include jQuery-UI in the Orchard.Resources csproj and fix jQueryTimeEntry script loading

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Resources/Orchard.Resources.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Resources/Orchard.Resources.csproj
@@ -822,6 +822,8 @@
     <Content Include="Styles\jquery-colorbox.min.css" />
     <Content Include="Styles\jquery-datetime-editor.css" />
     <Content Include="Styles\jquery-datetime-editor.min.css" />
+    <Content Include="Styles\jquery-ui.css" />
+    <Content Include="Styles\jquery-ui.min.css" />
     <Content Include="Styles\TimeEntry\jquery.timeentry.css" />
     <Content Include="Styles\TimeEntry\jquery.timeentry.min.css" />
     <Content Include="Web.config" />

--- a/src/Orchard.Web/Modules/Orchard.Resources/jQuery.cs
+++ b/src/Orchard.Web/Modules/Orchard.Resources/jQuery.cs
@@ -52,7 +52,7 @@ namespace Orchard.Resources {
             manifest.DefineStyle("jQueryCalendars_Picker").SetUrl("Calendars/jquery.calendars.picker.full.min.css", "Calendars/jquery.calendars.picker.full.css").SetDependencies("jQueryUI_Orchard").SetVersion("2.0.1");
 
             // jQuery Time Entry.
-            manifest.DefineScript("jQueryTimeEntry").SetUrl("TimeEntry/timejquery.timeentry.min.js", "TimeEntry/jquery.timeentry.js").SetDependencies("jQueryPlugin").SetVersion("2.0.1");
+            manifest.DefineScript("jQueryTimeEntry").SetUrl("TimeEntry/jquery.timeentry.min.js", "TimeEntry/jquery.timeentry.js").SetDependencies("jQueryPlugin").SetVersion("2.0.1");
             manifest.DefineStyle("jQueryTimeEntry").SetUrl("TimeEntry/jquery.timeentry.css").SetVersion("2.0.1");
 
             // jQuery Date/Time Editor Enhancements.


### PR DESCRIPTION
jQuery-UI wasn't included in the solution, which prevents it from being copied to the output directory when building.

There was a typo in the resource declaration of the jQueryTimeEntry script which prevented the minified version from loading.