### PR TITLE
Order contained content items in ascending order

### DIFF
--- a/src/Orchard.Web/Core/Containers/Drivers/ContainerPartDriver.cs
+++ b/src/Orchard.Web/Core/Containers/Drivers/ContainerPartDriver.cs
@@ -53,7 +53,7 @@ namespace Orchard.Core.Containers.Drivers {
                 var query = _contentManager
                 .Query(VersionOptions.Published)
                 .Join<CommonPartRecord>().Where(x => x.Container.Id == container.Id)
-                .Join<ContainablePartRecord>().OrderByDescending(x => x.Position);
+                .Join<ContainablePartRecord>().OrderBy(x => x.Position);
 
                 var metadata = container.ContentManager.GetItemMetadata(container);
                 if (metadata != null) {


### PR DESCRIPTION
As widgets and all other elements are ordered by position in ascending order. Why the contained items are ordered in descending order?