### PR TITLE
[Fixes #7111] Fields display as "&amp;" instead of "&" in validation error msgs

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
@@ -139,7 +139,7 @@ namespace Orchard.Fields.Drivers {
                         value = DateLocalizationServices.ConvertFromLocalizedString(viewModel.Editor.Date, viewModel.Editor.Time, options);
                     }
                     catch {
-                        updater.AddModelError(GetPrefix(field, part), T("{0} could not be parsed as a valid date and time.", field.DisplayName));
+                        updater.AddModelError(GetPrefix(field, part), T("{0} could not be parsed as a valid date and time.", T(field.DisplayName)));
                     }
                 }
 
@@ -151,7 +151,7 @@ namespace Orchard.Fields.Drivers {
                 }
 
                 if (settings.Required && (!value.HasValue || (settings.Display != DateTimeFieldDisplays.TimeOnly && value.Value.Date == DateTime.MinValue))) {
-                    updater.AddModelError(GetPrefix(field, part), T("{0} is required.", field.DisplayName));
+                    updater.AddModelError(GetPrefix(field, part), T("{0} is required.", T(field.DisplayName)));
                 }
 
                 field.DateTime = value.HasValue ? value.Value : DateTime.MinValue;

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/LinkFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/LinkFieldDriver.cs
@@ -51,13 +51,13 @@ namespace Orchard.Fields.Drivers {
                 var settings = field.PartFieldDefinition.Settings.GetModel<LinkFieldSettings>();
 
                 if (settings.Required && String.IsNullOrWhiteSpace(field.Value)) {
-                    updater.AddModelError(GetPrefix(field, part), T("Url is required for {0}", field.DisplayName));
+                    updater.AddModelError(GetPrefix(field, part), T("Url is required for {0}", T(field.DisplayName)));
                 }
                 else if (!String.IsNullOrWhiteSpace(field.Value) && !Uri.IsWellFormedUriString(field.Value, UriKind.RelativeOrAbsolute)) {
                     updater.AddModelError(GetPrefix(field, part), T("{0} is an invalid url.", field.Value));
                 }
                 else if (settings.LinkTextMode == LinkTextMode.Required && String.IsNullOrWhiteSpace(field.Text)) {
-                    updater.AddModelError(GetPrefix(field, part), T("Text is required for {0}.", field.DisplayName));
+                    updater.AddModelError(GetPrefix(field, part), T("Text is required for {0}.", T(field.DisplayName)));
                 }
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
@@ -72,7 +72,7 @@ namespace Orchard.Fields.Drivers {
                     }
                 }
                 else if (!Decimal.TryParse(viewModel.Value, NumberStyles.Any, _cultureInfo.Value, out value)) {
-                    updater.AddModelError(GetPrefix(field, part), T("{0} is an invalid number", field.DisplayName));
+                    updater.AddModelError(GetPrefix(field, part), T("{0} is an invalid number", T(field.DisplayName)));
                 }
                 else {
 
@@ -89,10 +89,10 @@ namespace Orchard.Fields.Drivers {
                     // checking the number of decimals
                     if (Math.Round(value, settings.Scale) != value) {
                         if (settings.Scale == 0) {
-                            updater.AddModelError(GetPrefix(field, part), T("The field {0} must be an integer", field.DisplayName));
+                            updater.AddModelError(GetPrefix(field, part), T("The field {0} must be an integer", T(field.DisplayName)));
                         }
                         else {
-                            updater.AddModelError(GetPrefix(field, part), T("Invalid number of digits for {0}, max allowed: {1}", field.DisplayName, settings.Scale));
+                            updater.AddModelError(GetPrefix(field, part), T("Invalid number of digits for {0}, max allowed: {1}", T(field.DisplayName), settings.Scale));
                         }
                     }
                 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
@@ -65,7 +65,7 @@ namespace Orchard.MediaLibrary.Drivers {
             }
 
             if (settings.Required && field.Ids.Length == 0) {
-                updater.AddModelError("Id", T("The field {0} is mandatory", field.DisplayName));
+                updater.AddModelError("Id", T("The field {0} is mandatory", T(field.DisplayName)));
             }
 
             return Editor(part, field, shapeHelper);

--- a/src/Orchard.Web/Modules/Orchard.Templates/Drivers/ShapePartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Templates/Drivers/ShapePartDriver.cs
@@ -81,7 +81,7 @@ namespace Orchard.Templates.Drivers {
                 return true;
             }
 
-            updater.AddModelError("Title", T("{0} names can only contain alphanumerical or underscore (_) characters and have to start with a letter.", part.ContentItem.TypeDefinition.DisplayName));
+            updater.AddModelError("Title", T("{0} names can only contain alphanumerical or underscore (_) characters and have to start with a letter.", T(part.ContentItem.TypeDefinition.DisplayName)));
             return false;
         }
 


### PR DESCRIPTION
[Fixes #7111] Fields display as "&amp;" instead of "&" in validation error msgs