### PR TITLE
Updating with a precise user message

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
@@ -204,7 +204,7 @@ namespace Orchard.Users.Controllers {
 
             _userService.SendLostPasswordEmail(username, nonce => Url.MakeAbsolute(Url.Action("LostPassword", "Account", new { Area = "Orchard.Users", nonce = nonce }), siteUrl));
 
-            _orchardServices.Notifier.Information(T("If you are an existing user, we will immediately send you an email with a link to reset your password."));
+            _orchardServices.Notifier.Information(T("If your username or email is correct, we will immediately send you an email with a link to reset your password."));
             
             return RedirectToAction("LogOn");
         }

--- a/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
@@ -204,7 +204,7 @@ namespace Orchard.Users.Controllers {
 
             _userService.SendLostPasswordEmail(username, nonce => Url.MakeAbsolute(Url.Action("LostPassword", "Account", new { Area = "Orchard.Users", nonce = nonce }), siteUrl));
 
-            _orchardServices.Notifier.Information(T("Check your e-mail for the confirmation link."));
+            _orchardServices.Notifier.Information(T("If you are an existing user, we will immediately send you an email with a link to reset your password."));
             
             return RedirectToAction("LogOn");
         }


### PR DESCRIPTION
The email is sent only when the user is found in the system, not otherwise. 
When a non existing user tries to recover the password, the current message does not say that the user wouldn't receive the email.
