### PR TITLE
avoid potential arg null ex

### DIFF
--- a/src/Orchard.Web/Modules/Lucene/Models/LuceneSearchHit.cs
+++ b/src/Orchard.Web/Modules/Lucene/Models/LuceneSearchHit.cs
@@ -14,7 +14,7 @@ namespace Lucene.Models {
             _score = score;
         }
 
-        public int ContentItemId { get { return int.Parse(GetString("id")); } }
+        public int ContentItemId { get { return GetInt("id"); } }
 
         public int GetInt(string name) {
             var field = _doc.GetField(name);


### PR DESCRIPTION
inside public string GetString(string name) {
            var field = _doc.GetField(name);
            return field == null ? null : field.StringValue;
        }
if field=null, then arg null ex for int.Parse