### PR TITLE
#6863 Fixed problem with case comparison when checking request headers in output cache

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -384,7 +384,7 @@ namespace Orchard.OutputCache.Filters {
             // Vary by configured request headers.
             var requestHeaders = filterContext.RequestContext.HttpContext.Request.Headers;
             foreach (var varyByRequestHeader in CacheSettings.VaryByRequestHeaders) {
-                if (requestHeaders.AllKeys.Contains(varyByRequestHeader))
+                if (requestHeaders[varyByRequestHeader]!=null)
                     result["HEADER:" + varyByRequestHeader] = requestHeaders[varyByRequestHeader];
             }
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/Orchard/issues/6863
By default request header "HOST" is taken into account by GetCacheKeyParameters method.
Problem is it is in upper case "HOST" and in request header the key is "Host".
When requestHeaders.AllKeys.Contains(varyByRequestHeader) is evaluated result is false.
