### PR TITLE
[Fixes #7142] - Orchard.Blogs - Edit Blog says New Blog in title 

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Blogs/Views/Content-Blog.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Views/Content-Blog.Edit.cshtml
@@ -1,7 +1,4 @@
 @using Orchard.Mvc.Html;
-@{
-    Layout.Title = T("New Blog");
-}
 <div class="edit-item">
     <div class="edit-item-primary">
         @if (Model.Content != null) {


### PR DESCRIPTION
Fixes #7142 

Starts off with either `\Views\BlogAdmin\Create.cshtml` or `\Views\BlogAdmin\Edit.cshtml` which set correct heading. 

Both controller actions use `\Views\Content-Blog.Edit.cshtml` which set the title a second time.