### PR TITLE
Fix #6721: Fix an issue that ChildAction will incorrectly reset _cacheKey for OutputCacheFilter

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -178,15 +178,16 @@ namespace Orchard.OutputCache.Filters {
         }
 
         public void OnResultExecuted(ResultExecutedContext filterContext) {
+            // This filter is not reentrant (multiple executions within the same request are
+            // not supported) so child actions are ignored completely.
+            if (filterContext.IsChildAction)
+                return;
 
             var captureHandlerIsAttached = false;
 
             try {
-                
-                // This filter is not reentrant (multiple executions within the same request are
-                // not supported) so child actions are ignored completely.
-                if (filterContext.IsChildAction || !_isCachingRequest)
-                return;
+                if (!_isCachingRequest)
+                    return;
 
                 Logger.Debug("Item '{0}' was rendered.", _cacheKey);
 


### PR DESCRIPTION
This wasn't raising awareness in Orchard community as the official code base does not use Child Actions (they use shapes).

Previously there is reentrancy-prevention code in OnResultExecuted to filter out Child Actions so that OnResultExecuted only gets executed once per request and only for the parent Action. However, this reentrancy-prevention code is being incorrectly placed in the try-catch block, that the finally-block can get executed more than once if parent Action includes any Child Action. This wasn't an issue until commit 117dd09f (first included in release 1.10) which resets _cacheKey in that finally-block via ReleaseCacheKeyLock. Now for every request that uses Child Actions, the finally block will be executed at least once during Child Action's OnResultExecuted, leaving the _cacheKey as null. Later after all Child Actions finish execution, the parent Action's OnResultExecuted will now see a _cacheKey of null, thus causing NRE in the inline event handling code for event captureStream.Captured.