### PR TITLE
Changed CultureSelectorResult.Priority type to double

### DIFF
--- a/src/Orchard/Localization/Services/ICultureSelector.cs
+++ b/src/Orchard/Localization/Services/ICultureSelector.cs
@@ -2,7 +2,7 @@
 
 namespace Orchard.Localization.Services {
     public class CultureSelectorResult {
-        public int Priority { get; set; }
+        public double Priority { get; set; }
         public string CultureName { get; set; }
     }
 


### PR DESCRIPTION
Orchard culture selectors' priorities are from -5 to -1. This makes impossible to create a culture selector, that returns result with priority between default ones. For example if we want to have default culture per user stored in database, but want to override it with cookie, we'll need to have a selector with priority smaller than `CookieCultureSelector `but greater than all others, for example -2.5. 