### PR TITLE
#5143 AssemblyInfo build action Compile instead of Content with CodeGen update

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Orchard.AuditTrail.csproj
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Orchard.AuditTrail.csproj
@@ -135,7 +135,7 @@
     </Content>
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
     <Content Include="Views\Parts.Contents.AuditTrail.SummaryAdmin.cshtml" />
     <Content Include="Views\DefinitionTemplates\AuditTrailPartSettings.cshtml" />

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Orchard.Azure.MediaServices.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Orchard.Azure.MediaServices.csproj
@@ -276,7 +276,7 @@
     </Content>
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
     <Content Include="Assets\TypeScript\cloudmedia-videoplayer-data.ts" />
     <Content Include="Assets\TypeScript\cloudmedia-videoplayer-injectors-dash.ts" />

--- a/src/Orchard.Web/Modules/Orchard.Caching/Orchard.Caching.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Caching/Orchard.Caching.csproj
@@ -90,7 +90,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.CodeGeneration/CodeGenerationTemplates/ModuleCsProj.txt
+++ b/src/Orchard.Web/Modules/Orchard.CodeGeneration/CodeGenerationTemplates/ModuleCsProj.txt
@@ -69,7 +69,9 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
-  $$FileIncludes$$<ItemGroup>
+  $$CompileIncludes$$
+  $$ContentIncludes$$
+  <ItemGroup>
     $$OrchardReferences$$
   </ItemGroup>
   <PropertyGroup>

--- a/src/Orchard.Web/Modules/Orchard.CodeGeneration/Commands/CodeGenerationCommands.cs
+++ b/src/Orchard.Web/Modules/Orchard.CodeGeneration/Commands/CodeGenerationCommands.cs
@@ -273,6 +273,7 @@ namespace Orchard.CodeGeneration.Commands {
             string propertiesPath = modulePath + "Properties";
             var content = new HashSet<string>();
             var folders = new HashSet<string>();
+            var compile = new HashSet<string>();
 
             foreach (var folder in _moduleDirectories) {
                 Directory.CreateDirectory(modulePath + folder);
@@ -297,27 +298,29 @@ namespace Orchard.CodeGeneration.Commands {
             File.WriteAllText(modulePath + "Styles\\Web.config", File.ReadAllText(_codeGenTemplatePath + "StaticFilesWebConfig.txt"));
             content.Add(modulePath + "Styles\\Web.config");
 
-            string templateText = File.ReadAllText(_codeGenTemplatePath + "ModuleAssemblyInfo.txt");
-            templateText = templateText.Replace("$$ModuleName$$", moduleName);
-            templateText = templateText.Replace("$$ModuleTypeLibGuid$$", Guid.NewGuid().ToString());
-            File.WriteAllText(propertiesPath + "\\AssemblyInfo.cs", templateText);
-            content.Add(propertiesPath + "\\AssemblyInfo.cs");
-
-            templateText = File.ReadAllText(_codeGenTemplatePath + "ModuleManifest.txt");
+            string templateText = File.ReadAllText(_codeGenTemplatePath + "ModuleManifest.txt");
             templateText = templateText.Replace("$$ModuleName$$", moduleName);
             File.WriteAllText(modulePath + "Module.txt", templateText, System.Text.Encoding.UTF8);
             content.Add(modulePath + "Module.txt");
 
-            var itemGroup = CreateProjectItemGroup(modulePath, content, folders);
+            templateText = File.ReadAllText(_codeGenTemplatePath + "ModuleAssemblyInfo.txt");
+            templateText = templateText.Replace("$$ModuleName$$", moduleName);
+            templateText = templateText.Replace("$$ModuleTypeLibGuid$$", Guid.NewGuid().ToString());
+            File.WriteAllText(propertiesPath + "\\AssemblyInfo.cs", templateText);
+            compile.Add(propertiesPath + "\\AssemblyInfo.cs");
 
-            File.WriteAllText(modulePath + moduleName + ".csproj", CreateCsProject(moduleName, projectGuid, itemGroup));
+            var contentItemGroup = CreateProjectItemGroup(modulePath, content, folders);
+            var compileItemGroup = CreateCompileItemGroup(modulePath, compile);
+
+            File.WriteAllText(modulePath + moduleName + ".csproj", CreateCsProject(moduleName, projectGuid, contentItemGroup, compileItemGroup));
         }
 
-        private static string CreateCsProject(string projectName, string projectGuid, string itemGroup) {
+        private static string CreateCsProject(string projectName, string projectGuid, string contentItemGroup, string compileItemGroup) {
             string text = File.ReadAllText(_codeGenTemplatePath + "\\ModuleCsProj.txt");
             text = text.Replace("$$ModuleName$$", projectName);
             text = text.Replace("$$ModuleProjectGuid$$", projectGuid);
-            text = text.Replace("$$FileIncludes$$", itemGroup ?? "");
+            text = text.Replace("$$ContentIncludes$$", contentItemGroup ?? "");
+            text = text.Replace("$$CompileIncludes$$", compileItemGroup ?? "");
             text = text.Replace("$$OrchardReferences$$", GetOrchardReferences());
             return text;
         }
@@ -402,7 +405,7 @@ namespace Orchard.CodeGeneration.Commands {
             // create new csproj for the theme
             if (projectGuid != null) {
                 var itemGroup = CreateProjectItemGroup(themePath, createdFiles, createdFolders);
-                string projectText = CreateCsProject(themeName, projectGuid, itemGroup);
+                string projectText = CreateCsProject(themeName, projectGuid, itemGroup, null);
                 File.WriteAllText(themePath + "\\" + themeName + ".csproj", projectText);
             }
 
@@ -462,6 +465,23 @@ namespace Orchard.CodeGeneration.Commands {
                                                                select "    <Folder Include=\"" + folder.Replace(relativeFromPath, "") + "\" />");
             }
             return string.Format(CultureInfo.InvariantCulture, "<ItemGroup>\r\n{0}\r\n  </ItemGroup>\r\n  ", contentInclude);
+        }
+
+        private static string CreateCompileItemGroup(string relativeFromPath, HashSet<string> compile) {
+            var compileInclude = "";
+            if (relativeFromPath != null && !relativeFromPath.EndsWith("\\", StringComparison.OrdinalIgnoreCase)) {
+                relativeFromPath += "\\";
+            }
+            else if (relativeFromPath == null) {
+                relativeFromPath = "";
+            }
+
+            if (compile != null && compile.Count > 0) {
+                compileInclude = string.Join("\r\n",
+                                             from file in compile
+                                             select "    <Compile Include=\"" + file.Replace(relativeFromPath, "") + "\" />");
+            }
+            return string.Format(CultureInfo.InvariantCulture, "<ItemGroup>\r\n{0}\r\n  </ItemGroup>\r\n  ", compileInclude);
         }
 
         private void AddFilesToOrchardThemesProject(TextWriter output, string itemGroup) {

--- a/src/Orchard.Web/Modules/Orchard.Conditions/Orchard.Conditions.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Conditions/Orchard.Conditions.csproj
@@ -93,7 +93,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.Dashboards/Orchard.Dashboards.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Dashboards/Orchard.Dashboards.csproj
@@ -99,7 +99,7 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
     <Content Include="Views\StaticDashboard.cshtml" />
     <Content Include="Views\Content.Dashboard.cshtml" />

--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Orchard.DynamicForms.csproj
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Orchard.DynamicForms.csproj
@@ -124,7 +124,7 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Orchard.Layouts.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Orchard.Layouts.csproj
@@ -181,7 +181,7 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
     <Content Include="Views\EditorTemplates\Parts.Layout.cshtml" />
     <Content Include="Views\Element\Edit.cshtml" />

--- a/src/Orchard.Web/Modules/Orchard.MessageBus/Orchard.MessageBus.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MessageBus/Orchard.MessageBus.csproj
@@ -103,7 +103,7 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Orchard.OutputCache.csproj
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Orchard.OutputCache.csproj
@@ -103,7 +103,7 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.Redis/Orchard.Redis.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Redis/Orchard.Redis.csproj
@@ -81,7 +81,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.Resources/Orchard.Resources.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Resources/Orchard.Resources.csproj
@@ -829,7 +829,7 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.Templates/Orchard.Templates.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Templates/Orchard.Templates.csproj
@@ -154,7 +154,7 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
+++ b/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
@@ -118,7 +118,7 @@
     <Content Include="Styles\menu.upgrade-admin.css" />
     <Content Include="Web.config" />
     <Content Include="Styles\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fix for issue #5143 and root cause of several recurring issues related to AssemblyInfo being set to Content instead of Compile.

Updated CodeGen CL to add AssemblyInfo as Compile instead of content, in addition updated existing modules which had AssemblyInfo set to content:

- Orchard.AuditTrail
- Orchard.Azure.MediaServices
- Orchard.Caching
- Orchard.Conditions
- Orchard.Dashboards
- Orchard.DynamicForms
- Orchard.Layouts
- Orchard.MessageBus
- Orchard.OutputCache
- Orchard.Redis
- Orchard.Resources
- Orchard.Templates
- Upgrade

Smoketest passed commands:

codegen module <name>
codegen datamigration <name>
codegen moduletests <name>
codegen theme <name>
codegen theme <name> /createproject:true

Build with unit tests passed.