### PR TITLE
#6831 Implemented CdnSupportsSsl in Orchard UI Resources

### DIFF
--- a/src/Orchard.Tests/UI/Resources/ResourceManagerTests.cs
+++ b/src/Orchard.Tests/UI/Resources/ResourceManagerTests.cs
@@ -31,9 +31,13 @@ namespace Orchard.Tests.UI.Resources {
         }
 
         private void VerifyPaths(string resourceType, RequireSettings defaultSettings, string expectedPaths) {
+            VerifyPaths(resourceType, defaultSettings, expectedPaths, false);
+        }
+
+        private void VerifyPaths(string resourceType, RequireSettings defaultSettings, string expectedPaths, bool ssl) {
             defaultSettings = defaultSettings ?? new RequireSettings();
             var requiredResources = _resourceManager.BuildRequiredResources(resourceType);
-            var renderedResources = string.Join(",", requiredResources.Select(context => context.GetResourceUrl(defaultSettings, _appPath)).ToArray());
+            var renderedResources = string.Join(",", requiredResources.Select(context => context.GetResourceUrl(defaultSettings, _appPath, ssl)).ToArray());
             Assert.That(renderedResources, Is.EqualTo(expectedPaths));
         }
 
@@ -90,6 +94,33 @@ namespace Orchard.Tests.UI.Resources {
             };
             _resourceManager.Require("script", "Script1");
             VerifyPaths("script", new RequireSettings { CdnMode = true }, "http://cdn/script1.min.js");
+        }
+
+        [Test]
+        public void CdnSslPathIsUsedInCdnMode() {
+            _testManifest.DefineManifest = m => {
+                m.DefineResource("script", "Script1").SetUrl("script1.js").SetCdn("https://cdn/script1.min.js");
+            };
+            _resourceManager.Require("script", "Script1");
+            VerifyPaths("script", new RequireSettings { CdnMode = true }, "https://cdn/script1.min.js", true);
+        }
+
+        [Test]
+        public void LocalPathIsUsedInCdnModeNotSupportsSsl() {
+            _testManifest.DefineManifest = m => {
+                m.DefineResource("script", "Script1").SetUrl("script1.min.js", "script1.js").SetCdn("http://cdn/script1.min.js", "http://cdn/script1.js", false);
+            };
+            _resourceManager.Require("script", "Script1");
+            VerifyPaths("script", new RequireSettings { CdnMode = true }, "script1.min.js", true);
+        }
+
+        [Test]
+        public void LocalDebugPathIsUsedInCdnModeNotSupportsSslAndDebug() {
+            _testManifest.DefineManifest = m => {
+                m.DefineResource("script", "Script1").SetUrl("script1.min.js", "script1.js").SetCdn("http://cdn/script1.min.js", "http://cdn/script1.js", false);
+            };
+            _resourceManager.Require("script", "Script1");
+            VerifyPaths("script", new RequireSettings { CdnMode = true, DebugMode = true }, "script1.js", true);
         }
 
         [Test]

--- a/src/Orchard.Web/Core/Shapes/CoreShapes.cs
+++ b/src/Orchard.Web/Core/Shapes/CoreShapes.cs
@@ -455,12 +455,12 @@ namespace Orchard.Core.Shapes {
             var appPath = httpContext == null || httpContext.Request == null
                 ? null
                 : httpContext.Request.ApplicationPath;
-
+            var ssl = httpContext?.Request?.IsSecureConnection ?? false;
             foreach (var context in requiredResources.Where(r =>
                 (includeLocation.HasValue ? r.Settings.Location == includeLocation.Value : true) &&
                 (excludeLocation.HasValue ? r.Settings.Location != excludeLocation.Value : true))) {
 
-                var path = context.GetResourceUrl(defaultSettings, appPath);
+                var path = context.GetResourceUrl(defaultSettings, appPath, ssl);
                 var condition = context.Settings.Condition;
                 var attributes = context.Settings.HasAttributes ? context.Settings.Attributes : null;
                 IHtmlString result;

--- a/src/Orchard/UI/Resources/ResourceDefinition.cs
+++ b/src/Orchard/UI/Resources/ResourceDefinition.cs
@@ -152,6 +152,9 @@ namespace Orchard.UI.Resources {
             if (cdnSupportsSsl.HasValue) {
                 CdnSupportsSsl = cdnSupportsSsl.Value;
             }
+            else {
+                CdnSupportsSsl = cdnUrl.StartsWith("https", StringComparison.OrdinalIgnoreCase);
+            }
             return this;
         }
 
@@ -175,20 +178,31 @@ namespace Orchard.UI.Resources {
         }
 
         public string ResolveUrl(RequireSettings settings, string applicationPath) {
+            return ResolveUrl(settings, applicationPath, false);
+        }
+
+        public string ResolveUrl(RequireSettings settings, string applicationPath, bool ssl) {
             string url;
             if (_urlResolveCache.TryGetValue(settings, out url)) {
                 return url;
             }
             // Url priority:
-            if (settings.DebugMode) {
-                url = settings.CdnMode
-                    ? Coalesce(UrlCdnDebug, UrlDebug, UrlCdn, Url)
-                    : Coalesce(UrlDebug, Url, UrlCdnDebug, UrlCdn);
+            if (!ssl || (ssl && CdnSupportsSsl)) { //Not ssl or ssl and cdn supports it
+                if (settings.DebugMode) {
+                    url = settings.CdnMode
+                        ? Coalesce(UrlCdnDebug, UrlDebug, UrlCdn, Url)
+                        : Coalesce(UrlDebug, Url, UrlCdnDebug, UrlCdn);
+                }
+                else {
+                    url = settings.CdnMode
+                        ? Coalesce(UrlCdn, Url, UrlCdnDebug, UrlDebug)
+                        : Coalesce(Url, UrlDebug, UrlCdn, UrlCdnDebug);
+                }
             }
-            else {
-                url = settings.CdnMode
-                    ? Coalesce(UrlCdn, Url, UrlCdnDebug, UrlDebug)
-                    : Coalesce(Url, UrlDebug, UrlCdn, UrlCdnDebug);
+            else { //ssl and cdn does not support it, only evaluate non-cdn url's
+                url = settings.DebugMode
+                    ? Coalesce(UrlDebug, Url)
+                    : Coalesce(Url, UrlDebug);
             }
             if (String.IsNullOrEmpty(url)) {
                 return null;

--- a/src/Orchard/UI/Resources/ResourceRequiredContext.cs
+++ b/src/Orchard/UI/Resources/ResourceRequiredContext.cs
@@ -6,15 +6,15 @@ namespace Orchard.UI.Resources {
         public ResourceDefinition Resource { get; set; }
         public RequireSettings Settings { get; set; }
 
-        public string GetResourceUrl(RequireSettings baseSettings, string appPath) {
-            return Resource.ResolveUrl(baseSettings == null ? Settings : baseSettings.Combine(Settings), appPath);
+        public string GetResourceUrl(RequireSettings baseSettings, string appPath, bool ssl) {
+            return Resource.ResolveUrl(baseSettings == null ? Settings : baseSettings.Combine(Settings), appPath, ssl);
         }
 
         public TagBuilder GetTagBuilder(RequireSettings baseSettings, string appPath) {
             var tagBuilder = new TagBuilder(Resource.TagName);
             tagBuilder.MergeAttributes(Resource.TagBuilder.Attributes);
             if (!String.IsNullOrEmpty(Resource.FilePathAttributeName)) {
-                var resolvedUrl = GetResourceUrl(baseSettings, appPath);
+                var resolvedUrl = GetResourceUrl(baseSettings, appPath, false);
                 if (!String.IsNullOrEmpty(resolvedUrl)) {
                     tagBuilder.MergeAttribute(Resource.FilePathAttributeName, resolvedUrl, true);
                 }


### PR DESCRIPTION
This PR implements **CdnSupportsSsl**  as per the comments on issue #6831.

1. Pass the Request.IsSecureConnection from CoreShapes as a parameter to the ResourceRequiredContext,
2. If CdnSupportsSsl is not provided, then set it to true if CdnUrl starts with "https",
3. If serving under SSL and CdnSupportsSsl and CDN URL is configured then return CDN URL,
4. If not serving under SSL and CDN URL is configured then return CDN URL
5. Otherwise return local URL

Smoketest
(pending)

Build and unit tests pass, including 2 new unit tests added.