### PR TITLE
Fixed the output caching of non 200  - fixes #7034

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -227,8 +227,10 @@ namespace Orchard.OutputCache.Filters {
                         // should be resolved from it.
 
                         // Recheck the response status code incase it was modified before the callback.
-                        if (response.StatusCode != 200)
+                        if (response.StatusCode != 200) {
+                            Logger.Debug("Response for item '{0}' will not be cached because status code was set to {1} during rendering.", _cacheKey, response.StatusCode);
                             return;
+                        }
 
                         using (var scope = _workContextAccessor.CreateWorkContextScope()) {
                             var cacheItem = new CacheItem() {

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -226,6 +226,10 @@ namespace Orchard.OutputCache.Filters {
                         // To prevent access to the original lifetime scope a new work context scope should be created here and dependencies
                         // should be resolved from it.
 
+                        // Recheck the response status code incase it was modified before the callback.
+                        if (response.StatusCode != 200)
+                            return;
+
                         using (var scope = _workContextAccessor.CreateWorkContextScope()) {
                             var cacheItem = new CacheItem() {
                                 CachedOnUtc = _now,


### PR DESCRIPTION
Fixed the output caching of non 200 responses when exceptions are thrown by views, htmlhelpers, etc.