### PR TITLE
Fixing multi-submission

### DIFF
--- a/src/Orchard.Web/Themes/TheAdmin/Scripts/admin.js
+++ b/src/Orchard.Web/Themes/TheAdmin/Scripts/admin.js
@@ -93,18 +93,10 @@
 
         form.addClass(submittingClass);
 
-        buttons = form.find("[type='submit']");
-        buttons.prop("disabled", true)
-
         // safety-nest in case the form didn't refresh the page
         setTimeout(function () {
             form.removeClass(submittingClass);
-            buttons.prop("disabled", false)
         }, 5000);
-
-        e.preventDefault();
-        return;
-
     });
 
     // Handle keypress events in bulk action fieldsets that are part of a single form.


### PR DESCRIPTION
Fixes #6788 

@sebastienros 

Just because i still have some drawbacks with your last `multi-submission` checking, here, a proposed solution which seems to work. So, based on the last implementation but:

- Without using `e.preventDefault()` at the end. This to submit the form.
- And without adding to the buttons the disabled property. Otherwise the button value e.g `submit.Publish` is not used and e.g you will not see `Your Page has been saved`.

Note: as before, this only acts on forms with the `no-multisubmit` class.

Best.