### PR TITLE
fixes #6877 - wrap text in views with t()

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Views/Element/Create.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Views/Element/Create.cshtml
@@ -1,6 +1,6 @@
 ﻿@model Orchard.Layouts.ViewModels.EditElementViewModel
 @{
 	ViewBag.Command = "add";
-	ViewBag.TitleFormat = "Add {0}";
+	ViewBag.TitleFormat = T("Add {0}").Text;
 }
 @Html.Partial("ElementEditor", Model, ViewData)

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Views/Element/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Views/Element/Edit.cshtml
@@ -1,6 +1,6 @@
 ﻿@model Orchard.Layouts.ViewModels.EditElementViewModel
 @{
     ViewBag.Command = "update";
-    ViewBag.TitleFormat = String.IsNullOrWhiteSpace(Model.ElementData) ? "Add {0}" : "Edit {0}";
+    ViewBag.TitleFormat = String.IsNullOrWhiteSpace(Model.ElementData) ? T("Add {0}").Text : T("Edit {0}").Text;
 }
 @Html.Partial("ElementEditor", Model, ViewData)


### PR DESCRIPTION
fixes #6877 - wrap text in views with t()

retargeted to 1.10.x from #6878 