### PR TITLE
#6986 Created feature Media Processing Html Filter

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Constants.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Constants.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Orchard.MediaProcessing {
+    public static class Features {
+
+        public const string OrchardMediaProcessingHtmlFilter = "Orchard.MediaProcessingHtmlFilter";
+
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Filters/MediaProcessingHtmlFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Filters/MediaProcessingHtmlFilter.cs
@@ -1,0 +1,166 @@
+﻿using HtmlAgilityPack;
+using Orchard.ContentManagement;
+using Orchard.Environment.Extensions;
+using Orchard.FileSystems.Media;
+using Orchard.Forms.Services;
+using Orchard.Logging;
+using Orchard.MediaProcessing.Models;
+using Orchard.MediaProcessing.Services;
+using Orchard.Services;
+using Orchard.Settings;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Orchard.MediaProcessing.Filters {
+    /// <summary>
+    /// Resizes any images in HTML provided by parts that support IHtmlFilter and sets an alt text if not already supplied
+    /// </summary>
+    [OrchardFeature(Features.OrchardMediaProcessingHtmlFilter)]
+    public class MediaProcessingHtmlFilter : IHtmlFilter {
+
+        private readonly IWorkContextAccessor _wca;
+        private readonly IImageProcessingFileNameProvider _fileNameProvider;
+        private readonly IImageProfileManager _profileManager;
+        private readonly IStorageProvider _storageProvider;
+
+        private MediaHtmlFilterSettingsPart _settingsPart;
+        private Dictionary<string, string> _validExtensions = new Dictionary<string, string> {
+            { ".jpeg", "jpg" }, //For example: .jpeg supports commpression (quality), format to 'jpg'
+            { ".jpg", "jpg"  },
+            { ".png", null }};
+
+        public MediaProcessingHtmlFilter(IWorkContextAccessor wca, IImageProcessingFileNameProvider fileNameProvider, IImageProfileManager profileManager, IStorageProvider storageProvider) {
+            _fileNameProvider = fileNameProvider;
+            _profileManager = profileManager;
+            _storageProvider = storageProvider;
+            _wca = wca;
+            Logger = NullLogger.Instance;
+        }
+
+        public ILogger Logger { get; set; }
+
+        public MediaHtmlFilterSettingsPart Settings { get {
+                if (_settingsPart == null) {
+                    _settingsPart = _wca.GetContext().CurrentSite.As<MediaHtmlFilterSettingsPart>();
+                }
+                return _settingsPart;
+            }
+        }
+
+        public string ProcessContent(string text, string flavor) {
+            if (!string.IsNullOrEmpty(text) && flavor == "html") {
+                var doc = new HtmlDocument();
+                doc.LoadHtml(text);
+                foreach (var node in doc.DocumentNode.DescendantsAndSelf("img")) {
+                    ProcessImageContent(node);
+                    if (Settings.PopulateAlt) {
+                        ProcessImageAltContent(node);
+                    }
+                }
+                return doc.DocumentNode.OuterHtml;
+            }
+            else {
+                return text;
+            }
+        }
+
+        private void ProcessImageContent(HtmlNode node) {
+            // If the noresize attribute is present, do nothing.
+            if (node.Attributes.AttributesWithName("noresize").Any()) {
+                return;
+            }
+
+            var src = GetAttributeValue(node, "src");
+            var ext = string.IsNullOrEmpty(src) ? null : Path.GetExtension(src);
+            var width = GetAttributeValueInt(node, "width");
+            var height = GetAttributeValueInt(node, "height");
+
+            if (width > 0 && height > 0 && !string.IsNullOrEmpty(src) && !src.Contains("_Profiles") && _validExtensions.ContainsKey(ext)) {
+                try {
+                    //If img has a width, height, not already in _Profiles and a valid ext, process the image.
+                    node.Attributes["src"].Value = TryGetImageProfilePath(src, ext, width, height);
+                }
+                catch (Exception ex) {
+                    Logger.Error(ex, "Unable to process Html Dynamic image profile for '{0}'", src);
+                }
+            }
+        }
+
+        private string TryGetImageProfilePath(string src, string ext, int width, int height) {
+            
+            var filters = new List<FilterRecord>();
+            filters.Add(CreateResizeFilter(width * Settings.DensityThreshold, height * Settings.DensityThreshold)); // Factor in a min height and width with respect to higher pixel density devices.
+
+            // If the ext supports compression, also set the quality.
+            if (_validExtensions[ext] != null && Settings.Quality < 100) {
+                filters.Add(CreateFormatFilter(Settings.Quality, _validExtensions[ext]));
+            }
+
+            var profileName = string.Format("Transform_Resize_w_{0}_h_{1}_m_Stretch_a_MiddleCenter_c_{2}_d_@{3}x", width, height, Settings.Quality, Settings.DensityThreshold);
+            return _profileManager.GetImageProfileUrl(src, profileName, null, filters.ToArray());
+
+        }
+
+        private FilterRecord CreateResizeFilter(int width, int height) {
+            // Because the images can be resized in the html editor, we must assume that the image
+            // is of the exact desired dimensions and that stretch is an appropriate mode.
+            // Note that the default is to never upscale images.
+            var state = new Dictionary<string, string> {
+                { "Width", width.ToString() },
+                { "Height", height.ToString() },
+                { "Mode", "Stretch" },
+                { "Alignment", "MiddleCenter" },
+                { "PadColor", "" }
+            };
+
+            return new FilterRecord {
+                Category = "Transform",
+                Type = "Resize",
+                State = FormParametersHelper.ToString(state)
+            };
+        }
+
+        private FilterRecord CreateFormatFilter(int quality, string format) {
+            var state = new Dictionary<string, string> {
+                { "Quality", quality.ToString() },
+                { "Format", format },
+            };
+
+            return new FilterRecord {
+                Category = "Transform",
+                Type = "Format",
+                State = FormParametersHelper.ToString(state)
+            };
+        }
+
+        private void ProcessImageAltContent(HtmlNode node) {
+            var src = GetAttributeValue(node, "src");
+            var alt = GetAttributeValue(node, "alt");
+            if (string.IsNullOrEmpty(alt) && !string.IsNullOrEmpty(src)) {
+                var text = Path.GetFileNameWithoutExtension(src).Replace("-", " ").Replace("_", " ");
+                SetAttributeValue(node, "alt", text);
+            }
+        }
+
+        private string GetAttributeValue(HtmlNode node, string name) {
+            return node.Attributes[name] == null ? null : node.Attributes[name].Value;
+        }
+
+        private int GetAttributeValueInt(HtmlNode node, string name) {
+            int val = 0;
+            return node.Attributes[name] == null ? 0 : int.TryParse(node.Attributes[name].Value, out val) ? val : 0;
+        }
+
+        private void SetAttributeValue(HtmlNode node, string name, string value) {
+            if (node.Attributes.Contains(name)) {
+                node.Attributes[name].Value = value;
+            }
+            else {
+                node.Attributes.Add(name, value);
+            }
+        }
+
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Handlers/MediaHtmlFilterSettingsPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Handlers/MediaHtmlFilterSettingsPartHandler.cs
@@ -1,0 +1,28 @@
+﻿using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
+using Orchard.Environment.Extensions;
+using Orchard.Localization;
+using Orchard.MediaProcessing.Models;
+
+namespace Orchard.MediaProcessing.Handlers {
+
+    [OrchardFeature(Features.OrchardMediaProcessingHtmlFilter)]
+    public class MediaHtmlFilterSettingsPartHandler : ContentHandler {
+        public MediaHtmlFilterSettingsPartHandler() {
+            T = NullLocalizer.Instance;
+
+            Filters.Add(new ActivatingFilter<MediaHtmlFilterSettingsPart>("Site"));
+            Filters.Add(new TemplateFilterForPart<MediaHtmlFilterSettingsPart>("MediaHtmlFilterSettings", "Parts.MediaProcessing.MediaHtmlFilterSettings", "media"));
+        }
+
+        public Localizer T { get; set; }
+
+        protected override void GetItemMetadata(GetContentItemMetadataContext context) {
+            if (context.ContentItem.ContentType != "Site")
+                return;
+            base.GetItemMetadata(context);
+            context.Metadata.EditorGroupInfo.Add(new GroupInfo(T("Media")));
+        }
+
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Models/MediaHtmlFilterSettingsPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Models/MediaHtmlFilterSettingsPart.cs
@@ -1,0 +1,23 @@
+﻿using Orchard.ContentManagement;
+using Orchard.ContentManagement.FieldStorage.InfosetStorage;
+
+namespace Orchard.MediaProcessing.Models {
+    public class MediaHtmlFilterSettingsPart : ContentPart {
+
+        public int DensityThreshold {
+            get { return this.Retrieve(x => x.DensityThreshold, 2); }
+            set { this.Store(x => x.DensityThreshold, value); }
+        }
+
+        public int Quality {
+            get { return this.Retrieve(x => x.Quality, 95); }
+            set { this.Store(x => x.Quality, value); }
+        }
+
+        public bool PopulateAlt {
+            get { return this.Retrieve(x => x.PopulateAlt, true); }
+            set { this.Store(x => x.PopulateAlt, value); }
+        }
+
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Module.txt
@@ -7,3 +7,8 @@ OrchardVersion: 1.9
 Description: Module for processing Media e.g. image resizing
 Category: Media
 Dependencies: Orchard.Forms
+Features:
+    Orchard.MediaProcessingHtmlFilter:
+        Name: Media Processing HTML Filter
+        Description: Dynamically resizes images to their height and width attributes
+        Category: Media

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Orchard.MediaProcessing.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Orchard.MediaProcessing.csproj
@@ -49,6 +49,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="HtmlAgilityPack, Version=1.4.9.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\..\NuGet\Packages\HtmlAgilityPack.1.4.9\lib\Net45\HtmlAgilityPack.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="ImageResizer, Version=3.4.3.103, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\ImageResizer.3.4.3\lib\ImageResizer.dll</HintPath>
       <Private>True</Private>
@@ -104,6 +108,10 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
+    <Compile Include="Constants.cs" />
+    <Compile Include="Filters\MediaProcessingHtmlFilter.cs" />
+    <Compile Include="Handlers\MediaHtmlFilterSettingsPartHandler.cs" />
+    <Compile Include="Models\MediaHtmlFilterSettingsPart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
@@ -189,6 +197,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\EditorTemplates\Parts.MediaProcessing.MediaHtmlFilterSettings.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Views/EditorTemplates/Parts.MediaProcessing.MediaHtmlFilterSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Views/EditorTemplates/Parts.MediaProcessing.MediaHtmlFilterSettings.cshtml
@@ -1,0 +1,26 @@
+﻿@model Orchard.MediaProcessing.Models.MediaHtmlFilterSettingsPart
+
+<fieldset>
+    <legend>@T("Media Processing Filter")</legend>
+    <div>
+        @Html.LabelFor(m => m.DensityThreshold, T("Density Threshold"))
+        @Html.DropDownListFor(m => m.DensityThreshold, new List<SelectListItem>(new [] {
+                    new SelectListItem { Value = "1", Text = "@1x" },
+                    new SelectListItem { Value = "2", Text = "@2x" },
+                    new SelectListItem { Value = "3", Text = "@3x" },
+                    new SelectListItem { Value = "4", Text = "@4x" }}
+                ))
+        <span class="hint">@T("The image will only be reduced if at least this pixel density is maintained.")</span>
+    </div>
+    <div>
+        @Html.LabelFor(m => m.Quality, T("JPEG Quality"))
+        @Html.TextBoxFor(i => i.Quality, new { @type = "number", @min = "0", @max = "100" }) %
+        <span class="hint">@T("The quality level to apply on JPEG's, where 100 is full-quality (no compression).")</span>
+    </div>
+    <div>
+        @Html.CheckBoxFor(i => i.PopulateAlt)
+        @Html.LabelFor(m => m.PopulateAlt, T("Populate Empty Alt Tags").Text, new { @class = "forcheckbox" })
+        <span class="hint">@T("Populate an Alt tag based on the file name if the Alt tag is empty")</span>
+    </div>
+
+</fieldset>

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net452" />
   <package id="ImageResizer" version="3.4.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />


### PR DESCRIPTION
Fixes #6986

Enabling this feature registers an implementation of `IHtmlFilter` that works on any part with a flavor of "HTML" that injects and applies the registered IHtmlFilters.

Additional settings appear under in the Admin UI under `Settings > Media` to control to behavior of this feature. It is quite straightforward:

**Density Threshold**
With a threshold of, for example, `@2x`, an image will only be reduced if the natural size of the image is more than 2x the size specified in the attributes.

**Quality**
Only applies to jpeg's, the quality to compress the image at.

**Populate Empty Alt Tags**
If the img has an empty Alt tag, one will be composed based on the image file name

**noresize attribute**
Adding a noresize attribute to any img element will cause the element not to be processed:

`<img noresize src="/Media/example.jpg" alt="this image will not be processed" />`

_Note that images already the result of a profile (ie already under /_Profiles/*) will not be processed._

To try out this feature, simply add a suitable image from your media library to e.g. a body part and use the handles in the editor the resize the image. When rendered, you will see that the image comes from a profile and not from the original source. Change the quality or density in the settings and you will see new profiles being generated.

Clean up the dynamic test profiles or force regeneration with the "Purge Obsolete" feature from PR #6984.
