### PR TITLE
#6639 : Azure Media Storage don't recognizes its own URLs

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/AzureFileSystem.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/AzureFileSystem.cs
@@ -308,9 +308,9 @@ namespace Orchard.Azure.Services.FileSystems {
 
         public string GetPublicUrl(string path) {
             path = ConvertToRelativeUriPath(path);
-            var uri = new UriBuilder(Container.GetBlockBlobReference(String.Concat(_root, path)).Uri);
-            if (!string.IsNullOrEmpty(_publicHostName)) uri.Host = _publicHostName;
-            return uri.Uri.ToString();
+            var uriBuilder = new UriBuilder(Container.GetBlockBlobReference(String.Concat(_root, path)).Uri);
+            if (!string.IsNullOrEmpty(_publicHostName)) uriBuilder.Host = _publicHostName;
+            return uriBuilder.Uri.ToString();
         }
 
         private class AzureBlobFileStorage : IStorageFile {

--- a/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/AzureFileSystem.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/AzureFileSystem.cs
@@ -310,7 +310,7 @@ namespace Orchard.Azure.Services.FileSystems {
             path = ConvertToRelativeUriPath(path);
             var uri = new UriBuilder(Container.GetBlockBlobReference(String.Concat(_root, path)).Uri);
             if (!string.IsNullOrEmpty(_publicHostName)) uri.Host = _publicHostName;
-            return uri.ToString();
+            return uri.Uri.ToString();
         }
 
         private class AzureBlobFileStorage : IStorageFile {

--- a/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/Media/AzureBlobStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/Media/AzureBlobStorageProvider.cs
@@ -4,6 +4,7 @@ using Orchard.Azure.Services.Environment.Configuration;
 using Orchard.Environment.Configuration;
 using Orchard.Environment.Extensions;
 using Orchard.FileSystems.Media;
+using System;
 
 namespace Orchard.Azure.Services.FileSystems.Media {
 
@@ -64,8 +65,10 @@ namespace Orchard.Azure.Services.FileSystems.Media {
         /// <returns>The corresponding local path.</returns>
         public string GetStoragePath(string url) {
             EnsureInitialized();
-            if (url.StartsWith(_absoluteRoot)) {
-                return HttpUtility.UrlDecode(url.Substring(Combine(_absoluteRoot, "/").Length));
+            var rootUri = new Uri(_absoluteRoot);
+            var uri = new Uri(url);
+            if((uri.Host == rootUri.Host || (!string.IsNullOrWhiteSpace(_publicHostName) && uri.Host == _publicHostName)) && uri.AbsolutePath.StartsWith(rootUri.AbsolutePath)) {
+                return HttpUtility.UrlDecode(uri.PathAndQuery.Substring(Combine(rootUri.AbsolutePath, "/").Length));
             }
 
             return null;

--- a/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/Media/AzureBlobStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/Media/AzureBlobStorageProvider.cs
@@ -67,7 +67,7 @@ namespace Orchard.Azure.Services.FileSystems.Media {
             EnsureInitialized();
             var rootUri = new Uri(_absoluteRoot);
             var uri = new Uri(url);
-            if((uri.Host == rootUri.Host || (!string.IsNullOrWhiteSpace(_publicHostName) && uri.Host == _publicHostName)) && uri.AbsolutePath.StartsWith(rootUri.AbsolutePath)) {
+            if((uri.Host == rootUri.Host || (!string.IsNullOrEmpty(_publicHostName) && uri.Host == _publicHostName)) && uri.AbsolutePath.StartsWith(rootUri.AbsolutePath)) {
                 return HttpUtility.UrlDecode(uri.PathAndQuery.Substring(Combine(rootUri.AbsolutePath, "/").Length));
             }
 


### PR DESCRIPTION
Removes port when default in PublicUrl.
`GetStoragePath` recognizes endpoint and public hostnames.