### PR TITLE
[1.10.x] Link placeholder used but doesn't exist in settings

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Link.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Link.Edit.cshtml
@@ -38,7 +38,7 @@
             <label for="@Html.FieldIdFor(m => m.Text)" @if (settings.LinkTextMode == LinkTextMode.Required) { <text> class="required" </text>  }>@T("Text")</label>
         </div>
         <div class="editor-field">
-            @(isTextRequired ? Html.TextBoxFor(m => m.Text, new { @class = "text medium", placeholder = settings.TextPlaceholder, required = "required" }) : Html.TextBoxFor(m => m.Text, new { @class = "text medium", placeholder = settings.TextPlaceholder }))
+            @(isTextRequired ? Html.TextBoxFor(m => m.Text, new { @class = "text medium", required = "required" }) : Html.TextBoxFor(m => m.Text, new { @class = "text medium" }))
             @if (!String.IsNullOrWhiteSpace(settings.TextDefaultValue)) {
                 <span class="hint">@T("If the field is left empty then the default value will be used.")</span>
             }


### PR DESCRIPTION
So the `Link.Edit.cshtml` fails.
Just seen that the placeholder settings is defined in the dev branch, not in 1.10.x.

Best.