### PR TITLE
[Fixes #7193] Admin Theme - Orchard.Taxonomies - Empty taxonomies view needs full stop

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/Admin/Index.cshtml
@@ -91,7 +91,7 @@
         <div class="panel-body">
             <h3 class="no-content">
                 @T("There are currently no taxonomies.")
-                @Html.ActionLink(T("Add one now").Text, "Create", new { Area = "Contents", Id = "Taxonomy", ReturnUrl = Request.RawUrl }, new { @class = "" })
+                @Html.ActionLink(T("Add one now").Text, "Create", new { Area = "Contents", Id = "Taxonomy", ReturnUrl = Request.RawUrl }, new { @class = "" })<text>.</text>
             </h3>
         </div>
     }


### PR DESCRIPTION
[Fixes #7193] Orchard.Taxonomies - Empty taxonomies view needs full stop