### PR TITLE
#6659: [1.10.x] [dev] Taxonomy Tags Api issue

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Scripts/admin-taxonomy-tags.js
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Scripts/admin-taxonomy-tags.js
@@ -86,11 +86,12 @@
     **********************************************************************/
     $(".terms-editor").each(function () {
         var selectedTerms = $(this).data("selected-terms");
+        var baseUrl = $(this).data("base-url");
 
         var $tagit = $("> ul", this).tagit({
             tagSource: function (request, response) {
                 var termsEditor = $(this.element).parents(".terms-editor");
-                $.getJSON("/api/taxonomies/tags", { taxonomyId: termsEditor.data("taxonomy-id"), leavesOnly: termsEditor.data("leaves-only"), query: request.term }, function (data, status, xhr) {
+                $.getJSON(baseUrl + "/api/taxonomies/tags", { taxonomyId: termsEditor.data("taxonomy-id"), leavesOnly: termsEditor.data("leaves-only"), query: request.term }, function (data, status, xhr) {
                     response(data);
                 });
             },

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.Autocomplete.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.Autocomplete.cshtml
@@ -3,7 +3,7 @@
 @using Orchard.Taxonomies.Models
 @using Orchard.Utility.Extensions;
 @using Orchard.Taxonomies.ViewModels;
-
+@using Orchard.Environment.Configuration
 
 @{
     if (Model.Settings.Autocomplete) {
@@ -18,6 +18,7 @@
     Script.Include("~/Themes/TheAdmin/scripts/admin.js").AtFoot();
     Script.Include("admin-taxonomy-expando.js").AtFoot();
 
+    var baseUrl = Href("~/");
 }
 @functions {
     bool IsTermDisabled(TermPart term) {
@@ -27,13 +28,13 @@
 @{
     var termIndex = 0;
     var checkedTerms = Model.SelectedTerms.ToList();
-    var selectedTerms = Newtonsoft.Json.JsonConvert.SerializeObject(checkedTerms.Select(x => new { label = x.Name, value = x.Id, levels = 0, disabled = true })); 
+    var selectedTerms = Newtonsoft.Json.JsonConvert.SerializeObject(checkedTerms.Select(x => new { label = x.Name, value = x.Id, levels = 0, disabled = true }));
 
 }
 <fieldset class="taxonomy-wrapper" data-name-prefix="@Html.FieldNameFor(m => m)" data-id-prefix="@Html.FieldIdFor(m => m)">
     <label @if(Model.Settings.Required) { <text>class="required"</text> }>@Model.DisplayName</label>
     @if (Model.Settings.Autocomplete) {
-    <div class="terms-editor text text-medium" data-taxonomy-id="@Model.TaxonomyId" data-leaves-only="@Model.Settings.LeavesOnly" data-selected-terms="@selectedTerms" data-allow-new-terms="@Model.Settings.AllowCustomTerms.ToString().ToLower()" data-singlechoice="@Model.Settings.SingleChoice.ToString().ToLower()">
+    <div class="terms-editor text text-medium" data-base-url="@baseUrl" data-taxonomy-id="@Model.TaxonomyId" data-leaves-only="@Model.Settings.LeavesOnly" data-selected-terms="@selectedTerms" data-allow-new-terms="@Model.Settings.AllowCustomTerms.ToString().ToLower()" data-singlechoice="@Model.Settings.SingleChoice.ToString().ToLower()">
             <ul></ul>
             @if (Model.Settings.SingleChoice) {
                 <div class="hint">@T("Enter a single term. Hit <i>tab</i> or <i>enter</i> to apply the term.") @if (!Model.Settings.AllowCustomTerms) { <text>@T("This taxonomy does not allow you to create new terms.") </text> }</div>


### PR DESCRIPTION
Fixes #6659 

**Repro** (both in 1.10.x and dev)

- Use a virtual directory as `OrchardLocal` (or maybe a tenant prefix).
- Add a taxonomy field to a content type, and check the autocomplete option.
- Edit a content item of this type and try to add a term by using the autocomplete field.
- Then you get `can't acces the admin` exceptions.

**Analysis**

- In `admin-taxonomy-tags.js` there is an ajax call that targets `TagsController` (an `ApiController`) by using a relative url (not a full url) with an absolute virtual path `/api/taxonomies/tags`. So, It doesn't work if you use a virtual directory as `OrchardLocal` or, i think, if you use a tenant prefix.

**Fix**

- By initializing a `baseUrl` variable in the razor view and using it as an html data attribute. Then, using this data attribute in the script to construct the full url e.g  `http://localhost:30321/OrchardLoca/api/taxonomies/tags`.

**Note**

In place of using a baseUrl, i could resolve and use directly the full url by using an url helper to target the api controller. But i would need to apply #5823. If applied, using one of the following works:

    // This one because of the fixed priority issue.
    var fullApiUrl = Url.HttpRouteUrl("", new { area = "Orchard.Taxonomies", controller = "Tags" });

    // Or, maybe better, this one because of the new http route default name.
    var fullApiUrl = Url.HttpRouteUrl("Taxonomies.Api", new { controller = "Tags" });

Best.