### PR TITLE
#6981 Normalized image profile path hash and added profile purging

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/IImageProfileManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/IImageProfileManager.cs
@@ -8,5 +8,8 @@ namespace Orchard.MediaProcessing.Services {
         string GetImageProfileUrl(string path, string profileName, FilterRecord customFilter);
         string GetImageProfileUrl(string path, string profileName, FilterRecord customFilter, ContentItem contentItem);
         string GetImageProfileUrl(string path, string profileName, ContentItem contentItem, params FilterRecord[] customFilters);
+
+        bool PurgeImageProfile(int id);
+        bool PurgeObsoleteImageProfiles();
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
@@ -15,6 +15,8 @@ using Orchard.MediaProcessing.Media;
 using Orchard.MediaProcessing.Models;
 using Orchard.Tokens;
 using Orchard.Utility.Extensions;
+using Orchard.Environment.Configuration;
+using Orchard.Caching;
 
 namespace Orchard.MediaProcessing.Services {
     public class ImageProfileManager : IImageProfileManager {
@@ -24,6 +26,8 @@ namespace Orchard.MediaProcessing.Services {
         private readonly IImageProcessingManager _processingManager;
         private readonly IOrchardServices _services;
         private readonly ITokenizer _tokenizer;
+        private readonly ISignals _signals;
+        private readonly IAppConfigurationAccessor _appConfigurationAccessor;
 
         public ImageProfileManager(
             IStorageProvider storageProvider,
@@ -31,13 +35,17 @@ namespace Orchard.MediaProcessing.Services {
             IImageProfileService profileService,
             IImageProcessingManager processingManager,
             IOrchardServices services,
-            ITokenizer tokenizer) {
+            ITokenizer tokenizer,
+            ISignals signals,
+            IAppConfigurationAccessor appConfigurationAccessor) {
             _storageProvider = storageProvider;
             _fileNameProvider = fileNameProvider;
             _profileService = profileService;
             _processingManager = processingManager;
             _services = services;
             _tokenizer = tokenizer;
+            _signals = signals;
+            _appConfigurationAccessor = appConfigurationAccessor;
 
             Logger = NullLogger.Instance;
         }
@@ -235,14 +243,66 @@ namespace Orchard.MediaProcessing.Services {
             return false;
         }
 
+        public bool PurgeImageProfile(int id) {
+            var profile = _profileService.GetImageProfile(id);
+            try {
+                var folder = _storageProvider.Combine("_Profiles", GetHexHashCode(profile.Name));
+                _storageProvider.DeleteFolder(folder);
+                profile.FileNames.Clear();
+                _signals.Trigger("MediaProcessing_Saved_" + profile.Name);
+                return true;
+            }
+            catch (Exception ex) {
+                Logger.Warning(ex, "Unable to purge image profile '{0}'", profile.Name);
+                return false;
+            }
+        }
+
+        public bool PurgeObsoleteImageProfiles() {
+            var profiles = _profileService.GetAllImageProfiles();
+            try {
+                if (profiles != null) {
+                    var validPaths = profiles.Select(profile => _storageProvider.Combine("_Profiles", GetHexHashCode(profile.Name)));
+                    foreach (var folder in _storageProvider.ListFolders("_Profiles").Select(f => f.GetPath())) {
+                        if (!validPaths.Any(v => folder.StartsWith(v))) {
+                            _storageProvider.DeleteFolder(folder);
+                        }
+                    }
+                }
+                return true;
+            }
+            catch (Exception ex) {
+                Logger.Warning(ex, "Unable to purge obsolete image profiles");
+                return false;
+            }
+        }
+
         private string FormatProfilePath(string profileName, string path) {
-            
-            var filenameWithExtension = Path.GetFileName(path) ?? "";
-            var fileLocation = path.Substring(0, path.Length - filenameWithExtension.Length);
+            var normalizedPath = ShouldNormalizePath() ? NormalizePath(path) : path;
+            var filenameWithExtension = Path.GetFileName(normalizedPath) ?? "";
+            var fileLocation = normalizedPath.Substring(0, normalizedPath.Length - filenameWithExtension.Length);
 
             return _storageProvider.Combine(
-                _storageProvider.Combine(profileName.GetHashCode().ToString("x").ToLowerInvariant(), fileLocation.GetHashCode().ToString("x").ToLowerInvariant()),
+                _storageProvider.Combine(GetHexHashCode(profileName), GetHexHashCode(fileLocation)),
                     filenameWithExtension);
+        }
+
+        private string GetHexHashCode(string value) {
+            return value.GetHashCode().ToString("x").ToLowerInvariant();
+        }
+
+        private string NormalizePath(string path) {
+            //Slice at the protocol, if any. E.g. http:// or https://.
+            var index = path.IndexOf("//", StringComparison.OrdinalIgnoreCase);
+            //Slice at the first directory after the protocol or at 0 if no protocol specified.
+            index = path.IndexOf("/", index < 0 ? 0 : index + 2, StringComparison.OrdinalIgnoreCase);
+            //Return path from the first directory, replacing lcase 'media' (Azure container) with ucase 'Media' (filestorage).
+            return path.Substring(index < 1 ? 0 : index).Replace("media", "Media");
+        }
+
+        private bool ShouldNormalizePath() {
+            var normalizePath = _appConfigurationAccessor.GetConfiguration("Orchard.MediaProcessing.NormalizePath");
+            return string.IsNullOrEmpty(normalizePath) || normalizePath.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Views/Admin/Index.cshtml
@@ -14,7 +14,10 @@
 
 @using (Html.BeginFormAntiForgeryPost()) { 
     @Html.ValidationSummary()
-    <div class="manage">@Html.ActionLink(T("Add a new Media Profile").ToString(), "Create", new { Area = "Contents", id = "ImageProfile", returnurl = HttpContext.Current.Request.RawUrl }, new { @class = "button primaryAction" })</div>
+    <div class="manage">
+        @Html.ActionLink(T("Purge Obsolete").ToString(), "PurgeObsolete", null, new { itemprop = "UnsafeUrl", @class = "button remove", data_unsafe_url = @T("Are you sure you wish to purge all obsolete profile images and force all dynamic profile images to be regenerated?").ToString() })
+        @Html.ActionLink(T("Add a new Media Profile").ToString(), "Create", new { Area = "Contents", id = "ImageProfile", returnurl = HttpContext.Current.Request.RawUrl }, new { @class = "button primaryAction" })
+    </div>
 
     <fieldset class="bulk-actions">
         <label for="publishActions">@T("Actions:")</label>
@@ -56,6 +59,7 @@
                     <td>
                         @Html.ActionLink(T("Properties").ToString(), "Edit", new { Area = "Contents", id = entry.ImageProfileId, returnurl = HttpContext.Current.Request.RawUrl }) |
                         @Html.ActionLink(T("Edit").ToString(), "Edit", new { id = entry.ImageProfileId }) |
+                        @Html.ActionLink(T("Purge").ToString(), "Purge", new { id = entry.ImageProfileId }, new { itemprop = "UnsafeUrl", data_unsafe_url = @T("Are you sure you wish to purge all images for this profile?").ToString() }) |
                         @Html.ActionLink(T("Delete").ToString(), "Delete", new { id = entry.ImageProfileId }, new { itemprop = "RemoveUrl UnsafeUrl" })
                         @*@Html.ActionLink(T("Preview").ToString(), "Preview", new { id = entry.ImageProfileId })*@
                     </td>


### PR DESCRIPTION
This resolves both issue #6981 by normalizing the profile path hash, as well as re-introduces an old CodePlex PR that missed the GitHub boat, namely the ability to purge profiles through the Admin UI.

**Normalizing the image profile path**
Normalizing the image profile path hash "should" be the default for all new sites, as it allows for changing the domain from which images are served, whilst maintaining the already generated profiles. This enables, for example, 301 SEO-friendly redirects when moving from local storage to azure storage or moving to a CDN by simply redirecting one-to-one at the `^_Profiles/.*` level.

**Important for Release Notes**
_Existing sites may opt-out from Normalizing the profile paths, especially those which are not serving from the local Media folder, those which use a container other than "media" in Azure Blob Storage and those sites which use a custom storage provider. This can be achieved by setting the following AppSetting to `false`, which sets the behavior exactly as before:_

`<add key="Orchard.MediaProcessing.NormalizePath" value="false" />`

**Purging Profiles**
As mentioned, this PR also enables 2 purge options form the Admin > Media > Profiles view, forcing profiles to be regenerated and old "orphaned" images will be cleared:
1. Purge all images under an individual profile
2. Purge all obsolete images, including all dynamic profiles (such as the Admin UI thumbs)

This functionality sits quite naturally with the normalization of the hashes, as those who wish to implement the normalization on existing sites immediately have a function to clear the old profiles (using the Purge Obsolete option). Though for SEO purposes you probably want to wait a few months before doing so.
