### PR TITLE
Request/patching framework extensions

### DIFF
--- a/src/Orchard/Mvc/Extensions/UrlHelperExtensions.cs
+++ b/src/Orchard/Mvc/Extensions/UrlHelperExtensions.cs
@@ -28,12 +28,17 @@ namespace Orchard.Mvc.Extensions {
             if(url != null && url.StartsWith("http", StringComparison.OrdinalIgnoreCase)) {
                 return url;
             }
-            
-            if(String.IsNullOrEmpty(baseUrl)) {
-                var workContextAccessor = urlHelper.RequestContext.GetWorkContext();
-                baseUrl = workContextAccessor.CurrentSite.BaseUrl;
 
-                if (String.IsNullOrWhiteSpace(baseUrl)) {
+            if (String.IsNullOrEmpty(baseUrl))
+            {
+                var workContextAccessor = urlHelper.RequestContext.GetWorkContext();
+
+                if (workContextAccessor != null)
+                {
+                    baseUrl = workContextAccessor.CurrentSite.BaseUrl;
+                }
+                if(workContextAccessor == null || String.IsNullOrWhiteSpace(baseUrl))
+                {
                     baseUrl = urlHelper.RequestContext.HttpContext.Request.ToApplicationRootUrlString();
                 }
             }

--- a/src/Orchard/Mvc/Html/LayoutExtensions.cs
+++ b/src/Orchard/Mvc/Html/LayoutExtensions.cs
@@ -48,6 +48,16 @@ namespace Orchard.Mvc.Html {
             return MvcHtmlString.Create(html.Encode(titleParts[0]));
         }
 
+        public static MvcHtmlString TitleForPage(this HtmlHelper html, params MvcHtmlString[] titleParts) {
+            if (titleParts == null || titleParts.Length < 1)
+                return null;
+
+            string[] parts = titleParts.Select(t => t.ToString()).ToArray();
+            html.AppendTitleParts(parts);
+
+            return MvcHtmlString.Create(html.Encode(titleParts[0]));
+        }
+
         public static MvcHtmlString TitleForPage(this HtmlHelper html, params LocalizedString[] titleParts) {
             if (titleParts == null || titleParts.Length < 1)
                 return null;


### PR DESCRIPTION
Orchard framework extension methods had a couple of issues. I tried to fix them in a modular way but unfortunately there was no way around it aside from patching the actual methods themselves. 

I encountered these issues when I was setting up the Gallery server. The TitleForPage issue arises in the gallery theme. I think a better solution is an implicit conversion from `MvcHtmlString[]` to `String[]`

The second issue in UrlHelpers arises when I was exposing the feed. The problem is if `workContextAccessor` is null for any reason it'll throw up, without even logging the error. 

I must say you guys have a done a fantastic job with Orchard. The modularity is top notch, and the code itself is self documenting. Keep up the good work
