### PR TITLE
Fix for Jobs queue service throwing exception

### DIFF
--- a/src/Orchard/Events/EventsInterceptor.cs
+++ b/src/Orchard/Events/EventsInterceptor.cs
@@ -39,19 +39,22 @@ namespace Orchard.Events {
             // static IEnumerable<T> IEnumerable.OfType<T>(this IEnumerable source)
             // where T is from returnType's IEnumerable<T>
             var enumerableOfTypeT = _enumerableOfTypeTDictionary.GetOrAdd( returnType, type => typeof(Enumerable).GetGenericMethod("OfType", type.GetGenericArguments(), new[] { typeof(IEnumerable) }, typeof(IEnumerable<>)));
-            return enumerableOfTypeT.Invoke(null, new[] { results });
+            return (enumerableOfTypeT != null) ? enumerableOfTypeT.Invoke(null, new[] { results }) : null;
         }
     }
 
     public static class Extensions {
         public static MethodInfo GetGenericMethod(this Type t, string name, Type[] genericArgTypes, Type[] argTypes, Type returnType) {
-            return (from m in t.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                    where m.Name == name &&
-                    m.GetGenericArguments().Length == genericArgTypes.Length &&
-                    m.GetParameters().Select(pi => pi.ParameterType).SequenceEqual(argTypes) &&
-                    (m.ReturnType.IsGenericType && !m.ReturnType.IsGenericTypeDefinition ? returnType.GetGenericTypeDefinition() : m.ReturnType) == returnType
-                    select m).Single().MakeGenericMethod(genericArgTypes);
-
+            var method = (from m in t.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                          where m.Name == name &&
+                          m.GetGenericArguments().Length == genericArgTypes.Length &&
+                          m.GetParameters().Select(pi => pi.ParameterType).SequenceEqual(argTypes) &&
+                          (m.ReturnType.IsGenericType && !m.ReturnType.IsGenericTypeDefinition ? returnType.GetGenericTypeDefinition() : m.ReturnType) == returnType
+                          select m).SingleOrDefault();
+            if (method != null) {
+                return method.MakeGenericMethod(genericArgTypes);
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
EventsInterceptor fails when it tries to locate a generic method on an implementation with a return type. A null check has been added to avoid the exception.

Related issues: #4718, #4584 

Thanks @sebastienros, @sfmskywalker and @CSurieux for the fix.