### PR TITLE
User name format in CreateUserActivity

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Users/Activities/CreateUserActivity.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Activities/CreateUserActivity.cs
@@ -67,6 +67,8 @@ namespace Orchard.Users.Activities {
                 yield break;
             }
 
+            userName = userName.Trim();
+
             var user = _membershipService.CreateUser(
                 new CreateUserParams(
                     userName,


### PR DESCRIPTION
if the user creates a user name with whitespaces at the end or the start this will cause you a lot of problems with physical paths and the virtual ones,because in physicals you can't have whitespaces but in the orchard objects you'll have the paths with the whitespaces (using the user name with the whitespaces to compose the path)