### PR TITLE
[Fixes #7202] Orchard.MediaLibrary - Wrong css causes txt wrap to fail

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Styles/orchard-medialibrary-admin.css
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Styles/orchard-medialibrary-admin.css
@@ -345,7 +345,7 @@
         -ms-text-overflow: ellipsis;
         -o-text-overflow: ellipsis;
         text-overflow: ellipsis;
-        text-wrap: none;
+        white-space: nowrap;
     }
 
     .media-library-main-list-overlay .publication-status {

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Admin/Index.cshtml
@@ -42,7 +42,7 @@
                         <div class="thumbnail" data-bind="html: data.thumbnail">
                         </div>
                         <div class="media-library-main-list-overlay">
-                            <p class="title" data-bind="text: data.title"></p>
+                            <p class="title" data-bind="text: data.title, attr: { title: data.title }"></p>
                             <p class="publication-status" data-bind="text: publicationStatus"></p>
                         </div>
                     </li>


### PR DESCRIPTION
[Fixes #7202] Orchard.MediaLibrary - Wrong css causes txt wrap to fail