### PR TITLE
[1.10.x] fix double click prevention when client validation

### DIFF
--- a/src/Orchard.Web/Themes/TheAdmin/Scripts/admin.js
+++ b/src/Orchard.Web/Themes/TheAdmin/Scripts/admin.js
@@ -84,11 +84,14 @@
     //Prevent double-click on buttons of type "submit"
     $("form button[type='submit'], form input[type='submit']").click(function (e) {
         var form = $(this).closest("form")[0];
-        if (typeof(form.formSubmitted) != "undefined") {
+        if (typeof (form.formSubmitted) != "undefined" && form.formSubmitted == true) {
             e.preventDefault();
             return;
         }
         form.formSubmitted = true;
+        setTimeout(function () {
+            form.formSubmitted = false;
+        }, 1000);
     });
 
     // Handle keypress events in bulk action fieldsets that are part of a single form.

--- a/src/Orchard.Web/Themes/TheAdmin/Scripts/admin.js
+++ b/src/Orchard.Web/Themes/TheAdmin/Scripts/admin.js
@@ -84,13 +84,13 @@
     //Prevent double-click on buttons of type "submit"
     $("form button[type='submit'], form input[type='submit']").click(function (e) {
         var form = $(this).closest("form")[0];
-        if (typeof (form.formSubmitted) != "undefined" && form.formSubmitted == true) {
+        if (!!form.submitted) {
             e.preventDefault();
             return;
         }
-        form.formSubmitted = true;
+        form.submitted = true;
         setTimeout(function () {
-            form.formSubmitted = false;
+            form.submitted = false;
         }, 1000);
     });
 


### PR DESCRIPTION
If you click on submit but the form is not submitted because of client validation, then you can't submit anymore.