### PR TITLE
[Fixes #7318] Orchard.DesignerTools - Setting Id not needed anymore

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.DesignerTools/Handlers/ShapeTracingSiteSettingsPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.DesignerTools/Handlers/ShapeTracingSiteSettingsPartHandler.cs
@@ -28,7 +28,6 @@ namespace Orchard.DesignerTools.Handlers {
             base.GetItemMetadata(context);
 
             var groupInfo = new GroupInfo(T("Shape Tracing"));
-            groupInfo.Id = "ShapeTracing";
 
             context.Metadata.EditorGroupInfo.Add(groupInfo);
         }


### PR DESCRIPTION
[Fixes #7318] Orchard.DesignerTools - Setting Id not needed anymore