### PR TITLE
Fixes #7121 Fix incorrect url to docs for layer rules

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Widgets/Views/EditorTemplates/Parts.Widgets.LayerPart.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Views/EditorTemplates/Parts.Widgets.LayerPart.cshtml
@@ -15,5 +15,5 @@
 <fieldset>
     @Html.LabelFor(layer => layer.LayerRule, T("Layer Rule"))
     @Html.TextAreaFor(layer => layer.LayerRule, new { spellcheck = "false" })
-    <span class="hint">@T("An expression that evaluates to true when the widgets in this layer must be displayed. See <a href=\"http://docs.orchardproject.net/Documentation/Managing-widgets#AddingaLayer\">http://docs.orchardproject.net/Documentation/Managing-widgets#AddingaLayer</a> for more information.")</span>
+    <span class="hint">@T("An expression that evaluates to true when the widgets in this layer must be displayed. See <a href=\"http://docs.orchardproject.net/en/latest/Documentation/Managing-widgets/#adding-a-layer\">http://docs.orchardproject.net/en/latest/Documentation/Managing-widgets/#adding-a-layer</a> for more information.")</span>
 </fieldset>


### PR DESCRIPTION
Fixes #7121

Correct url is now:

http://docs.orchardproject.net/en/latest/Documentation/Managing-widgets/#adding-a-layer