### PR TITLE
#6733: Fix Comments and Audit Trail issue, rebased on dev branch

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Providers/Content/GlobalContentHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Providers/Content/GlobalContentHandler.cs
@@ -34,7 +34,10 @@ namespace Orchard.AuditTrail.Providers.Content {
         protected override void Updating(UpdateContentContext context) {
             var contentItem = context.ContentItem;
 
-            _ignoreExportHandlerFor = contentItem;
+            if (contentItem.IsNew())
+                return;
+
+                _ignoreExportHandlerFor = contentItem;
             _previousVersionXml = _contentItemCreated 
                 ? default(XElement) // No need to do a diff on a newly created content item.
                 : _contentManager.Export(contentItem);
@@ -43,7 +46,10 @@ namespace Orchard.AuditTrail.Providers.Content {
 
         protected override void Updated(UpdateContentContext context) {
             var contentItem = context.ContentItem;
-           
+
+            if (contentItem.IsNew())
+                return;
+
             if (_contentItemCreated) {
                 RecordAuditTrailEvent(ContentAuditTrailEventProvider.Created, context.ContentItem);
             }

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Services/DiffGramAnalyzer.cs
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Services/DiffGramAnalyzer.cs
@@ -35,7 +35,9 @@ namespace Orchard.AuditTrail.Services {
                         case XmlNodeType.Element:
                             var match = reader.GetAttribute("match");
                             var isAttributeChange = match != null && match.StartsWith("@");
-                            var index = match == null || isAttributeChange ? default(int?) : Int32.Parse(match) - 1;
+                            int matchInt;
+                            var index = match == null || isAttributeChange || !Int32.TryParse(match, out matchInt) 
+                                ? default(int?) : matchInt - 1;
                             var diffType = reader.LocalName;
                             var currentElement = stack.Peek();
 

--- a/src/Orchard.Web/Modules/Orchard.Comments/Controllers/CommentController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Controllers/CommentController.cs
@@ -46,7 +46,9 @@ namespace Orchard.Comments.Controllers {
             }
 
             if (ModelState.IsValid) {
-                Services.ContentManager.Create(comment);
+                Services.ContentManager.Create(comment, VersionOptions.Draft);
+                Services.ContentManager.UpdateEditor(comment, this);
+                Services.ContentManager.Publish(comment.ContentItem);
 
                 var commentPart = comment.As<CommentPart>();
 


### PR DESCRIPTION
Fixes #6733 - **Rebased on dev branch**

@sebastienros here the best compromise i've found to fix the issue without breaking a first original one.

**Summary**
- If audit trail enabled, on a new comment errors are logged and bad event records are created. The audit trail handler rely on a created item and the comment controller creates it after model validation.

- A previous PR #6734 proposed to do a create before update editor (as in other controllers) but, for comments with many items / spams, it's good to preserve transaction logs when model validation fails.

- Another concern is not to conflict with another issue when sending an e-mail on comment publication, the model need to be validated. That's why the create was originally moved after model checking.

**Best compromise i've found**

- `CommentController.cs`: The create is still after the model validation but with a draft option, so with no publish event, then a 2nd update editor is done before publishing. So, it doesn't conflict with the original issue, and events are triggered in the standard order (good for audit trail).

- `GlobalContentHandler.cs`: In the updating and updated methods, before creating a bad audit trail record (e. version = 0) and logging errors, we check if the item is already created.

- `DiffGramAnalyzer.cs`: Here a null check has been added to prevent admin audit trail views from failing if some bad audit trail records have been created before the fix.


Best.
