### PR TITLE
Fix for getting other content item localzation.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationService.cs
@@ -29,11 +29,17 @@ namespace Orchard.Localization.Services {
             if (localized == null)
                 return null;
 
+            if (localized.Record.CultureId == cultureRecord.Id) {
+                return localized;
+            }
+
+            int masterContentItemId = localized.HasTranslationGroup ? localized.Record.MasterContentItemId : localized.Id;
+
             // Warning: Returns only the first of same culture localizations.
             return _contentManager
                 .Query<LocalizationPart>(versionOptions, content.ContentItem.ContentType)
                 .Where<LocalizationPartRecord>(l =>
-                (l.Id == content.ContentItem.Id || l.MasterContentItemId == content.ContentItem.Id)
+                (l.Id == masterContentItemId || l.MasterContentItemId == masterContentItemId)
                 && l.CultureId == cultureRecord.Id)
                 .Slice(1)
                 .FirstOrDefault();

--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationService.cs
@@ -29,10 +29,6 @@ namespace Orchard.Localization.Services {
             if (localized == null)
                 return null;
 
-            if (localized.Record.CultureId == cultureRecord.Id) {
-                return localized;
-            }
-
             int masterContentItemId = localized.HasTranslationGroup ? localized.Record.MasterContentItemId : localized.Id;
 
             // Warning: Returns only the first of same culture localizations.


### PR DESCRIPTION
LocalizationPartRecord for specific content usually looks like:

| Id | CultureId | MasterContentItemId |
| --- | --- | --- |
| 25 | 2 | 0 |
| 1236 | 3 | 25 |
| 1237 | 4 | 25 |

And when someone try to get another localization item for non-master content item that function returns nothing.
