### PR TITLE
Update Content-Term.Edit.cshtml

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/Items/Content-Term.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/Items/Content-Term.Edit.cshtml
@@ -2,6 +2,9 @@
 @{
     Html.AddTitleParts((string)Model.Title);
 }
-@Display(Model.Primary)
-@Display(Model.Secondary)
-<fieldset><button class="primaryAction" type="submit">@T("Save")</button></fieldset>
+<div class="primary">
+    @Display(Model.Content)
+</div>
+<div class="secondary">
+    @Display(Model.Sidebar)
+</div>


### PR DESCRIPTION
this file in Module “Taxonomies” 
when Taxonomy tile is "我是中文" the ToSafeName method will remove all chars 
alternates will match this file then bug happens

or just delete this file

