### PR TITLE
[fixes #7144] labels hidden when datetime field added

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/BooleanFieldSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/BooleanFieldSettings.cshtml
@@ -9,7 +9,7 @@
 </fieldset>
 <fieldset>
 	<div class="editor-field" data-controllerid="@Html.FieldIdFor(m => m.Optional)">
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.NotSetLabel)">@T("Neutral option text")</label>
+        <label for="@Html.FieldIdFor(m => m.NotSetLabel)">@T("Neutral option text")</label>
         @Html.TextBoxFor(m => m.NotSetLabel, new { @class = "text" })
         @Html.ValidationMessageFor(m => m.NotSetLabel)
         <span class="hint">@T("The text displayed when the field is not selected.")</span>
@@ -17,14 +17,14 @@
 </fieldset>
 <fieldset>
 	<div class="editor-field">
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.OnLabel)">@T("On Label")</label>
+        <label for="@Html.FieldIdFor(m => m.OnLabel)">@T("On Label")</label>
         @Html.TextBoxFor(m => m.OnLabel, new { @class = "text"})
         @Html.ValidationMessageFor(m => m.OnLabel)
         <span class="hint">@T("The text displayed when the field is selected.")</span>
 	</div>
 </fieldset>
 <fieldset>
-    <label class="forpicker" for="@Html.FieldIdFor(m => m.OffLabel)">@T("Off Label")</label>
+    <label for="@Html.FieldIdFor(m => m.OffLabel)">@T("Off Label")</label>
 	<div class="editor-field">
         @Html.TextBoxFor(m => m.OffLabel, new { @class = "text" })
         @Html.ValidationMessageFor(m => m.OffLabel)
@@ -32,7 +32,7 @@
 	</div>
 </fieldset>
 <fieldset>
-    <label class="forpicker" for="@Html.FieldIdFor(m => m.SelectionMode)">@T("Selection mode")</label>    
+    <label for="@Html.FieldIdFor(m => m.SelectionMode)">@T("Selection mode")</label>    
     <select id="@Html.FieldIdFor(m => m.SelectionMode)" name="@Html.FieldNameFor(m => m.SelectionMode)">
         @Html.SelectOption(SelectionMode.Checkbox, Model.SelectionMode == SelectionMode.Checkbox, T("Checkbox").ToString())
         @Html.SelectOption(SelectionMode.Radiobutton, Model.SelectionMode == SelectionMode.Radiobutton, T("Radio buttons").ToString())
@@ -41,7 +41,7 @@
     <span class="hint">@T("When Checkbox is selected, the label for 'on' will be used.")</span>
 </fieldset>
 <fieldset>
-	<label class="forpicker" for="@Html.FieldIdFor(m => m.DefaultValue)">@T("Default value")</label>    
+	<label for="@Html.FieldIdFor(m => m.DefaultValue)">@T("Default value")</label>    
     <select id="@Html.FieldIdFor(m => m.DefaultValue)" name="@Html.FieldNameFor(m => m.DefaultValue)">
         @Html.SelectOption((object)String.Empty, !Model.DefaultValue.HasValue, T("Neutral").ToString())
         @Html.SelectOption((object)true, Model.DefaultValue.HasValue && Model.DefaultValue == true, T("True").ToString())

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/EnumerationFieldSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/EnumerationFieldSettings.cshtml
@@ -7,14 +7,14 @@
     </div>
 </fieldset>
 <fieldset>
-    <label class="forpicker" for="@Html.FieldIdFor(m => m.Options)">@T("Options")</label>
+    <label for="@Html.FieldIdFor(m => m.Options)">@T("Options")</label>
 	<div class="editor-field">
     @Html.TextAreaFor(m => m.Options, new { @class = "text medium", rows = "5" })
     @Html.ValidationMessageFor(m => m.Options)
     <span class="hint">@T("Enter an option per line.")</span>
 	</div>
     
-	<label class="forpicker" for="@Html.FieldIdFor(m => m.ListMode)">@T("List mode")</label>    
+	<label for="@Html.FieldIdFor(m => m.ListMode)">@T("List mode")</label>    
     <select id="@Html.FieldIdFor(m => m.ListMode)" name="@Html.FieldNameFor(m => m.ListMode)">
         @Html.SelectOption(ListMode.Dropdown, Model.ListMode == ListMode.Dropdown, T("Dropdown list").ToString())
         @Html.SelectOption(ListMode.Radiobutton, Model.ListMode == ListMode.Radiobutton, T("Radio button list").ToString())

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/InputFieldSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/InputFieldSettings.cshtml
@@ -2,7 +2,7 @@
 
 <fieldset>
     <div>
-    	<label class="forpicker" for="@Html.FieldIdFor(m => m.Type)">@T("Input type")</label>    
+    	<label for="@Html.FieldIdFor(m => m.Type)">@T("Input type")</label>    
         <select id="@Html.FieldIdFor(m => m.Type)" name="@Html.FieldNameFor(m => m.Type)">
             @Html.SelectOption(Orchard.Fields.Settings.InputType.Text, Model.Type == Orchard.Fields.Settings.InputType.Text, T("Text").ToString(), new { id = Html.FieldIdFor(m => m.Type) + "-text" })
             @Html.SelectOption(Orchard.Fields.Settings.InputType.Url, Model.Type == Orchard.Fields.Settings.InputType.Url, T("Url").ToString())
@@ -12,7 +12,7 @@
         <span class="hint">@T("Defines what format should be applied to the text.")</span>
     </div>
 	<div class="editor-field" data-controllerid="@(Html.FieldIdFor(m => m.Type) + "-text")">
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.Pattern)">@T("Pattern")</label>
+        <label for="@Html.FieldIdFor(m => m.Pattern)">@T("Pattern")</label>
         @Html.TextBoxFor(m => m.Pattern, new { @class = "text medium" })
         @Html.ValidationMessageFor(m => m.Pattern)
         <span class="hint">@T("Declaring what pattern should be used for validating a field’s value, in the form of a regular expression. (optional)")</span>
@@ -20,7 +20,7 @@
 </fieldset>
 <fieldset>
 	<div class="editor-field">
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.Title)">@T("Title")</label>
+        <label for="@Html.FieldIdFor(m => m.Title)">@T("Title")</label>
         @Html.TextBoxFor(m => m.Title, new { @class = "text"})
         @Html.ValidationMessageFor(m => m.Title)
         <span class="hint">@T("The title attribute of the field. (optional)")</span>
@@ -46,7 +46,7 @@
 </fieldset>
 <fieldset>
 	<div class="editor-field">
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.Placeholder)">@T("Watermark")</label>
+        <label for="@Html.FieldIdFor(m => m.Placeholder)">@T("Watermark")</label>
         @Html.TextBoxFor(m => m.Placeholder, new { @class = "text" })
         @Html.ValidationMessageFor(m => m.Placeholder)
         <span class="hint">@T("A hint to display when the input is empty. (optional)")</span>
@@ -54,7 +54,7 @@
 </fieldset>
 <fieldset>
 	<div class="editor-field">
-    <label class="forpicker" for="@Html.FieldIdFor(m => m.EditorCssClass)">@T("Editor css class")</label>
+    <label for="@Html.FieldIdFor(m => m.EditorCssClass)">@T("Editor css class")</label>
         @Html.TextBoxFor(m => m.EditorCssClass, new { @class = "text" })
         @Html.ValidationMessageFor(m => m.EditorCssClass)
         <span class="hint">@T("The css class to use for the editor. (optional)")</span>
@@ -62,7 +62,7 @@
 </fieldset>
 <fieldset>
 	<div class="editor-field">
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.MaxLength)">@T("Maximum length")</label>
+        <label for="@Html.FieldIdFor(m => m.MaxLength)">@T("Maximum length")</label>
         @Html.TextBoxFor(m => m.MaxLength, new { @class = "text small" })
         @Html.ValidationMessageFor(m => m.MaxLength)
         <span class="hint">@T("The maximum number of chars allowed. (optional)")</span>

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/LinkFieldSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/LinkFieldSettings.cshtml
@@ -3,7 +3,7 @@
 
 <fieldset>
     <div>
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.TargetMode)">@T("Target")</label>    
+        <label for="@Html.FieldIdFor(m => m.TargetMode)">@T("Target")</label>    
         <select id="@Html.FieldIdFor(m => m.TargetMode)" name="@Html.FieldNameFor(m => m.TargetMode)">
             @Html.SelectOption(TargetMode.None, Model.TargetMode == TargetMode.None, T("No target").ToString())
             @Html.SelectOption(TargetMode.NewWindow, Model.TargetMode == TargetMode.NewWindow, T("Open link in new window").ToString())
@@ -21,7 +21,7 @@
 </fieldset>
 <fieldset>
     <div>
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.LinkTextMode)">@T("Link text")</label>    
+        <label for="@Html.FieldIdFor(m => m.LinkTextMode)">@T("Link text")</label>    
         <select id="@Html.FieldIdFor(m => m.LinkTextMode)" name="@Html.FieldNameFor(m => m.LinkTextMode)">
             @Html.SelectOption(LinkTextMode.Optional, Model.LinkTextMode == LinkTextMode.Optional, T("Optional").ToString())
             @Html.SelectOption(LinkTextMode.Required, Model.LinkTextMode == LinkTextMode.Required, T("Required").ToString())

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/NumericFieldSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/DefinitionTemplates/NumericFieldSettings.cshtml
@@ -9,7 +9,7 @@
 </fieldset>
 <fieldset>
 	<div class="editor-field">
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.Scale)">@T("Scale")</label>
+        <label for="@Html.FieldIdFor(m => m.Scale)">@T("Scale")</label>
         @Html.TextBoxFor(m => m.Scale, new { @class = "text small" })
         @Html.ValidationMessageFor(m => m.Scale)
         <span class="hint">@T("The number of digits to the right of the decimal. Put 0 for integers.")</span>
@@ -17,7 +17,7 @@
 </fieldset>
 <fieldset>
 	<div class="editor-field">
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.Minimum)">@T("Minimum")</label>
+        <label for="@Html.FieldIdFor(m => m.Minimum)">@T("Minimum")</label>
         @Html.TextBoxFor(m => m.Minimum, new { @class = "text small" })
         @Html.ValidationMessageFor(m => m.Minimum)
         <span class="hint">@T("The minimum value allowed. (optional)")</span>
@@ -25,7 +25,7 @@
 </fieldset>
 <fieldset>
 	<div class="editor-field">
-        <label class="forpicker" for="@Html.FieldIdFor(m => m.Maximum)">@T("Maximum")</label>
+        <label for="@Html.FieldIdFor(m => m.Maximum)">@T("Maximum")</label>
         @Html.TextBoxFor(m => m.Maximum, new { @class = "text small" })
         @Html.ValidationMessageFor(m => m.Maximum)
         <span class="hint">@T("The maximum value allowed. (optional)")</span>


### PR DESCRIPTION
fixes #7144 

It was a copy / paste issue thats been lurking around for years. `.forpicker` only exists in the datetimeeditor css file but many fields editors had obviously been copied from that initial snippet because they had the class.