### PR TITLE
RemovePublishLaterTaskIfNewerVersionIsPublished

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.PublishLater/Handlers/PublishLaterPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.PublishLater/Handlers/PublishLaterPartHandler.cs
@@ -15,6 +15,17 @@ namespace Orchard.PublishLater.Handlers {
             OnLoading<PublishLaterPart>((context, part) => LazyLoadHandlers(part));
             OnVersioning<PublishLaterPart>((context, part, newVersionPart) => LazyLoadHandlers(newVersionPart));
             OnRemoved<PublishLaterPart>((context, part) => publishingTaskManager.DeleteTasks(part.ContentItem));
+            OnPublishing<PublishLaterPart>((context, part) =>
+            {
+                var existingPublishTask = publishingTaskManager.GetPublishTask(context.ContentItem);
+
+                //Check if there is already and existing publish task for old version.
+                if (existingPublishTask != null)
+                {
+                    //If exists remove it in order no to override the latest published version.
+                    publishingTaskManager.DeleteTasks(context.ContentItem);
+                }
+            });
         }
 
         protected void LazyLoadHandlers(PublishLaterPart part) {


### PR DESCRIPTION
Added a functionality that will check when a new version is published, if the previews version has a publish later option. If so it will remove it, in order not to override already newly published content.

Link to issue:
https://github.com/OrchardCMS/Orchard/issues/6840