### PR TITLE
PE tasks list init and start background timer after PE tasks.

### DIFF
--- a/src/Orchard.Tests.Modules/Comments/Services/CommentServiceTests.cs
+++ b/src/Orchard.Tests.Modules/Comments/Services/CommentServiceTests.cs
@@ -203,6 +203,8 @@ namespace Orchard.Tests.Modules.Comments.Services {
 
     public class ProcessingEngineStub : IProcessingEngine {
 
+        public void Initialize() { }
+
         public string AddTask(ShellSettings shellSettings, ShellDescriptor shellDescriptor, string messageName, Dictionary<string, object> parameters) {
             return "";
         }

--- a/src/Orchard/Environment/DefaultOrchardShell.cs
+++ b/src/Orchard/Environment/DefaultOrchardShell.cs
@@ -50,6 +50,7 @@ namespace Orchard.Environment {
         }
 
         public ILogger Logger { get; set; }
+        public ISweepGenerator Sweep { get { return _sweepGenerator; } }
 
         public void Activate() {
             var appBuilder = new AppBuilder();

--- a/src/Orchard/Environment/IOrchardShell.cs
+++ b/src/Orchard/Environment/IOrchardShell.cs
@@ -1,6 +1,9 @@
+using Orchard.Tasks;
+
 namespace Orchard.Environment {
     public interface IOrchardShell {
         void Activate();
         void Terminate();
+        ISweepGenerator Sweep { get; }
     }
 }

--- a/src/Orchard/Environment/State/DefaultProcessingEngine.cs
+++ b/src/Orchard/Environment/State/DefaultProcessingEngine.cs
@@ -22,6 +22,10 @@ namespace Orchard.Environment.State {
             _entries = new ContextState<IList<Entry>>("DefaultProcessingEngine.Entries", () => new List<Entry>());
         }
 
+        public void Initialize() {
+            _entries.SetState(new List<Entry>());
+        }
+
         public string AddTask(ShellSettings shellSettings, ShellDescriptor shellDescriptor, string eventName, Dictionary<string, object> parameters) {
 
             var entry = new Entry {

--- a/src/Orchard/Environment/State/IProcessingEngine.cs
+++ b/src/Orchard/Environment/State/IProcessingEngine.cs
@@ -7,6 +7,11 @@ namespace Orchard.Environment.State
     public interface IProcessingEngine
     {
         /// <summary>
+        /// Init a new tasks list in the http context or in a new logical context.
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
         /// Queue an event to fire inside of an explicitly decribed shell context
         /// </summary>        
         string AddTask(


### PR DESCRIPTION
Fixes #6742 

- On startup, for each tenant, explicitly init the PE tasks list in a new (isolated from its parent) logical context, this at the beginning of the desired parent thread.

- On startup, for each tenant, suspend the background timer until the PE tasks list is fully evaluated.


On startup, a shell and its bg timer are activated in the same logical context, so the PE list is shared with bg tasks. So, maybe good to also init (isolate) the PE tasks list at the beginning of the background service. But here it's not needed because bg tasks are suspended while evaluating the PE list.


Best.