### PR TITLE
Pass the right display type to the widget element.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Widgets/Layouts/Providers/WidgetElementHarvester.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Layouts/Providers/WidgetElementHarvester.cs
@@ -56,7 +56,7 @@ namespace Orchard.Widgets.Layouts.Providers {
                 ? _contentManager.Value.Get(widgetId.Value, versionOptions)
                 : _contentManager.Value.New(contentTypeName);
 
-            var widgetShape = widget != null ? _contentManager.Value.BuildDisplay(widget) : default(dynamic);
+            var widgetShape = widget != null ? _contentManager.Value.BuildDisplay(widget, context.DisplayType) : default(dynamic);
             context.ElementShape.Widget = widget;
             context.ElementShape.WidgetShape = widgetShape;
         }


### PR DESCRIPTION
**In this PR**

- While helping someone which uses a projection element with a custom display type to render each content, we needed to pass the right diplay type to widget elements.

**Another suggestion**

- When in `Design` mode, because the actual `Projection.Design.cshtml` only uses the `ContentItems` collection, to prevent many handler / driver from being executed, we could use this in `ProjectionElementDriver.OnDisplaying()`.

    ```
// after this line
    context.ElementShape.ContentItems = contentItems;

    // Nothing more to do if we are in "Design" mode.
    if (context.DisplayType == "Design") {
        return;
    }
```
But i didn't include this in this PR because maybe we still want to be able to override `Projection.Design.cshtml` if someone want to render more things in design mode ... So let me know.

Best