### PR TITLE
[1.10.x] [Dev] Processing Engine Tasks not evaluated on startup

### DIFF
--- a/src/Orchard/Environment/DefaultOrchardHost.cs
+++ b/src/Orchard/Environment/DefaultOrchardHost.cs
@@ -161,7 +161,7 @@ namespace Orchard.Environment {
                             ActivateShell(context);
 
                             // If everything went well, return to stop the retry loop
-                            return;
+                            break;
                         }
                         catch (Exception ex) {
                             if (i == Retries) {


### PR DESCRIPTION
Not tried other things, just seen that we have to break the retry loop in place of returning.

Best.