### PR TITLE
Added DesignWidth and DesignHeight to VectorImage element

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Drivers/VectorImageElementDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Drivers/VectorImageElementDriver.cs
@@ -22,7 +22,9 @@ namespace Orchard.Layouts.Drivers {
             var viewModel = new VectorImageEditorViewModel {
                 VectorImageId = element.MediaId.ToString(),
                 Width = element.Width,
-                Height = element.Height
+                Height = element.Height,
+                DesignWidth = element.DesignWidth,
+                DesignHeight = element.DesignHeight
             };
             var editor = context.ShapeFactory.EditorTemplate(TemplateName: "Elements.VectorImage", Model: viewModel);
 
@@ -31,6 +33,8 @@ namespace Orchard.Layouts.Drivers {
                 element.MediaId = ParseVectorImageId(viewModel.VectorImageId);
                 element.Width = viewModel.Width;
                 element.Height = viewModel.Height;
+                element.DesignWidth = viewModel.DesignWidth;
+                element.DesignHeight = viewModel.DesignHeight;
             }
 
             var mediaId = element.MediaId;

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Elements/VectorImage.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Elements/VectorImage.cs
@@ -25,5 +25,17 @@ namespace Orchard.Layouts.Elements {
             get { return this.Retrieve(x => x.Height); }
             set { this.Store(x => x.Height, value); }
         }
+
+        public int? DesignWidth
+        {
+            get { return this.Retrieve(x => x.DesignWidth); }
+            set { this.Store(x => x.DesignWidth, value); }
+        }
+
+        public int? DesignHeight
+        {
+            get { return this.Retrieve(x => x.DesignHeight); }
+            set { this.Store(x => x.DesignHeight, value); }
+        }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Layouts/ViewModels/VectorImageEditorViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/ViewModels/VectorImageEditorViewModel.cs
@@ -5,6 +5,8 @@ namespace Orchard.Layouts.ViewModels {
         public string VectorImageId { get; set; }
         public int? Width { get; set; }
         public int? Height { get; set; }
+        public int? DesignWidth { get; set; }
+        public int? DesignHeight { get; set; }
         public VectorImagePart CurrentVectorImage { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Views/EditorTemplates/Elements.VectorImage.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Views/EditorTemplates/Elements.VectorImage.cshtml
@@ -32,3 +32,16 @@
         @Html.Hint(T("Optional. Specify the height of this element."))
     </div>
 </fieldset>
+
+<fieldset>
+    <div class="form-group">
+        @Html.LabelFor(m => m.DesignWidth, T("Design Width"))
+        @Html.TextBoxFor(m => m.DesignWidth, new { @class = "text medium" })
+        @Html.Hint(T("Optional. Specify the width of this element in the Layout Designer."))
+    </div>
+    <div class="form-group">
+        @Html.LabelFor(m => m.DesignHeight, T("Design Height"))
+        @Html.TextBoxFor(m => m.DesignHeight, new { @class = "text medium" })
+        @Html.Hint(T("Optional. Specify the height of this element in the Layout Designer."))
+    </div>
+</fieldset>

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Views/Elements/VectorImage.Design.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Views/Elements/VectorImage.Design.cshtml
@@ -7,6 +7,7 @@
     var element = (VectorImage)Model.Element;
     var vectorImagePart = (VectorImagePart)Model.VectorImagePart;
     var mediaPart = vectorImagePart != null ? vectorImagePart.As<MediaPart>() : default(MediaPart);
+    string style = string.Empty;
 
     if (mediaPart != null) {
         tagBuilder.Attributes["src"] = mediaPart.MediaUrl;
@@ -16,12 +17,29 @@
         tagBuilder.Attributes["alt"] = T("Image not found").Text;
     }
 
-    if (element.Width != null) {
+    if (element.DesignWidth != null) {
+        tagBuilder.Attributes["width"] = element.DesignWidth.ToString();
+        style += "width:" + element.DesignWidth.ToString() + "px;";
+    }
+    else if(element.Width != null) {
         tagBuilder.Attributes["width"] = element.Width.ToString();
     }
 
-    if (element.Height != null) {
+    if (element.DesignHeight != null) {
+        tagBuilder.Attributes["height"] = element.DesignHeight.ToString();
+        style += "height:" + element.DesignHeight.ToString() + "px;";
+    }
+    else if (element.Height != null) {
         tagBuilder.Attributes["height"] = element.Height.ToString();
+    }
+
+    if(!string.IsNullOrWhiteSpace(style)) {
+        if (tagBuilder.Attributes.ContainsKey("style")) {
+            tagBuilder.Attributes["style"] += style;
+        }
+        else {
+            tagBuilder.Attributes["style"] = style;
+        }
     }
 }
 @tagBuilder.ToHtmlString(TagRenderMode.SelfClosing)


### PR DESCRIPTION
In the Layout Designer view, VectorImages are always scaled up to fill available width, which is often undesirable as the image will eventually be scaled down on the front-end by a CSS rule. This causes the image size (and thus layout) to be different between Layout Designer and front-end, and is particularly annoying if the front-end image should be substantially smaller than the container.
By defining DesignWidth and DesignHeight, you can force the image to scale down (or up) in the Layout Designer to better approximate its final front-end dimensions. It has no effect on its front-end dimensions.