### PR TITLE
#5294 Fixed Specific url's in SecureSocketsLayer not redirected to https

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Services/SecureSocketsLayerService.cs
+++ b/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Services/SecureSocketsLayerService.cs
@@ -97,7 +97,7 @@ namespace Orchard.SecureSocketsLayer.Services {
             if (!settings.CustomEnabled) return false;
 
             var urlHelper = new UrlHelper(requestContext);
-            var url = urlHelper.Action(actionName, controllerName, requestContext.RouteData);
+            var url = urlHelper.Action(actionName, controllerName, requestContext.RouteData.Values);
 
             if (String.IsNullOrWhiteSpace(url)) {
                 return false;


### PR DESCRIPTION
When enabling SSL using module Orchard.SecureSocketsLayer and configuring a specific URL to be secured, e.g. "~/contact", then this URL is not redirected to https as expected.

This is fixed by the one-word update in this PR.