### PR TITLE
Add ReSharper support to the Razor view engine

### DIFF
--- a/src/Orchard/Mvc/ViewEngines/Razor/RazorViewEngineProvider.cs
+++ b/src/Orchard/Mvc/ViewEngines/Razor/RazorViewEngineProvider.cs
@@ -69,6 +69,7 @@ namespace Orchard.Mvc.ViewEngines.Razor {
                 .SelectMany(x => new[] {
                                            x + "/Views/{0}.cshtml",
                                        })
+                .Concat(new[] { "~/Views/{1}/{0}.cshtml", "~/Views/{0}.cshtml" })
                 .ToArray();
 
             //Logger.Debug("UniversalFormats (module): \r\n\t-{0}", string.Join("\r\n\t-", universalFormats));


### PR DESCRIPTION
Previously, ReSharper was unable to resolve views when using Orchard. Someone from the R# team recommended a fix to allow the resolution of views.

Here's the R# recommendation, for reference: https://youtrack.jetbrains.com/issue/RSRP-451935
