### PR TITLE
#6783: Workaround for PostgreSQL without breaking SQL server.

### DIFF
--- a/src/Orchard/Data/Migration/AutomaticDataMigrations.cs
+++ b/src/Orchard/Data/Migration/AutomaticDataMigrations.cs
@@ -85,9 +85,16 @@ namespace Orchard.Data.Migration {
             var schemaBuilder = new SchemaBuilder(_dataMigrationInterpreter);
             var distributedLockSchemaBuilder = new DistributedLockSchemaBuilder(_shellSettings, schemaBuilder);
             if (!distributedLockSchemaBuilder.SchemaExists()) {
+
                 // Workaround to avoid some Transaction issue for PostgreSQL.
-                _transactionManager.RequireNew();
+                if (_shellSettings.DataProvider.Equals("PostgreSql", StringComparison.OrdinalIgnoreCase)) {
+                    _transactionManager.RequireNew();
+                    distributedLockSchemaBuilder.CreateSchema();
+                    return;
+                }
+
                 distributedLockSchemaBuilder.CreateSchema();
+                _transactionManager.RequireNew();
             }
         }
     }


### PR DESCRIPTION
Fixes #6783 

This PR #6729 solved an issue with `PostgreSQL` but introduced a little drawback e.g with `SqlCe`, see in #6783. As said by @sebastienros we would need to revert #6729 ...

Here, i propose the same workaround for `PostgreSQL` without breaking other providers, e.g `SqlServer`.

Best.