### PR TITLE
Fixes #7120 Hidden Field in Dynamic Forms causes crash

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/HiddenFieldElementDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/HiddenFieldElementDriver.cs
@@ -36,7 +36,7 @@ namespace Orchard.DynamicForms.Drivers {
 
         protected override void OnDisplaying(HiddenField element, ElementDisplayingContext context) {
             context.ElementShape.ProcessedName = _tokenizer.Replace(element.Name, context.GetTokenData());
-            context.ElementShape.ProcessedValue = element.RuntimeValue;
+            context.ElementShape.ProcessedValue = element.RuntimeValue ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
Fixes #7120 - If a Hidden Field is added to a DynamicForm without a Value set then it will crash the front end because of a null value.