### PR TITLE
Workaround to avoid Transaction issue for PostgreSQL when creating DistributedLocks table

### DIFF
--- a/src/Orchard/Data/Migration/AutomaticDataMigrations.cs
+++ b/src/Orchard/Data/Migration/AutomaticDataMigrations.cs
@@ -84,8 +84,11 @@ namespace Orchard.Data.Migration {
             // Ensure the distributed lock record schema exists.
             var schemaBuilder = new SchemaBuilder(_dataMigrationInterpreter);
             var distributedLockSchemaBuilder = new DistributedLockSchemaBuilder(_shellSettings, schemaBuilder);
-            if (distributedLockSchemaBuilder.EnsureSchema())
+            if (!distributedLockSchemaBuilder.SchemaExists()) {
+                // Workaround to avoid some Transaction issue for PostgreSQL.
                 _transactionManager.RequireNew();
+                distributedLockSchemaBuilder.CreateSchema();
+            }
         }
     }
 }

--- a/src/Orchard/Tasks/Locking/Services/DistributedLockSchemaBuilder.cs
+++ b/src/Orchard/Tasks/Locking/Services/DistributedLockSchemaBuilder.cs
@@ -13,14 +13,6 @@ namespace Orchard.Tasks.Locking.Services {
             _schemaBuilder = schemaBuilder;
         }
 
-        public bool EnsureSchema() {
-            if (SchemaExists())
-                return false;
-
-            CreateSchema();
-            return true;
-        }
-
         public void CreateSchema() {
             _schemaBuilder.CreateTable(TableName, table => table
                 .Column<int>("Id", column => column.PrimaryKey().Identity())
@@ -36,8 +28,8 @@ namespace Orchard.Tasks.Locking.Services {
 
         public bool SchemaExists() {
             try {
-                var tablePrefix = String.IsNullOrEmpty(_shellSettings.DataTablePrefix) ? "" : _shellSettings.DataTablePrefix + "_";
-                _schemaBuilder.ExecuteSql(String.Format("select * from {0}{1}", tablePrefix, TableName));
+                var tablePrefix = string.IsNullOrEmpty(_shellSettings.DataTablePrefix) ? "" : _shellSettings.DataTablePrefix + "_";
+                _schemaBuilder.ExecuteSql(string.Format("select * from {0}{1}", tablePrefix, TableName));
                 return true;
             }
             catch {

--- a/src/Orchard/Tasks/Locking/Services/DistributedLockSchemaBuilder.cs
+++ b/src/Orchard/Tasks/Locking/Services/DistributedLockSchemaBuilder.cs
@@ -28,8 +28,8 @@ namespace Orchard.Tasks.Locking.Services {
 
         public bool SchemaExists() {
             try {
-                var tablePrefix = string.IsNullOrEmpty(_shellSettings.DataTablePrefix) ? "" : _shellSettings.DataTablePrefix + "_";
-                _schemaBuilder.ExecuteSql(string.Format("select * from {0}{1}", tablePrefix, TableName));
+                var tablePrefix = String.IsNullOrEmpty(_shellSettings.DataTablePrefix) ? "" : _shellSettings.DataTablePrefix + "_";
+                _schemaBuilder.ExecuteSql(String.Format("select * from {0}{1}", tablePrefix, TableName));
                 return true;
             }
             catch {


### PR DESCRIPTION
When checking if the "Orchard_Framework_DistributedLockRecord" exists, a select on the table is performed. When the table does not exist, this throws an exception.
In PostgreSQL, this sets the transaction in an Error state. Because of this, the transaction accepts no other commands, and the table is never created.

This pull request works around this, by starting a new transaction to create the table  

@OrchardCMS