### PR TITLE
[1.10.x] Tokens filters cohabitation.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Filters/TokensFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Filters/TokensFilter.cs
@@ -15,7 +15,7 @@ namespace Orchard.Layouts.Filters {
         }
 
         public string ProcessContent(string text, string flavor) {
-            return ProcessContent(text, flavor, new Dictionary<string, object>());
+            return text;
         }
 
         public string ProcessContent(string text, string flavor, IDictionary<string, object> context) {

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Services/ElementFilterProcessor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Services/ElementFilterProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Orchard.Services;
+using Orchard.Tokens.Filters;
 
 namespace Orchard.Layouts.Services {
     public class ElementFilterProcessor : IElementFilterProcessor {
@@ -10,8 +11,10 @@ namespace Orchard.Layouts.Services {
 
         public string ProcessContent(string text, string flavor, IDictionary<string, object> context) {
             foreach (var htmlFilter in _filters) {
-                var elementFilter = htmlFilter as IElementFilter;
-                text = elementFilter != null ? elementFilter.ProcessContent(text, flavor, context) : htmlFilter.ProcessContent(text, flavor);
+                if (!(htmlFilter is TokensFilter)) {
+                    var elementFilter = htmlFilter as IElementFilter;
+                    text = elementFilter != null ? elementFilter.ProcessContent(text, flavor, context) : htmlFilter.ProcessContent(text, flavor);
+                }
             }
             return text;
         }


### PR DESCRIPTION
Replace #6194 which fixed #6193, but was reverted because of a failing unit test.

For the 2 versions of TokenFilter (for content parts and for elements), context data are not passed in the same way. So, a first running filter can kill the token. To fix it, a previous PR #6194 was returning the token itself when the replacement value is null. But this last point was breaking an unit test.

Here, the idea is to use the right token filter based on the context.

- `ElementFilterProcessor.cs`: Here, in the context of an element, we don't call a filter which is an `Orchard.Tokens.Filters.TokensFilter`. Here you need to enable the layout tokens filter.

- `TokensFilter.cs`: If the layout token filter is called in the context of a content part, this is done through the method with the old signature `ProcessContent(string text, string flavor)`, not the new one with context data. So, in this case nothing is done. Here you also need to enable the content tokens filter

Best.