### PR TITLE
[Fixes #7258] Orchard.Core - Tabbed groupby breaks priority

### DIFF
--- a/src/Orchard.Web/Core/Shapes/CoreShapes.cs
+++ b/src/Orchard.Web/Core/Shapes/CoreShapes.cs
@@ -283,7 +283,7 @@ namespace Orchard.Core.Shapes {
         [Shape]
         public void ContentZone(dynamic Display, dynamic Shape, TextWriter Output) {
             var unordered = ((IEnumerable<dynamic>)Shape).ToArray();
-            var tabbed = unordered.GroupBy(x => (string)x.Metadata.Tab);
+            var tabbed = unordered.GroupBy(x => (string)x.Metadata.Tab ?? "");
 
             if (tabbed.Count() > 1) {
                 foreach (var tab in tabbed) {


### PR DESCRIPTION
Fixes #7258 - I just realised I targeted the wrong branch, it was triaged to 1.10.x so just putting it into the correct place.