### PR TITLE
Fix of removing not current page for breadcrumbs

### DIFF
--- a/src/Orchard.Web/Core/Navigation/Drivers/MenuWidgetPartDriver.cs
+++ b/src/Orchard.Web/Core/Navigation/Drivers/MenuWidgetPartDriver.cs
@@ -100,7 +100,22 @@ namespace Orchard.Core.Navigation.Drivers {
 
                     // inject the current page
                     if (!part.AddCurrentPage && selectedPath != null) {
-                        result.RemoveAt(result.Count - 1);
+                        var lastMenuItem = result[result.Count - 1];
+                        // we need to be ensure that breadcrumbs last item represents current page before deleting one.
+                        if (lastMenuItem.RouteValues != null && NavigationHelper.RouteMatches(lastMenuItem.RouteValues, routeData.Values)) {
+                            result.Remove(lastMenuItem);
+                        }
+                        else {
+                            string appPath = request.ApplicationPath ?? "/";
+                            string requestUrl = request.Path.StartsWith(appPath) ? request.Path.Substring(appPath.Length) : request.Path;
+
+                            string lastMenuItemUrl = lastMenuItem.Href.Replace("~/", appPath);
+                            lastMenuItemUrl = lastMenuItemUrl.StartsWith(appPath) ? lastMenuItemUrl.Substring(appPath.Length) : lastMenuItemUrl;
+
+                            if (requestUrl.Equals(lastMenuItemUrl, StringComparison.OrdinalIgnoreCase)) {
+                                result.Remove(lastMenuItem);
+                            }
+                        }
                     }
 
                     // prevent the home page to be added as the home page and the current page


### PR DESCRIPTION
Fix #5624

Last item in breadcrumbs doesn't always represent current page. It's not true for situation when current menu item is found by part of URL (not by full URL).

When add current page option for breadcrumbs is not active. It need to be ensure that breadcrumbs last item represents current page before deleting one.
