### PR TITLE
Add SiteName to New Account Subject

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
@@ -118,7 +118,7 @@ namespace Orchard.Users.Services {
                         template.Metadata.Wrappers.Add("Template_User_Wrapper");
 
                         var parameters = new Dictionary<string, object> {
-                            {"Subject", T("New account").Text},
+                            {"Subject", T("New account on "  + _orchardServices.WorkContext.CurrentSite.SiteName).Text},
                             {"Body", _shapeDisplay.Display(template)},
                             {"Recipients", recipient.Email }
                         };

--- a/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
@@ -118,7 +118,7 @@ namespace Orchard.Users.Services {
                         template.Metadata.Wrappers.Add("Template_User_Wrapper");
 
                         var parameters = new Dictionary<string, object> {
-                            {"Subject", T("New account on "  + _orchardServices.WorkContext.CurrentSite.SiteName).Text},
+                            {"Subject", T("New account on {0}.", _orchardServices.WorkContext.CurrentSite.SiteName).Text},
                             {"Body", _shapeDisplay.Display(template)},
                             {"Recipients", recipient.Email }
                         };


### PR DESCRIPTION
When you run more than one Orchard CMS site, and you have to moderate the logins, it's nice to know which site a new account was created on.