### PR TITLE
[Fixes #7132] Orchard.Fields - Inconsistent use of mandatory / required

### DIFF
--- a/src/Orchard.Specs/Boolean.feature
+++ b/src/Orchard.Specs/Boolean.feature
@@ -73,4 +73,4 @@ Scenario: Creating and using Boolean fields
             | name               | value |
             | Event.Active.Value |       |
         And I hit "Save"
-    Then I should see "The field Active is mandatory."
+    Then I should see "The Active field is required."

--- a/src/Orchard.Specs/Boolean.feature.cs
+++ b/src/Orchard.Specs/Boolean.feature.cs
@@ -211,7 +211,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 75
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 76
-    testRunner.Then("I should see \"The field Active is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("I should see \"The Active field is required.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/Orchard.Specs/Enumeration.feature
+++ b/src/Orchard.Specs/Enumeration.feature
@@ -106,7 +106,7 @@ Scenario: Creating and using Enumeration fields
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
         And I hit "Save"
-    Then I should see "The field Location is mandatory."
+    Then I should see "The Location field is required."
     
     # The default value should be proposed on creation
     When I go to "Admin/ContentTypes/Edit/Event"

--- a/src/Orchard.Specs/Enumeration.feature.cs
+++ b/src/Orchard.Specs/Enumeration.feature.cs
@@ -272,7 +272,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 108
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 109
-    testRunner.Then("I should see \"The field Location is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("I should see \"The Location field is required.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 112
     testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden

--- a/src/Orchard.Specs/Input.feature
+++ b/src/Orchard.Specs/Input.feature
@@ -114,7 +114,7 @@ Scenario: Creating and using Input fields
             | name                | value |
             | Event.Contact.Value |       |
         And I hit "Save"
-    Then I should see "The field Contact is mandatory."
+    Then I should see "The Contact field is required."
     
     # Creating an Event content item
     When I go to "Admin/Contents/Create/Event"

--- a/src/Orchard.Specs/Input.feature.cs
+++ b/src/Orchard.Specs/Input.feature.cs
@@ -271,7 +271,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 116
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 117
-    testRunner.Then("I should see \"The field Contact is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("I should see \"The Contact field is required.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 120
     testRunner.When("I go to \"Admin/Contents/Create/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line 121

--- a/src/Orchard.Specs/MediaPicker.feature
+++ b/src/Orchard.Specs/MediaPicker.feature
@@ -63,7 +63,7 @@ Scenario: Creating and using media fields
             | name           | value |
             | Event.File.Url |       |
         And I hit "Save"
-    Then I should see "The field File is mandatory."
+    Then I should see "The File field is required."
 
     # The value should be bound
     When I go to "Admin/ContentTypes/Edit/Event"

--- a/src/Orchard.Specs/MediaPicker.feature
+++ b/src/Orchard.Specs/MediaPicker.feature
@@ -77,4 +77,4 @@ Scenario: Creating and using media fields
             | name           | value                            |
             | Event.File.Url | ~/Media/Default/images/Image.png |
         And I hit "Save"
-    Then I should see "The field File must have one of these extensions: jpg"
+    Then I should see "The File field must have one of these extensions: jpg."

--- a/src/Orchard.Specs/MediaPicker.feature.cs
+++ b/src/Orchard.Specs/MediaPicker.feature.cs
@@ -190,7 +190,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 65
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 66
-    testRunner.Then("I should see \"The field File is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("I should see \"The File field is required.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 69
     testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden

--- a/src/Orchard.Specs/MediaPicker.feature.cs
+++ b/src/Orchard.Specs/MediaPicker.feature.cs
@@ -221,7 +221,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 79
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 80
-    testRunner.Then("I should see \"The field File must have one of these extensions: jpg\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("I should see \"The File field must have one of these extensions: jpg.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/Orchard.Specs/Numeric.feature
+++ b/src/Orchard.Specs/Numeric.feature
@@ -64,7 +64,7 @@ Scenario: Creating and using numeric fields
             | name               | value |
             | Event.Guests.Value |       |
         And I hit "Save"
-    Then I should see "The field Guests is mandatory."
+    Then I should see "The Guests field is required."
 
     # The value should be bound
     When I go to "Admin/ContentTypes/Edit/Event"

--- a/src/Orchard.Specs/Numeric.feature.cs
+++ b/src/Orchard.Specs/Numeric.feature.cs
@@ -194,7 +194,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 66
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 67
-    testRunner.Then("I should see \"The field Guests is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("I should see \"The Guests field is required.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 70
     testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden

--- a/src/Orchard.Specs/Text.feature
+++ b/src/Orchard.Specs/Text.feature
@@ -51,7 +51,7 @@ Scenario: Creating and using Text fields
             | name               | value |
             | Event.Subject.Text |       |
         And I hit "Save"
-    Then I should see "The field Subject is mandatory."
+    Then I should see "The Subject field is required."
 
     # The hint should be displayed
     When I go to "Admin/ContentTypes/Edit/Event"

--- a/src/Orchard.Specs/Text.feature.cs
+++ b/src/Orchard.Specs/Text.feature.cs
@@ -169,7 +169,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 53
         testRunner.And("I hit \"Save\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 54
-    testRunner.Then("I should see \"The field Subject is mandatory.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("I should see \"The Subject field is required.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 57
     testRunner.When("I go to \"Admin/ContentTypes/Edit/Event\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden

--- a/src/Orchard.Web/Core/Common/Drivers/TextFieldDriver.cs
+++ b/src/Orchard.Web/Core/Common/Drivers/TextFieldDriver.cs
@@ -69,7 +69,7 @@ namespace Orchard.Core.Common.Drivers {
                 field.Value = viewModel.Text;
 
                 if (settings.Required && String.IsNullOrWhiteSpace(field.Value)) {
-                    updater.AddModelError("Text", T("The field {0} is mandatory", T(field.DisplayName)));
+                    updater.AddModelError("Text", T("The {0} field is required.", T(field.DisplayName)));
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldDriver.cs
@@ -68,7 +68,7 @@ namespace Orchard.ContentPicker.Drivers {
             }
 
             if (settings.Required && field.Ids.Length == 0) {
-                updater.AddModelError("Id", T("The field {0} is mandatory", field.Name.CamelFriendly()));
+                updater.AddModelError("Id", T("The {0} field is required.", field.Name.CamelFriendly()));
             }
 
             return Editor(part, field, shapeHelper);

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
@@ -49,7 +49,7 @@ namespace Orchard.Fields.Drivers {
                 var settings = field.PartFieldDefinition.Settings.GetModel<BooleanFieldSettings>();
 
                 if (!settings.Optional && !field.Value.HasValue) {
-                    updater.AddModelError(field.Name, T("The field {0} is mandatory.", T(field.DisplayName)));
+                    updater.AddModelError(field.Name, T("The {0} field is required.", T(field.DisplayName)));
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
@@ -139,7 +139,7 @@ namespace Orchard.Fields.Drivers {
                         value = DateLocalizationServices.ConvertFromLocalizedString(viewModel.Editor.Date, viewModel.Editor.Time, options);
                     }
                     catch {
-                        updater.AddModelError(GetPrefix(field, part), T("{0} could not be parsed as a valid date and time.", field.DisplayName));
+                        updater.AddModelError(GetPrefix(field, part), T("{0} could not be parsed as a valid date and time.", T(field.DisplayName)));
                     }
                 }
 
@@ -151,7 +151,7 @@ namespace Orchard.Fields.Drivers {
                 }
 
                 if (settings.Required && (!value.HasValue || (settings.Display != DateTimeFieldDisplays.TimeOnly && value.Value.Date == DateTime.MinValue))) {
-                    updater.AddModelError(GetPrefix(field, part), T("{0} is required.", field.DisplayName));
+                    updater.AddModelError(GetPrefix(field, part), T("{0} is required.", T(field.DisplayName)));
                 }
 
                 field.DateTime = value.HasValue ? value.Value : DateTime.MinValue;

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
@@ -51,7 +51,7 @@ namespace Orchard.Fields.Drivers {
                 var settings = field.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
 
                 if (settings.Required && field.SelectedValues.Length == 0) {
-                    updater.AddModelError(field.Name, T("The field {0} is mandatory", T(field.DisplayName)));
+                    updater.AddModelError(field.Name, T("The {0} field is required.", T(field.DisplayName)));
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/InputFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/InputFieldDriver.cs
@@ -49,7 +49,7 @@ namespace Orchard.Fields.Drivers {
                 var settings = field.PartFieldDefinition.Settings.GetModel<InputFieldSettings>();
 
                 if (settings.Required && String.IsNullOrWhiteSpace(field.Value)) {
-                    updater.AddModelError(GetPrefix(field, part), T("The field {0} is mandatory.", T(field.DisplayName)));
+                    updater.AddModelError(GetPrefix(field, part), T("The {0} field is required.", T(field.DisplayName)));
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/LinkFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/LinkFieldDriver.cs
@@ -51,13 +51,13 @@ namespace Orchard.Fields.Drivers {
                 var settings = field.PartFieldDefinition.Settings.GetModel<LinkFieldSettings>();
 
                 if (settings.Required && String.IsNullOrWhiteSpace(field.Value)) {
-                    updater.AddModelError(GetPrefix(field, part), T("Url is required for {0}", field.DisplayName));
+                    updater.AddModelError(GetPrefix(field, part), T("Url is required for {0}.", T(field.DisplayName)));
                 }
                 else if (!String.IsNullOrWhiteSpace(field.Value) && !Uri.IsWellFormedUriString(field.Value, UriKind.RelativeOrAbsolute)) {
                     updater.AddModelError(GetPrefix(field, part), T("{0} is an invalid url.", field.Value));
                 }
                 else if (settings.LinkTextMode == LinkTextMode.Required && String.IsNullOrWhiteSpace(field.Text)) {
-                    updater.AddModelError(GetPrefix(field, part), T("Text is required for {0}.", field.DisplayName));
+                    updater.AddModelError(GetPrefix(field, part), T("Text is required for {0}.", T(field.DisplayName)));
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
@@ -68,31 +68,31 @@ namespace Orchard.Fields.Drivers {
 
                 if (String.IsNullOrWhiteSpace(viewModel.Value)) {
                     if (settings.Required) {
-                        updater.AddModelError(GetPrefix(field, part), T("The field {0} is mandatory.", T(field.DisplayName)));
+                        updater.AddModelError(GetPrefix(field, part), T("The {0} field is required.", T(field.DisplayName)));
                     }
                 }
                 else if (!Decimal.TryParse(viewModel.Value, NumberStyles.Any, _cultureInfo.Value, out value)) {
-                    updater.AddModelError(GetPrefix(field, part), T("{0} is an invalid number", field.DisplayName));
+                    updater.AddModelError(GetPrefix(field, part), T("{0} is an invalid number.", T(field.DisplayName)));
                 }
                 else {
 
                     field.Value = value;
 
                     if (settings.Minimum.HasValue && value < settings.Minimum.Value) {
-                        updater.AddModelError(GetPrefix(field, part), T("The value must be greater than {0}", settings.Minimum.Value));
+                        updater.AddModelError(GetPrefix(field, part), T("The value must be greater than {0}.", settings.Minimum.Value));
                     }
 
                     if (settings.Maximum.HasValue && value > settings.Maximum.Value) {
-                        updater.AddModelError(GetPrefix(field, part), T("The value must be less than {0}", settings.Maximum.Value));
+                        updater.AddModelError(GetPrefix(field, part), T("The value must be less than {0}.", settings.Maximum.Value));
                     }
 
                     // checking the number of decimals
                     if (Math.Round(value, settings.Scale) != value) {
                         if (settings.Scale == 0) {
-                            updater.AddModelError(GetPrefix(field, part), T("The field {0} must be an integer", field.DisplayName));
+                            updater.AddModelError(GetPrefix(field, part), T("The {0} field must be an integer.", T(field.DisplayName)));
                         }
                         else {
-                            updater.AddModelError(GetPrefix(field, part), T("Invalid number of digits for {0}, max allowed: {1}", field.DisplayName, settings.Scale));
+                            updater.AddModelError(GetPrefix(field, part), T("Invalid number of digits for {0}, max allowed: {1}.", T(field.DisplayName), settings.Scale));
                         }
                     }
                 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
@@ -65,7 +65,7 @@ namespace Orchard.MediaLibrary.Drivers {
             }
 
             if (settings.Required && field.Ids.Length == 0) {
-                updater.AddModelError("Id", T("The field {0} is mandatory", field.DisplayName));
+                updater.AddModelError("Id", T("The {0} field is required.", field.DisplayName));
             }
 
             return Editor(part, field, shapeHelper);

--- a/src/Orchard.Web/Modules/Orchard.MediaPicker/Drivers/MediaGalleryFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaPicker/Drivers/MediaGalleryFieldDriver.cs
@@ -72,11 +72,11 @@ namespace Orchard.MediaPicker.Drivers {
             var allItems = _jsonConverter.Deserialize<MediaGalleryItem[]>(field.SelectedItems);
 
             if (settings.Required && allItems.Length == 0) {
-                updater.AddModelError("SelectedItems", T("The field {0} is mandatory", field.Name.CamelFriendly()));
+                updater.AddModelError("SelectedItems", T("The {0} field is required.", field.Name.CamelFriendly()));
             }
 
             if (!settings.Multiple && allItems.Length > 1) {
-                updater.AddModelError("SelectedItems", T("The field {0} doesn't accept multiple media items", field.Name.CamelFriendly()));
+                updater.AddModelError("SelectedItems", T("The {0} field doesn't accept multiple media items.", field.Name.CamelFriendly()));
             }
 
             return Editor(part, field, shapeHelper);

--- a/src/Orchard.Web/Modules/Orchard.MediaPicker/Drivers/MediaPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaPicker/Drivers/MediaPickerFieldDriver.cs
@@ -45,11 +45,11 @@ namespace Orchard.MediaPicker.Drivers {
                         : settings.AllowedExtensions.Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries);
 
                 if (extensions.Any() && field.Url != null && !extensions.Any(x => field.Url.EndsWith(x, StringComparison.OrdinalIgnoreCase))) {
-                    updater.AddModelError("Url", T("The field {0} must have one of these extensions: {1}", field.Name.CamelFriendly(), settings.AllowedExtensions));
+                    updater.AddModelError("Url", T("The {0} field must have one of these extensions: {1}.", field.Name.CamelFriendly(), settings.AllowedExtensions));
                 }
 
                 if (settings.Required && String.IsNullOrWhiteSpace(field.Url)) {
-                    updater.AddModelError("Url", T("The field {0} is mandatory", field.Name.CamelFriendly()));
+                    updater.AddModelError("Url", T("The {0} field is required.", field.Name.CamelFriendly()));
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TaxonomyFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TaxonomyFieldDriver.cs
@@ -74,7 +74,7 @@ namespace Orchard.Taxonomies.Drivers {
 
                 var settings = field.PartFieldDefinition.Settings.GetModel<TaxonomyFieldSettings>();
                 if (settings.Required && !checkedTerms.Any()) {
-                    updater.AddModelError(GetPrefix(field, part), T("The field {0} is mandatory.", T(field.DisplayName)));
+                    updater.AddModelError(GetPrefix(field, part), T("The {0} field is required.", T(field.DisplayName)));
                 }
                 else
                     _taxonomyService.UpdateTerms(part.ContentItem, checkedTerms, field.Name);


### PR DESCRIPTION
[Fixes #7132] Orchard.Fields - Inconsistent use of mandatory / required

  * Fixes inconsistent use of mandatory / required
  * Brings wording in line with other validation messages
  * Tidies up missing full stops
  * Wraps all use of `DisplayName` in `T()`
  * Updated specflow tests