### PR TITLE
Cloning feature with fallback for 1.10.x

### DIFF
--- a/src/Orchard.Web/Core/Common/Drivers/BodyPartDriver.cs
+++ b/src/Orchard.Web/Core/Common/Drivers/BodyPartDriver.cs
@@ -11,6 +11,7 @@ using Orchard.Core.Common.ViewModels;
 using Orchard.Services;
 using System.Web.Mvc;
 using System.Web.Routing;
+using Orchard.ContentManagement.Handlers;
 
 namespace Orchard.Core.Common.Drivers {
     public class BodyPartDriver : ContentPartDriver<BodyPart> {
@@ -73,6 +74,10 @@ namespace Orchard.Core.Common.Drivers {
 
         protected override void Exporting(BodyPart part, ContentManagement.Handlers.ExportContentContext context) {
             context.Element(part.PartDefinition.Name).SetAttributeValue("Text", part.Text);
+        }
+
+        protected override void Cloning(BodyPart originalPart, BodyPart clonePart, CloneContentContext context) {
+            clonePart.Text = originalPart.Text;
         }
 
         private static BodyEditorViewModel BuildEditorViewModel(BodyPart part,RequestContext requestContext) {

--- a/src/Orchard.Web/Core/Common/Drivers/CommonPartDriver.cs
+++ b/src/Orchard.Web/Core/Common/Drivers/CommonPartDriver.cs
@@ -123,5 +123,9 @@ namespace Orchard.Core.Common.Drivers {
                     .SetAttributeValue("ModifiedUtc", XmlConvert.ToString(part.ModifiedUtc.Value, XmlDateTimeSerializationMode.Utc));
             }
         }
+
+        protected override void Cloning(CommonPart originalPart, CommonPart clonePart, CloneContentContext context) {
+            clonePart.Container = originalPart.Container;
+        }
     }
 }

--- a/src/Orchard.Web/Core/Common/Drivers/TextFieldDriver.cs
+++ b/src/Orchard.Web/Core/Common/Drivers/TextFieldDriver.cs
@@ -88,6 +88,10 @@ namespace Orchard.Core.Common.Drivers {
                 context.Element(field.FieldDefinition.Name + "." + field.Name).SetAttributeValue("Text", field.Value);
         }
 
+        protected override void Cloning(ContentPart part, TextField originalField, TextField cloneField, CloneContentContext context) {
+            cloneField.Value = originalField.Value;
+        }
+
         protected override void Describe(DescribeMembersContext context) {
             context
                 .Member(null, typeof(string), T("Value"), T("The text associated with the field."))

--- a/src/Orchard.Web/Core/Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Core/Contents/Controllers/AdminController.cs
@@ -110,11 +110,11 @@ namespace Orchard.Core.Contents.Controllers {
                     break;
             }
 
-            if(!String.IsNullOrWhiteSpace(model.Options.SelectedCulture)) {
+            if (!String.IsNullOrWhiteSpace(model.Options.SelectedCulture)) {
                 query = _cultureFilter.FilterCulture(query, model.Options.SelectedCulture);
             }
 
-            if(model.Options.ContentsStatus == ContentsStatus.Owner) {
+            if (model.Options.ContentsStatus == ContentsStatus.Owner) {
                 query = query.Where<CommonPartRecord>(cr => cr.OwnerId == Services.WorkContext.CurrentUser.Id);
             }
 
@@ -388,25 +388,27 @@ namespace Orchard.Core.Contents.Controllers {
 
         [HttpPost]
         public ActionResult Clone(int id, string returnUrl) {
-            var contentItem = _contentManager.GetLatest(id);
+            var originalContentItem = _contentManager.GetLatest(id);
 
-            if (contentItem == null)
-                return HttpNotFound();
-
-            if (!Services.Authorizer.Authorize(Permissions.EditContent, contentItem, T("Couldn't clone content")))
+            if (!Services.Authorizer.Authorize(Permissions.ViewContent, originalContentItem, T("Couldn't open original content")))
                 return new HttpUnauthorizedResult();
 
-            try {
-                Services.ContentManager.Clone(contentItem);
-            }
-            catch (InvalidOperationException) {
-                Services.Notifier.Warning(T("Could not clone the content item."));
-                return this.RedirectLocal(returnUrl, () => RedirectToAction("List"));
-            }
+            // pass a dummy content to the authorization check to check for "own" variations
+            var dummyContent = _contentManager.New(originalContentItem.ContentType);
+
+            if (!Services.Authorizer.Authorize(Permissions.EditContent, dummyContent, T("Couldn't create clone content")))
+                return new HttpUnauthorizedResult();
+
+            var cloneContentItem = _contentManager.Clone(originalContentItem);
 
             Services.Notifier.Information(T("Successfully cloned. The clone was saved as a draft."));
-
-            return this.RedirectLocal(returnUrl, () => RedirectToAction("List"));
+            if (string.IsNullOrWhiteSpace(returnUrl)) {
+                var adminRouteValues = _contentManager.GetItemMetadata(cloneContentItem).AdminRouteValues;
+                return RedirectToRoute(adminRouteValues);
+            }
+            else {
+                return this.RedirectLocal(returnUrl, () => RedirectToAction("List"));
+            }
         }
 
         [HttpPost]

--- a/src/Orchard.Web/Core/Contents/Views/Parts.Contents.Clone.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Core/Contents/Views/Parts.Contents.Clone.SummaryAdmin.cshtml
@@ -1,10 +1,9 @@
 ﻿@using Orchard.ContentManagement
 @using Orchard.Core.Contents
-@using Orchard.Utility.Extensions
 @{
   ContentPart contentPart = Model.ContentPart;
 }
 @if (Authorizer.Authorize(Permissions.EditContent, contentPart)) {
-    <a href="@Url.Action("Clone", "Admin", new { Id = Model.ContentItem.Id, ReturnUrl = Request.ToUrlString(), Area = "Contents" })" itemprop="UnsafeUrl">@T("Clone")</a>
+    <a href="@Url.Action("Clone", "Admin", new { Id = Model.ContentItem.Id, Area = "Contents" })" itemprop="UnsafeUrl">@T("Clone")</a>
     @T(" | ")
 }

--- a/src/Orchard.Web/Core/Title/Drivers/TitlePartDriver.cs
+++ b/src/Orchard.Web/Core/Title/Drivers/TitlePartDriver.cs
@@ -52,5 +52,9 @@ namespace Orchard.Core.Title.Drivers {
         protected override void Exporting(TitlePart part, ExportContentContext context) {
             context.Element(part.PartDefinition.Name).SetAttributeValue("Title", part.Title);
         }
+
+        protected override void Cloning(TitlePart originalPart, TitlePart clonePart, CloneContentContext context) {
+            clonePart.Title = originalPart.Title;
+        }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Drivers/AutoroutePartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Drivers/AutoroutePartDriver.cs
@@ -177,5 +177,7 @@ namespace Orchard.Autoroute.Drivers {
             context.Element(part.PartDefinition.Name).SetAttributeValue("UseCulturePattern", part.Record.UseCulturePattern);
             context.Element(part.PartDefinition.Name).SetAttributeValue("PromoteToHomePage", part.PromoteToHomePage);
         }
+
+        protected override void Cloning(AutoroutePart originalPart, AutoroutePart clonePart, CloneContentContext context) { }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Comments/Drivers/CommentsPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Drivers/CommentsPartDriver.cs
@@ -5,6 +5,7 @@ using Orchard.Comments.Services;
 using Orchard.Comments.Settings;
 using Orchard.ContentManagement;
 using Orchard.ContentManagement.Drivers;
+using Orchard.ContentManagement.Handlers;
 using System.Collections.Generic;
 
 namespace Orchard.Comments.Drivers {
@@ -97,7 +98,7 @@ namespace Orchard.Comments.Drivers {
             return ContentShape("Parts_Comments_Enable",
                                 () => {
                                     // if the part is new, then apply threaded comments defaults
-                                    if(!part.ContentItem.HasDraft() && !part.ContentItem.HasPublished()) {
+                                    if (!part.ContentItem.HasDraft() && !part.ContentItem.HasPublished()) {
                                         var settings = part.TypePartDefinition.Settings.GetModel<CommentsPartSettings>();
                                         part.ThreadedComments = settings.DefaultThreadedComments;
                                     }
@@ -110,7 +111,7 @@ namespace Orchard.Comments.Drivers {
             return Editor(part, shapeHelper);
         }
 
-        protected override void Importing(CommentsPart part, ContentManagement.Handlers.ImportContentContext context) {
+        protected override void Importing(CommentsPart part, ImportContentContext context) {
             // Don't do anything if the tag is not specified.
             if (context.Data.Element(part.PartDefinition.Name) == null) {
                 return;
@@ -129,10 +130,16 @@ namespace Orchard.Comments.Drivers {
             );
         }
 
-        protected override void Exporting(CommentsPart part, ContentManagement.Handlers.ExportContentContext context) {
+        protected override void Exporting(CommentsPart part, ExportContentContext context) {
             context.Element(part.PartDefinition.Name).SetAttributeValue("CommentsShown", part.CommentsShown);
             context.Element(part.PartDefinition.Name).SetAttributeValue("CommentsActive", part.CommentsActive);
             context.Element(part.PartDefinition.Name).SetAttributeValue("ThreadedComments", part.ThreadedComments);
+        }
+
+        protected override void Cloning(CommentsPart originalPart, CommentsPart clonePart, CloneContentContext context) {
+            clonePart.CommentsShown = originalPart.CommentsShown;
+            clonePart.CommentsActive = originalPart.CommentsActive;
+            // ThreadedComments will be overrided with settings default
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldDriver.cs
@@ -7,6 +7,7 @@ using Orchard.ContentManagement.Handlers;
 using Orchard.ContentPicker.ViewModels;
 using Orchard.Localization;
 using Orchard.Utility.Extensions;
+using Orchard.ContentPicker.Fields;
 
 namespace Orchard.ContentPicker.Drivers {
     public class ContentPickerFieldDriver : ContentFieldDriver<Fields.ContentPickerField> {
@@ -96,6 +97,10 @@ namespace Orchard.ContentPicker.Drivers {
 
                 context.Element(field.FieldDefinition.Name + "." + field.Name).SetAttributeValue("ContentItems", string.Join(",", contentItemIds));
             }
+        }
+
+        protected override void Cloning(ContentPart part, ContentPickerField originalField, ContentPickerField cloneField, CloneContentContext context) {
+            cloneField.Ids = originalField.Ids;
         }
 
         protected override void Describe(DescribeMembersContext context) {

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldLocalizationDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldLocalizationDriver.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Drivers;
+using Orchard.ContentPicker.Fields;
+using Orchard.ContentPicker.ViewModels;
+using Orchard.Environment.Extensions;
+
+namespace Orchard.ContentPicker.Drivers {
+    [OrchardFeature("Orchard.ContentPicker.LocalizationExtensions")]
+    public class ContentPickerFieldLocalizationDriver : ContentFieldDriver<Fields.ContentPickerField> {
+        private readonly IContentManager _contentManager;
+
+        public ContentPickerFieldLocalizationDriver(IContentManager contentManager) {
+            _contentManager = contentManager;
+        }
+
+        private static string GetPrefix(Fields.ContentPickerField field, ContentPart part) {
+            return part.PartDefinition.Name + "." + field.Name;
+        }
+
+        private static string GetDifferentiator(Fields.ContentPickerField field, ContentPart part) {
+            return field.Name;
+        }
+
+        protected override DriverResult Editor(ContentPart part, Fields.ContentPickerField field, dynamic shapeHelper) {
+            return ContentShape("Fields_ContentPickerLocalization_Edit", GetDifferentiator(field, part),
+                () => {
+                    var model = new ContentPickerFieldViewModel {
+                        Field = field,
+                        Part = part,
+                        ContentItems = _contentManager.GetMany<ContentItem>(field.Ids, VersionOptions.Latest, QueryHints.Empty).ToList()
+                    };
+
+                    model.SelectedIds = string.Join(",", field.Ids);
+
+                    return shapeHelper.EditorTemplate(TemplateName: "Fields/ContentPickerLocalization.Edit", Model: model, Prefix: GetPrefix(field, part));
+                });
+        }
+
+        protected override DriverResult Editor(ContentPart part, ContentPickerField field, IUpdateModel updater, dynamic shapeHelper) {
+            return Editor(part, field, shapeHelper);
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Handlers/ContentPickerFieldLocalizationExtensionHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Handlers/ContentPickerFieldLocalizationExtensionHandler.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
+using Orchard.ContentPicker.Fields;
+using Orchard.ContentPicker.Settings;
+using Orchard.Environment.Extensions;
+using Orchard.Localization;
+using Orchard.Localization.Models;
+using Orchard.Localization.Services;
+using Orchard.UI.Notify;
+
+namespace Orchard.ContentPicker.Handlers {
+    [OrchardFeature("Orchard.ContentPicker.LocalizationExtensions")]
+    public class ContentPickerFieldLocalizationExtensionHandler : ContentHandler {
+        private readonly IOrchardServices _orchardServices;
+        private readonly IContentManager _contentManager;
+        private readonly ILocalizationService _localizationService;
+        public Localizer T { get; set; }
+
+        public ContentPickerFieldLocalizationExtensionHandler(
+            IOrchardServices orchardServices,
+            IContentManager contentManager,
+            ILocalizationService localizationService) {
+            _orchardServices = orchardServices;
+            _contentManager = contentManager;
+            _localizationService = localizationService;
+
+            T = NullLocalizer.Instance;
+        }
+
+        protected override void UpdateEditorShape(UpdateEditorContext context) {
+            base.UpdateEditorShape(context);
+            //Here we implement the logic based on the settings introduced in ContentPickerFieldLocalizationSettings
+            //These settings should only be active if the ContentItem that is being updated has a LocalizationPart
+            if (context.ContentItem.Parts.Any(part => part is LocalizationPart)) {
+                var lPart = (LocalizationPart)context.ContentItem.Parts.Single(part => part is LocalizationPart);
+                var fields = context.ContentItem.Parts.SelectMany(x => x.Fields.Where(f => f.FieldDefinition.Name == typeof(ContentPickerField).Name)).Cast<ContentPickerField>();
+
+                foreach (var field in fields) {
+                    var settings = field.PartFieldDefinition.Settings.GetModel<ContentPickerFieldLocalizationSettings>();
+                    if (settings.TryToLocalizeItems) {
+                        //try to replace items in the field with their translation
+                        var itemsInField = _contentManager.GetMany<ContentItem>(field.Ids, VersionOptions.Published, QueryHints.Empty);
+                        if (settings.RemoveItemsWithNoLocalizationPart && itemsInField.Where(ci => !ci.Parts.Any(part => part is LocalizationPart)).Any()) {
+                            //keep only items that have a LocalizationPart
+                            _orchardServices.Notifier.Warning(T(
+                                "{0}: The following items could have no localization, so they were removed: {1}",
+                                field.DisplayName,
+                                string.Join(", ", itemsInField.Where(ci => !ci.Parts.Any(part => part is LocalizationPart)).Select(ci => _contentManager.GetItemMetadata(ci).DisplayText))
+                                ));
+                            itemsInField = itemsInField.Where(ci => ci.Parts.Any(part => part is LocalizationPart));
+                        }
+                        //use an (int, int) tuple to track translations
+                        var newIds = itemsInField.Select(ci => {
+                            if (ci.Parts.Any(part => part is LocalizationPart)) {
+                                if (_localizationService.GetContentCulture(ci) == lPart.Culture.Culture)
+                                    return new Tuple<int, int>(ci.Id, ci.Id); //this item is fine
+                                var localized = _localizationService.GetLocalizations(ci).FirstOrDefault(lp => lp.Culture == lPart.Culture);
+                                return localized == null ? new Tuple<int, int>(ci.Id, -ci.Id) : new Tuple<int, int>(ci.Id, localized.Id); //return negative id where we found no translation
+                            }
+                            else {
+                                //we only go here if RemoveItemsWithNoLocalizationPart == false
+                                return new Tuple<int, int>(ci.Id, ci.Id);
+                            }
+                        });
+                        if (newIds.Any(tup => tup.Item2 < 0)) {
+                            if (settings.RemoveItemsWithoutLocalization) {
+                                //remove the items for which we could not find a localization
+                                _orchardServices.Notifier.Warning(T(
+                                    "{0}: We could not find a localization for the following items, so they were removed: {1}",
+                                    field.DisplayName,
+                                    string.Join(", ", newIds.Where(tup => tup.Item2 < 0).Select(tup => _contentManager.GetItemMetadata(_contentManager.GetLatest(tup.Item1)).DisplayText))
+                                    ));
+                                newIds = newIds.Where(tup => tup.Item2 > 0);
+                            }
+                            else {
+                                //negative Ids are made positive again
+                                newIds = newIds.Select(tup => tup = new Tuple<int, int>(tup.Item1, Math.Abs(tup.Item2)));
+                            }
+                        }
+                        if (newIds.Where(tup => tup.Item1 != tup.Item2).Any()) {
+                            _orchardServices.Notifier.Warning(T(
+                                "{0}: The following items were replaced by their correct localization: {1}",
+                                field.DisplayName,
+                                string.Join(", ", newIds.Where(tup => tup.Item1 != tup.Item2).Select(tup => _contentManager.GetItemMetadata(_contentManager.GetLatest(tup.Item1)).DisplayText))
+                                ));
+                        }
+
+                        field.Ids = newIds.Select(tup => tup.Item2).Distinct().ToArray();
+                    }
+                    if (settings.AssertItemsHaveSameCulture) {
+                        //verify that the items in the ContentPickerField are all in the culture of the ContentItem whose editor we are updating
+                        var itemsInField = _contentManager.GetMany<ContentItem>(field.Ids, VersionOptions.Published, QueryHints.Empty);
+                        var itemsWithoutLocalizationPart = itemsInField.Where(ci => !ci.Parts.Any(part => part is LocalizationPart));
+                        List<int> badItemIds = itemsInField.Where(ci => ci.Parts.Any(part => part is LocalizationPart && ((LocalizationPart)part).Culture != lPart.Culture)).Select(ci => ci.Id).ToList();
+                        if (itemsWithoutLocalizationPart.Count() > 0) {
+                            //Verify items from the ContentPickerField that cannot be localized
+                            _orchardServices.Notifier.Warning(T("{0}: Some of the selected items cannot be localized: {1}",
+                                field.DisplayName,
+                                string.Join(", ", itemsWithoutLocalizationPart.Select(ci => _contentManager.GetItemMetadata(ci).DisplayText))
+                                ));
+                            if (settings.BlockForItemsWithNoLocalizationPart) {
+                                badItemIds.AddRange(itemsWithoutLocalizationPart.Select(ci => ci.Id));
+                            }
+                        }
+                        if (badItemIds.Count > 0) {
+                            context.Updater.AddModelError(field.DisplayName, T("Some of the items selected have the wrong localization: {0}",
+                                string.Join(", ", badItemIds.Select(id => _contentManager.GetItemMetadata(_contentManager.GetLatest(id)).DisplayText))
+                                ));
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Module.txt
@@ -10,3 +10,8 @@ Features:
         Description: UI for selecting Content Items.
         Dependencies: Contents, Navigation
         Category: Input Editor
+	Orchard.ContentPicker.LocalizationExtensions:
+		Name: Orchard.ContentPicker.LocalizationExtensions
+		Description: Provides settings to enable advanced localization behaviours for ContentPickerFields.
+		Dependencies: Orchard.ContentPicker, Orchard.Localization, Orchard.Resources
+		Category: Input Editor

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
@@ -98,6 +98,10 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Drivers\ContentPickerFieldLocalizationDriver.cs" />
+    <Compile Include="Handlers\ContentPickerFieldLocalizationExtensionHandler.cs" />
+    <Compile Include="Settings\ContentPickerFieldLocalizationEditorEvents.cs" />
+    <Compile Include="Settings\ContentPickerFieldLocalizationSettings.cs" />
     <Compile Include="ViewModels\NavigationPartViewModel.cs" />
     <Content Include="Scripts\ContentPicker.js" />
     <Content Include="Scripts\SelectableContentTab.js" />
@@ -182,12 +186,22 @@
       <Name>Orchard.Core</Name>
       <Private>false</Private>
     </ProjectReference>
+    <ProjectReference Include="..\Orchard.Localization\Orchard.Localization.csproj">
+      <Project>{fbc8b571-ed50-49d8-8d9d-64ab7454a0d6}</Project>
+      <Name>Orchard.Localization</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\ContentPicker.Edit.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\DefinitionTemplates\ContentPickerFieldLocalizationSettings.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\EditorTemplates\Fields\ContentPickerLocalization.Edit.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Placement.info
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Placement.info
@@ -1,5 +1,6 @@
 ﻿<Placement>
   <Place Fields_ContentPicker_Edit="Content:2.3"/>
+  <Place Fields_ContentPickerLocalization_Edit="Content:2.3"/>
   <Place Parts_Navigation_Edit="Content:10"/>
   <Place Parts_ContentMenuItem_Edit="Content:10"/>
 

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Settings/ContentPickerFieldLocalizationEditorEvents.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Settings/ContentPickerFieldLocalizationEditorEvents.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.MetaData;
+using Orchard.ContentManagement.MetaData.Builders;
+using Orchard.ContentManagement.MetaData.Models;
+using Orchard.ContentManagement.ViewModels;
+using Orchard.Environment.Extensions;
+
+namespace Orchard.ContentPicker.Settings {
+    [OrchardFeature("Orchard.ContentPicker.LocalizationExtensions")]
+    public class ContentPickerFieldLocalizationEditorEvents : ContentDefinitionEditorEventsBase {
+
+        public override IEnumerable<TemplateViewModel> PartFieldEditor(ContentPartFieldDefinition definition) {
+            if (definition.FieldDefinition.Name == "ContentPickerField") {
+                var model = definition.Settings.GetModel<ContentPickerFieldLocalizationSettings>();
+                yield return DefinitionTemplate(model);
+            }
+        }
+
+        public override IEnumerable<TemplateViewModel> PartFieldEditorUpdate(ContentPartFieldDefinitionBuilder builder, IUpdateModel updateModel) {
+            if (builder.FieldType != "ContentPickerField") {
+                yield break;
+            }
+
+            var model = new ContentPickerFieldLocalizationSettings();
+            if (updateModel.TryUpdateModel(model, "ContentPickerFieldLocalizationSettings", null, null)) {
+                builder.WithSetting("ContentPickerFieldLocalizationSettings.TryToLocalizeItems", model.TryToLocalizeItems.ToString(CultureInfo.InvariantCulture));
+                builder.WithSetting("ContentPickerFieldLocalizationSettings.RemoveItemsWithoutLocalization", model.RemoveItemsWithoutLocalization.ToString(CultureInfo.InvariantCulture));
+                builder.WithSetting("ContentPickerFieldLocalizationSettings.RemoveItemsWithNoLocalizationPart", model.RemoveItemsWithNoLocalizationPart.ToString(CultureInfo.InvariantCulture));
+                builder.WithSetting("ContentPickerFieldLocalizationSettings.AssertItemsHaveSameCulture", model.AssertItemsHaveSameCulture.ToString(CultureInfo.InvariantCulture));
+                builder.WithSetting("ContentPickerFieldLocalizationSettings.BlockForItemsWithNoLocalizationPart", model.BlockForItemsWithNoLocalizationPart.ToString(CultureInfo.InvariantCulture));
+            }
+
+            yield return DefinitionTemplate(model);
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Settings/ContentPickerFieldLocalizationSettings.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Settings/ContentPickerFieldLocalizationSettings.cs
@@ -1,0 +1,16 @@
+﻿using Orchard.Environment.Extensions;
+
+namespace Orchard.ContentPicker.Settings {
+    [OrchardFeature("Orchard.ContentPicker.LocalizationExtensions")]
+    public class ContentPickerFieldLocalizationSettings {
+
+        public ContentPickerFieldLocalizationSettings() {
+            TryToLocalizeItems = true;
+        }
+        public bool TryToLocalizeItems { get; set; }
+        public bool RemoveItemsWithoutLocalization { get; set; }
+        public bool RemoveItemsWithNoLocalizationPart { get; set; }
+        public bool AssertItemsHaveSameCulture { get; set; }
+        public bool BlockForItemsWithNoLocalizationPart { get; set; }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/DefinitionTemplates/ContentPickerFieldLocalizationSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/DefinitionTemplates/ContentPickerFieldLocalizationSettings.cshtml
@@ -1,0 +1,24 @@
+﻿@model Orchard.ContentPicker.Settings.ContentPickerFieldLocalizationSettings
+
+<fieldset>
+    @Html.CheckBoxFor(m => m.TryToLocalizeItems)
+    <label for="@Html.FieldIdFor(m => m.TryToLocalizeItems)" class="forcheckbox">@T("Try to replace selected items with their correct localization.")</label>
+    <span class="hint">@T("Check to attempt to replace items selected in this field with their translation in the main ContentItem's culture. This only applies if the main ContentItem has a LocalizationPart.")</span>
+    <div data-controllerid="@Html.FieldIdFor(m => m.TryToLocalizeItems)">
+        @Html.CheckBoxFor(m => m.RemoveItemsWithoutLocalization)
+        <label for="@Html.FieldIdFor(m => m.RemoveItemsWithoutLocalization)" class="forcheckbox">@T("Remove items that do not have the correct translation.")</label>
+        <span class="hint">@T("Check to remove items from the ContentPickerField when the items selected do not have a version in the correct culture (they have a LocalizationPart, but not a translation in the main ContentItem's culture').")</span>
+        @Html.CheckBoxFor(m => m.RemoveItemsWithNoLocalizationPart)
+        <label for="@Html.FieldIdFor(m => m.RemoveItemsWithNoLocalizationPart)" class="forcheckbox">@T("Remove items that cannot be localized.")</label>
+        <span class="hint">@T("Check to remove items from the ContentPickerField when the items selected cannot be localized (do not have a LocalizationPart).")</span>
+    </div>
+
+    @Html.CheckBoxFor(m => m.AssertItemsHaveSameCulture)
+    <label for="@Html.FieldIdFor(m => m.AssertItemsHaveSameCulture)" class="forcheckbox">@T("Verify culture of selected items.")</label>
+    <span class="hint">@T("Check to prevent publication of contents when the items selected have a different culture. This only applies if the main ContentItem has a LocalizationPart.")</span>
+    <div data-controllerid="@Html.FieldIdFor(m => m.AssertItemsHaveSameCulture)">
+        @Html.CheckBoxFor(m => m.BlockForItemsWithNoLocalizationPart)
+        <label for="@Html.FieldIdFor(m => m.BlockForItemsWithNoLocalizationPart)" class="forcheckbox">@T("Do not admit items that cannot be localized.")</label>
+        <span class="hint">@T("Check to stop publication of contents when the items selected cannot be localized (do not have a LocalizationPart).")</span>
+    </div>
+</fieldset>

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/EditorTemplates/Fields/ContentPickerLocalization.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/EditorTemplates/Fields/ContentPickerLocalization.Edit.cshtml
@@ -1,0 +1,39 @@
+﻿@model Orchard.ContentPicker.ViewModels.ContentPickerFieldViewModel
+@using Orchard.ContentPicker.Settings;
+@using Orchard.Localization.Models;
+@using Orchard.ContentManagement;
+
+@{
+    Script.Require("jQuery").AtFoot();
+
+    var settings = Model.Field.PartFieldDefinition.Settings.GetModel<ContentPickerFieldLocalizationSettings>();
+
+    string tryTranslateMsg = T("Selected items with a localization different than the current one will be localized.").Text;
+    string removeMissingMsg = T("Selected items for which there is no correct localization will be removed.").Text;
+    string removeUnlocalizableMsg = T("Selected items that cannot have localizations will be removed.").Text;
+
+    if (settings.RemoveItemsWithoutLocalization) { tryTranslateMsg += " " + removeMissingMsg; }
+    if (settings.RemoveItemsWithNoLocalizationPart) { tryTranslateMsg += " " + removeUnlocalizableMsg; }
+
+    //We will use a script to find the fieldset for the field we are currently processing.
+    //The fieldset contains a span of class "hint". We will add tryTranslateMsg to it.
+    string dataPartName = HttpUtility.JavaScriptStringEncode(Model.Part.PartDefinition.Name);
+    string dataFieldName = HttpUtility.JavaScriptStringEncode(Model.Field.PartFieldDefinition.Name);
+}
+@using (Script.Foot()) {
+    <script type="text/javascript">
+        $(function () {
+            $("fieldset[data-part-name='@dataPartName'][data-field-name='@dataFieldName']").find("span.hint")[0].innerText += "@tryTranslateMsg";
+        });
+        @foreach (var contentItem in Model.ContentItems) {
+            var loc = contentItem.As<LocalizationPart>();
+            if (loc != null && loc.Culture!=null && !string.IsNullOrWhiteSpace(loc.Culture.Culture)) {
+                <text>
+        $(function () {
+            $("span[data-id='@contentItem.Id'][data-fieldid='@Html.FieldIdFor(m => m.Field.Ids)'].content-picker-item")[0].append(" (@loc.Culture.Culture)");
+        })
+        </text>
+            }
+        }
+    </script>
+}

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/RecentContentTab.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/RecentContentTab.cshtml
@@ -1,7 +1,7 @@
 ﻿@using Orchard.Core.Contents.ViewModels;
 @{
     Script.Require("SelectableContentTab");
-    
+
     var typeDisplayName = Model.TypeDisplayName;
     var pageTitle = T("Recent Content");
 
@@ -9,8 +9,10 @@
         pageTitle = T("Manage {0} Content", typeDisplayName);
     }
 
+    IEnumerable<string> cultures = Model.Options.Cultures;
+
     Layout.Title = pageTitle;
-    
+
 }
 
 <div class="manage">
@@ -25,6 +27,17 @@
                 @Html.SelectOption((string)Model.Options.SelectedFilter, (string)filterOption.Key, (string)filterOption.Value)
             }
         </select>
+
+        @if (cultures.Count() > 1) {
+            <label for="filterCultures" class="bulk-culture">@T("Culture")</label>
+            <select id="filterCultures" name="Options.SelectedCulture">
+                @Html.SelectOption((string)Model.Options.SelectedCulture, "", T("any (show all)").ToString())
+                @foreach (string culture in cultures) {
+                    @Html.SelectOption((string)Model.Options.SelectedCulture, culture, System.Globalization.CultureInfo.GetCultureInfo(culture).DisplayName)
+                }
+            </select>
+        }
+
         <label for="orderResults" class="bulk-order">@T("Ordered by")</label>
         <select id="orderResults" name="Options.OrderBy">
             @Html.SelectOption((ContentsOrder)Model.Options.OrderBy, ContentsOrder.Created, T("recently created").ToString())

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
@@ -66,6 +66,10 @@ namespace Orchard.Fields.Drivers {
 				context.Element(field.FieldDefinition.Name + "." + field.Name).SetAttributeValue("Value", field.Value);
         }
 
+        protected override void Cloning(ContentPart part, BooleanField originalField, BooleanField cloneField, CloneContentContext context) {
+            cloneField.Value = originalField.Value;
+        }
+
         protected override void Describe(DescribeMembersContext context) {
             context
                 .Member(null, typeof(Boolean), T("Value"), T("The boolean value of the field."))

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/DateTimeFieldDriver.cs
@@ -170,6 +170,10 @@ namespace Orchard.Fields.Drivers {
                 context.Element(GetPrefix(field, part)).SetAttributeValue("Value", XmlConvert.ToString(value, XmlDateTimeSerializationMode.Utc));
         }
 
+        protected override void Cloning(ContentPart part, DateTimeField originalField, DateTimeField cloneField, CloneContentContext context) {
+            cloneField.DateTime = originalField.DateTime;
+        }
+
         protected override void Describe(DescribeMembersContext context) {
             context
                 .Member(null, typeof(DateTime), T("Value"), T("The date and time value of the field."))

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
@@ -67,6 +67,10 @@ namespace Orchard.Fields.Drivers {
                 context.Element(field.FieldDefinition.Name + "." + field.Name).SetAttributeValue("Value", field.Value);
         }
 
+        protected override void Cloning(ContentPart part, EnumerationField originalField, EnumerationField cloneField, CloneContentContext context) {
+            cloneField.Value = originalField.Value;
+        }
+
         protected override void Describe(DescribeMembersContext context) {
             context
                 .Member(null, typeof(string), T("Value"), T("The selected values of the field."))

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/InputFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/InputFieldDriver.cs
@@ -65,6 +65,10 @@ namespace Orchard.Fields.Drivers {
                 context.Element(field.FieldDefinition.Name + "." + field.Name).SetAttributeValue("Value", field.Value);
         }
 
+        protected override void Cloning(ContentPart part, InputField originalField, InputField cloneField, CloneContentContext context) {
+            cloneField.Value = originalField.Value;
+        }
+
         protected override void Describe(DescribeMembersContext context) {
             context
                 .Member(null, typeof(string), T("Value"), T("The value of the field."))

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/LinkFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/LinkFieldDriver.cs
@@ -78,6 +78,12 @@ namespace Orchard.Fields.Drivers {
             }
         }
 
+        protected override void Cloning(ContentPart part, LinkField originalField, LinkField cloneField, CloneContentContext context) {
+            cloneField.Text = originalField.Text;
+            cloneField.Value = originalField.Value;
+            cloneField.Target = originalField.Target;
+        }
+
         protected override void Describe(DescribeMembersContext context) {
             context
                 .Member("Text", typeof(string), T("Text"), T("The text of the link."))

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
@@ -110,6 +110,10 @@ namespace Orchard.Fields.Drivers {
                 context.Element(field.FieldDefinition.Name + "." + field.Name).SetAttributeValue("Value", field.Value.Value.ToString(CultureInfo.InvariantCulture));
         }
 
+        protected override void Cloning(ContentPart part, NumericField originalField, NumericField cloneField, CloneContentContext context) {
+            cloneField.Value = originalField.Value;
+        }
+
         protected override void Describe(DescribeMembersContext context) {
             context
                 .Member(null, typeof(decimal), T("Value"), T("The value of the field."))

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Drivers/LayoutPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Drivers/LayoutPartDriver.cs
@@ -151,15 +151,13 @@ namespace Orchard.Layouts.Drivers {
 
         protected override void Exported(LayoutPart part, ExportContentContext context) {
             _layoutManager.Exported(new ExportLayoutContext { Layout = part });
-
-            context.Element(part.PartDefinition.Name).SetElementValue("LayoutData", part.LayoutData);
         }
 
         protected override void Importing(LayoutPart part, ImportContentContext context) {
             HandleImportEvent(part, context, importLayoutContext => {
                 context.ImportChildEl(part.PartDefinition.Name, "LayoutData", s => {
                     part.LayoutData = s;
-                    _layoutManager.Importing(importLayoutContext);
+                _layoutManager.Importing(importLayoutContext);
                 });
 
                 context.ImportAttribute(part.PartDefinition.Name, "TemplateId", s => part.TemplateId = GetTemplateId(context, s));
@@ -192,6 +190,12 @@ namespace Orchard.Layouts.Drivers {
 
             var template = context.GetItemFromSession(templateIdentity);
             return template != null ? template.Id : default(int?);
+        }
+
+
+        protected override void Cloning(LayoutPart originalPart, LayoutPart clonePart, CloneContentContext context) {
+            clonePart.LayoutData = originalPart.LayoutData;
+            clonePart.TemplateId = originalPart.TemplateId;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
@@ -54,7 +54,7 @@ namespace Orchard.Localization.Controllers {
             contentItemTranslation.MasterContentItem = masterContentItem;
 
             var content = _contentManager.BuildEditor(contentItemTranslation);
-            
+
             return View(content);
         }
 
@@ -89,14 +89,14 @@ namespace Orchard.Localization.Controllers {
             if (existingTranslation != null) {
                 var existingTranslationMetadata = _contentManager.GetItemMetadata(existingTranslation);
                 return RedirectToAction(
-                    Convert.ToString(existingTranslationMetadata.EditorRouteValues["action"]), 
+                    Convert.ToString(existingTranslationMetadata.EditorRouteValues["action"]),
                     existingTranslationMetadata.EditorRouteValues);
             }
 
             var contentItemTranslation = _contentManager
                 .Create<LocalizationPart>(masterContentItem.ContentType, VersionOptions.Draft, part => {
                     part.MasterContentItem = masterContentItem;
-            });
+                });
 
             var content = _contentManager.UpdateEditor(contentItemTranslation, this);
 

--- a/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Orchard.ContentManagement;
 using Orchard.ContentManagement.Drivers;
+using Orchard.ContentManagement.Handlers;
 using Orchard.Localization.Models;
 using Orchard.Localization.Services;
 using Orchard.Localization.ViewModels;
@@ -107,7 +108,7 @@ namespace Orchard.Localization.Drivers {
                 }).ToList();
         }
 
-        protected override void Importing(LocalizationPart part, ContentManagement.Handlers.ImportContentContext context) {
+        protected override void Importing(LocalizationPart part, ImportContentContext context) {
             // Don't do anything if the tag is not specified.
             if (context.Data.Element(part.PartDefinition.Name) == null) {
                 return;
@@ -131,7 +132,7 @@ namespace Orchard.Localization.Drivers {
             });
         }
 
-        protected override void Exporting(LocalizationPart part, ContentManagement.Handlers.ExportContentContext context) {
+        protected override void Exporting(LocalizationPart part, ExportContentContext context) {
             if (part.MasterContentItem != null) {
                 var masterContentItemIdentity = _contentManager.GetItemMetadata(part.MasterContentItem).Identity;
                 context.Element(part.PartDefinition.Name).SetAttributeValue("MasterContentItem", masterContentItemIdentity.ToString());
@@ -140,6 +141,11 @@ namespace Orchard.Localization.Drivers {
             if (part.Culture != null) {
                 context.Element(part.PartDefinition.Name).SetAttributeValue("Culture", part.Culture.Culture);
             }
+        }
+
+        protected override void Cloning(LocalizationPart originalPart, LocalizationPart clonePart, CloneContentContext context) { }
+        protected override void Cloned(LocalizationPart originalPart, LocalizationPart clonePart, CloneContentContext context) {
+            clonePart.Culture = originalPart.Culture;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Handlers/LocalizationPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Handlers/LocalizationPartHandler.cs
@@ -31,7 +31,7 @@ namespace Orchard.Localization.Handlers {
 
         protected static void PropertySetHandlers(ActivatedContentContext context, LocalizationPart localizationPart) {
             localizationPart.CultureField.Setter(cultureRecord => {
-                localizationPart.Record.CultureId = cultureRecord.Id;
+                localizationPart.Record.CultureId = cultureRecord != null ? cultureRecord.Id : 0;
                 return cultureRecord;
             });
             

--- a/src/Orchard.Web/Modules/Orchard.Localization/Orchard.Localization.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Orchard.Localization.csproj
@@ -136,9 +136,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Views\Admin\Translate.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Views\EditorTemplates\Parts\Localization.ContentTranslations.Edit.cshtml" />
   </ItemGroup>
   <ItemGroup>
@@ -197,6 +194,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Admin\Translate.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Orchard.Web/Modules/Orchard.Localization/Views/Admin/Translate.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Views/Admin/Translate.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     Layout.Title = T("Translate Content").ToString();
 }
 

--- a/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
@@ -53,7 +53,7 @@
                 if (Model.MissingCultures.Any()) {
                     var contentItemId = Model.MasterContentItem != null ? Model.MasterContentItem.Id : Model.ContentItem.Id;
 
-                    <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new {area = "Orchard.Localization", id = contentItemId}, null)</div>
+                    <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new { area = "Orchard.Localization", id = contentItemId }, null)</div>
                 }
 
                 @Html.Hidden(Html.FieldNameFor(m => m.SelectedCulture), Model.SelectedCulture)

--- a/src/Orchard.Web/Modules/Orchard.Localization/Views/Parts/Localization.ContentTranslations.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Views/Parts/Localization.ContentTranslations.SummaryAdmin.cshtml
@@ -16,7 +16,7 @@ var localizationLinks = Html.UnorderedList(localizations, (c, i) => Html.ItemEdi
     }
     @if (Model.Culture != null && !((IEnumerable<string>)Model.SiteCultures).All(c => c == Model.Culture || localizations.Any(l => c == l.Culture.Culture)))
     {
-    <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new { area = "Orchard.Localization", id = Model.Id }, null)</div>
+    <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new { area = "Orchard.Localization", id = Model.Id }, new { itemprop = "UnsafeUrl" })</div>
     }
 </div>
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
@@ -7,6 +7,7 @@ using Orchard.ContentManagement.Handlers;
 using Orchard.MediaLibrary.ViewModels;
 using Orchard.Localization;
 using Orchard.Utility.Extensions;
+using Orchard.MediaLibrary.Fields;
 
 namespace Orchard.MediaLibrary.Drivers {
     public class MediaLibraryPickerFieldDriver : ContentFieldDriver<Fields.MediaLibraryPickerField> {
@@ -93,6 +94,10 @@ namespace Orchard.MediaLibrary.Drivers {
 
                 context.Element(field.FieldDefinition.Name + "." + field.Name).SetAttributeValue("ContentItems", string.Join(",", contentItemIds));
             }
+        }
+
+        protected override void Cloning(ContentPart part, MediaLibraryPickerField originalField, MediaLibraryPickerField cloneField, CloneContentContext context) {
+            cloneField.Ids = originalField.Ids;
         }
 
         protected override void Describe(DescribeMembersContext context) {

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultTagCache.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultTagCache.cs
@@ -2,19 +2,27 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using Orchard.OutputCache.Models;
 using Orchard.Utility.Extensions;
+using Orchard.Environment.Configuration;
+using System.Web.Caching;
 
 namespace Orchard.OutputCache.Services {
     /// <summary>
     /// Tenant wide case insensitive reverse index for <see cref="CacheItem"/> tags.
     /// </summary>
     public class DefaultTagCache : ITagCache {
-
         private readonly ConcurrentDictionary<string, HashSet<string>> _dictionary;
 
-        public DefaultTagCache() {
-            _dictionary = new ConcurrentDictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        public DefaultTagCache(IWorkContextAccessor workContextAccessor, ShellSettings shellSettings) {
+            var key = shellSettings.Name + ":TagCache";
+            var workContext = workContextAccessor.GetContext();
+
+            _dictionary = workContext.HttpContext.Cache.Get(key) as ConcurrentDictionary<string, HashSet<string>>;
+
+            if (_dictionary == null) {
+                _dictionary = new ConcurrentDictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+                workContext.HttpContext.Cache.Add(key, _dictionary, null, Cache.NoAbsoluteExpiration, Cache.NoSlidingExpiration, CacheItemPriority.Normal, null);
+            }
         }
 
         public void Tag(string tag, params string[] keys) {
@@ -26,7 +34,7 @@ namespace Orchard.OutputCache.Services {
                 }
             }
         }
-        
+
         public IEnumerable<string> GetTaggedItems(string tag) {
             HashSet<string> set;
             if (_dictionary.TryGetValue(tag, out set)) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/Drivers/ProjectionPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Drivers/ProjectionPartDriver.cs
@@ -341,6 +341,17 @@ namespace Orchard.Projections.Drivers {
             }
         }
 
+        protected override void Cloning(ProjectionPart originalPart, ProjectionPart clonePart, CloneContentContext context) {
+            clonePart.Record.Items = originalPart.Record.Items;
+            clonePart.Record.ItemsPerPage = originalPart.Record.ItemsPerPage;
+            clonePart.Record.Skip = originalPart.Record.Skip;
+            clonePart.Record.PagerSuffix = originalPart.Record.PagerSuffix;
+            clonePart.Record.MaxItems = originalPart.Record.MaxItems;
+            clonePart.Record.DisplayPager = originalPart.Record.DisplayPager;
+            clonePart.Record.QueryPartRecord = originalPart.Record.QueryPartRecord;
+            clonePart.Record.LayoutRecord = originalPart.Record.LayoutRecord;
+        }
+
         private class ViewDataContainer : IViewDataContainer {
             public ViewDataDictionary ViewData { get; set; }
         }

--- a/src/Orchard.Web/Modules/Orchard.PublishLater/Handlers/PublishLaterPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.PublishLater/Handlers/PublishLaterPartHandler.cs
@@ -15,6 +15,17 @@ namespace Orchard.PublishLater.Handlers {
             OnLoading<PublishLaterPart>((context, part) => LazyLoadHandlers(part));
             OnVersioning<PublishLaterPart>((context, part, newVersionPart) => LazyLoadHandlers(newVersionPart));
             OnRemoved<PublishLaterPart>((context, part) => publishingTaskManager.DeleteTasks(part.ContentItem));
+            OnPublishing<PublishLaterPart>((context, part) =>
+            {
+                var existingPublishTask = publishingTaskManager.GetPublishTask(context.ContentItem);
+
+                //Check if there is already and existing publish task for old version.
+                if (existingPublishTask != null)
+                {
+                    //If exists remove it in order no to override the latest published version.
+                    publishingTaskManager.DeleteTasks(context.ContentItem);
+                }
+            });
         }
 
         protected void LazyLoadHandlers(PublishLaterPart part) {

--- a/src/Orchard.Web/Modules/Orchard.Tags/Drivers/TagsPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Tags/Drivers/TagsPartDriver.cs
@@ -89,5 +89,9 @@ namespace Orchard.Tags.Drivers {
         protected override void Exporting(TagsPart part, ExportContentContext context) {
             context.Element(part.PartDefinition.Name).SetAttributeValue("Tags", String.Join(",", part.CurrentTags));
         }
+
+        protected override void Cloning(TagsPart originalPart, TagsPart clonePart, CloneContentContext context) {
+            clonePart.CurrentTags = originalPart.CurrentTags;
+        }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
@@ -42,11 +42,13 @@ namespace Orchard.Taxonomies.Controllers {
 
             var taxonomy = _taxonomyService.GetTaxonomy(taxonomyId);
 
-            var terms = TermPart.Sort(_taxonomyService.GetTermsQuery(taxonomyId).Slice(pager.GetStartIndex(), pager.PageSize));
+            var allTerms = TermPart.Sort(_taxonomyService.GetTermsQuery(taxonomyId).List());
 
-            var pagerShape = Shape.Pager(pager).TotalItemCount(_taxonomyService.GetTermsQuery(taxonomyId).Count());
+            var termsPage = pager.PageSize > 0 ? allTerms.Skip(pager.GetStartIndex()).Take(pager.PageSize) : allTerms;
 
-            var entries = terms
+            var pagerShape = Shape.Pager(pager).TotalItemCount(allTerms.Count());
+
+            var entries = termsPage
                     .Select(term => term.CreateTermEntry())
                     .ToList();
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TaxonomyFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TaxonomyFieldDriver.cs
@@ -141,6 +141,10 @@ namespace Orchard.Taxonomies.Drivers {
             _taxonomyService.UpdateTerms(part.ContentItem, terms.Select(x => x.As<TermPart>()), field.Name);
         }
 
+        protected override void Cloning(ContentPart part, TaxonomyField originalField, TaxonomyField cloneField, CloneContentContext context) {
+            _taxonomyService.UpdateTerms(context.CloneContentItem, originalField.Terms, cloneField.Name);
+        }
+
         private TermPart GetOrCreateTerm(TermEntry entry, int taxonomyId, TaxonomyField field) {
             var term = default(TermPart);
 

--- a/src/Orchard.Web/Modules/Orchard.Tokens/Providers/RequestTokens.cs
+++ b/src/Orchard.Web/Modules/Orchard.Tokens/Providers/RequestTokens.cs
@@ -1,16 +1,21 @@
 ﻿using System;
+using System.Linq;
 using System.Web;
 using Orchard.ContentManagement;
 using Orchard.Localization;
+using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Orchard.Tokens.Providers {
     public class RequestTokens : ITokenProvider {
         private readonly IWorkContextAccessor _workContextAccessor;
         private readonly IContentManager _contentManager;
+        private static string[] _textChainableTokens;
 
         public RequestTokens(IWorkContextAccessor workContextAccessor, IContentManager contentManager) {
             _workContextAccessor = workContextAccessor;
             _contentManager = contentManager;
+            _textChainableTokens = new string[] { "QueryString", "Form" };
             T = NullLocalizer.Instance;
         }
 
@@ -18,8 +23,8 @@ namespace Orchard.Tokens.Providers {
 
         public void Describe(DescribeContext context) {
             context.For("Request", T("Http Request"), T("Current Http Request tokens."))
-                .Token("QueryString:*", T("QueryString:<element>"), T("The Query String value for the specified element."))
-                .Token("Form:*", T("Form:<element>"), T("The Form value for the specified element."))
+                .Token("QueryString:*", T("QueryString:<element>"), T("The Query String value for the specified element. To chain text, surround the <element> with parentheses, e.g. 'QueryString:(param1)'."))
+                .Token("Form:*", T("Form:<element>"), T("The Form value for the specified element. To chain text, surround the <element> with parentheses, e.g. 'Form:(param1)'."))
                 .Token("Route:*", T("Route:<key>"), T("The Route value for the specified key."))
                 .Token("Content", T("Content"), T("The request routed Content Item."), "Content")
             ;
@@ -29,20 +34,30 @@ namespace Orchard.Tokens.Providers {
             if (_workContextAccessor.GetContext().HttpContext == null) {
                 return;
             }
-
+            /* Supported Syntaxes for Request and Form tokens are:
+             * 1. QueryString:(param1) or Form:(param1) 
+             * 2. QueryString:param1 or Form:param1
+             * 3. QueryString:(param1).SomeOtherTextToken or Form:(param1).SomeOtherTextToken
+             * 
+             * If you want to Chain TextTokens you have to use the 3rd syntax
+             * the element, here param1, has been surrounded with parentheses in order to preserve backward compatibility.
+             */
             context.For("Request", _workContextAccessor.GetContext().HttpContext.Request)
                 .Token(
-                    token => token.StartsWith("QueryString:", StringComparison.OrdinalIgnoreCase) ? token.Substring("QueryString:".Length) : null,
-                    (token, request) => request.QueryString.Get(token)
+                    FilterTokenParam,
+                    (token, request) => {
+                        return request.QueryString.Get(token);
+                    }
                 )
                 .Token(
-                    token => token.StartsWith("Form:", StringComparison.OrdinalIgnoreCase) ? token.Substring("Form:".Length) : null,
+                    FilterTokenParam,
                     (token, request) => request.Form.Get(token)
                 )
                 .Token(
                     token => token.StartsWith("Route:", StringComparison.OrdinalIgnoreCase) ? token.Substring("Route:".Length) : null,
                     (token, request) => GetRouteValue(token, request)
                 )
+                .Chain(FilterChainParam, "Text", (token, request) => request.QueryString.Get(token))
                 .Token("Content",
                     (request) => DisplayText(GetRoutedContentItem(request))
                 )
@@ -98,5 +113,53 @@ namespace Orchard.Tokens.Providers {
 
             return _contentManager.GetItemMetadata(content).DisplayText;
         }
+
+        private static string FilterTokenParam(string token) {
+            string tokenPrefix;
+            int chainIndex, tokenLength;
+            if (token.IndexOf(":") == -1) {
+                return null;
+            }
+            tokenPrefix = token.Substring(0, token.IndexOf(":"));
+            if (!_textChainableTokens.Contains(tokenPrefix, StringComparer.OrdinalIgnoreCase)) {
+                return null;
+            }
+
+            // use ")." as chars combination to discover the end of the parameter
+            chainIndex = token.IndexOf(").") + 1;
+            tokenLength = (tokenPrefix + ":").Length;
+            if (chainIndex == 0) {// ")." has not be found
+                return token.Substring(tokenLength).Trim(new char[] { '(', ')' });
+            }
+            if (!token.StartsWith((tokenPrefix + ":"), StringComparison.OrdinalIgnoreCase) || chainIndex <= tokenLength) {
+                return null;
+            }
+            return token.Substring(tokenLength, chainIndex - tokenLength).Trim(new char[] { '(', ')' });
+        }
+        private static Tuple<string, string> FilterChainParam(string token) {
+            string tokenPrefix;
+            int chainIndex, tokenLength;
+
+            if (token.IndexOf(":") == -1) {
+                return null;
+            }
+            tokenPrefix = token.Substring(0, token.IndexOf(":"));
+            if (!_textChainableTokens.Contains(tokenPrefix, StringComparer.OrdinalIgnoreCase)) {
+                return null;
+            }
+
+            // use ")." as chars combination to discover the end of the parameter
+            chainIndex = token.IndexOf(").") + 1;
+            tokenLength = (tokenPrefix + ":").Length;
+            if (chainIndex == 0) { // ")." has not be found
+                return new Tuple<string, string>(token.Substring(tokenLength).Trim(new char[] { '(', ')' }), token.Length.ToString());
+            }
+            if (!token.StartsWith((tokenPrefix + ":"), StringComparison.OrdinalIgnoreCase) || chainIndex <= tokenLength) {
+                return null;
+            }
+            return new Tuple<string, string>(token.Substring(tokenLength, chainIndex - tokenLength).Trim(new char[] { '(', ')' }), token.Substring(chainIndex + 1));
+
+        }
     }
+
 }

--- a/src/Orchard/ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard/ContentManagement/DefaultContentManager.cs
@@ -565,26 +565,14 @@ namespace Orchard.ContentManagement {
         }
 
         public virtual ContentItem Clone(ContentItem contentItem) {
-            // Mostly taken from: http://orchard.codeplex.com/discussions/396664
-            var element = Export(contentItem);
+            var cloneContentItem = New(contentItem.ContentType);
+            Create(cloneContentItem, VersionOptions.Draft);
 
-            // If a handler prevents this element from being exported, it can't be cloned.
-            if (element == null) {
-                throw new InvalidOperationException("The content item couldn't be cloned because a handler prevented it from being exported.");
-            }
+            var context = new CloneContentContext(contentItem, cloneContentItem);
+            Handlers.Invoke(handler => handler.Cloning(context), Logger);
+            Handlers.Invoke(handler => handler.Cloned(context), Logger);
 
-            var elementId = element.Attribute("Id");
-            var copyId = elementId.Value + "-copy";
-            elementId.SetValue(copyId);
-            var status = element.Attribute("Status");
-            if (status != null) status.SetValue("Draft"); // So the copy is always a draft.
-
-            var importContentSession = new ImportContentSession(this);
-            importContentSession.Set(copyId, element.Name.LocalName);
-            Import(element, importContentSession);
-            CompleteImport(element, importContentSession);
-
-            return importContentSession.Get(copyId, element.Name.LocalName);
+            return cloneContentItem;
         }
 
         public virtual ContentItem Restore(ContentItem contentItem, VersionOptions options) {

--- a/src/Orchard/ContentManagement/Drivers/ContentFieldDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/ContentFieldDriver.cs
@@ -8,7 +8,7 @@ using Orchard.DisplayManagement.Shapes;
 using Orchard.Logging;
 
 namespace Orchard.ContentManagement.Drivers {
-    public abstract class ContentFieldDriver<TField> : IContentFieldDriver where TField : ContentField, new() {
+    public abstract class ContentFieldDriver<TField> : IContentFieldCloningDriver where TField : ContentField, new() {
         protected virtual string Prefix { get { return ""; } }
         protected virtual string Zone { get { return "Content"; } }
 
@@ -84,11 +84,11 @@ namespace Orchard.ContentManagement.Drivers {
             Process(context.ContentItem, (part, field) => Exported(part, field, context), context.Logger);
         }
 
-        void IContentFieldDriver.Cloning(CloneContentContext context) {
+        void IContentFieldCloningDriver.Cloning(CloneContentContext context) {
             ProcessClone(context.ContentItem, context.CloneContentItem, (part, originalField, cloneField) => Cloning(part, originalField, cloneField, context), context.Logger);
         }
 
-        void IContentFieldDriver.Cloned(CloneContentContext context) {
+        void IContentFieldCloningDriver.Cloned(CloneContentContext context) {
             ProcessClone(context.ContentItem, context.CloneContentItem, (part, originalField, cloneField) => Cloned(part, originalField, cloneField, context), context.Logger);
         }
 

--- a/src/Orchard/ContentManagement/Drivers/ContentFieldDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/ContentFieldDriver.cs
@@ -84,6 +84,14 @@ namespace Orchard.ContentManagement.Drivers {
             Process(context.ContentItem, (part, field) => Exported(part, field, context), context.Logger);
         }
 
+        void IContentFieldDriver.Cloning(CloneContentContext context) {
+            ProcessClone(context.ContentItem, context.CloneContentItem, (part, originalField, cloneField) => Cloning(part, originalField, cloneField, context), context.Logger);
+        }
+
+        void IContentFieldDriver.Cloned(CloneContentContext context) {
+            ProcessClone(context.ContentItem, context.CloneContentItem, (part, originalField, cloneField) => Cloned(part, originalField, cloneField, context), context.Logger);
+        }
+
         void IContentFieldDriver.Describe(DescribeMembersContext context) {
             Describe(context);
         }
@@ -91,6 +99,12 @@ namespace Orchard.ContentManagement.Drivers {
         void Process(ContentItem item, Action<ContentPart, TField> effort, ILogger logger) {
             var occurences = item.Parts.SelectMany(part => part.Fields.OfType<TField>().Select(field => new { part, field }));
             occurences.Invoke(pf => effort(pf.part, pf.field), logger);
+        }
+
+        void ProcessClone(ContentItem originalItem, ContentItem cloneItem, Action<ContentPart, TField, TField> effort, ILogger logger) {
+            var occurences = originalItem.Parts.SelectMany(part => part.Fields.OfType<TField>().Select(field => new { part, field }))
+                .Join(cloneItem.Parts.SelectMany(part => part.Fields.OfType<TField>()), original => original.field.Name, cloneField => cloneField.Name, (original, cloneField) => new { original, cloneField } );
+            occurences.Invoke(pf => effort(pf.original.part, pf.original.field, pf.cloneField), logger);
         }
 
         DriverResult Process(ContentItem item, Func<ContentPart, TField, DriverResult> effort, ILogger logger) {
@@ -126,7 +140,8 @@ namespace Orchard.ContentManagement.Drivers {
         protected virtual void ImportCompleted(ContentPart part, TField field, ImportContentContext context) { }
         protected virtual void Exporting(ContentPart part, TField field, ExportContentContext context) { }
         protected virtual void Exported(ContentPart part, TField field, ExportContentContext context) { }
-
+        protected virtual void Cloning(ContentPart part, TField originalField, TField cloneField, CloneContentContext context) { }
+        protected virtual void Cloned(ContentPart part, TField originalField, TField cloneField, CloneContentContext context) { }
         protected virtual void Describe(DescribeMembersContext context) { }
 
         public ContentShapeResult ContentShape(string shapeType, Func<dynamic> factory) {

--- a/src/Orchard/ContentManagement/Drivers/ContentPartDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/ContentPartDriver.cs
@@ -10,7 +10,7 @@ using Orchard.DisplayManagement.Shapes;
 using System.Linq;
 
 namespace Orchard.ContentManagement.Drivers {
-    public abstract class ContentPartDriver<TContent> : IContentPartDriver where TContent : ContentPart, new() {
+    public abstract class ContentPartDriver<TContent> : IContentPartCloningDriver where TContent : ContentPart, new() {
         protected virtual string Prefix { get { return typeof(TContent).Name; } }
 
         void IContentPartDriver.GetContentItemMetadata(GetContentItemMetadataContext context) {
@@ -106,14 +106,14 @@ namespace Orchard.ContentManagement.Drivers {
                 Exported(part, context);
         }
 
-        void IContentPartDriver.Cloning(CloneContentContext context) {
+        void IContentPartCloningDriver.Cloning(CloneContentContext context) {
             var originalPart = context.ContentItem.As<TContent>();
             var clonePart = context.CloneContentItem.As<TContent>();
             if (originalPart != null && clonePart != null)
                 Cloning(originalPart, clonePart, context);
         }
 
-        void IContentPartDriver.Cloned(CloneContentContext context) {
+        void IContentPartCloningDriver.Cloned(CloneContentContext context) {
             var originalPart = context.ContentItem.As<TContent>();
             var clonePart = context.CloneContentItem.As<TContent>();
             if (originalPart != null && clonePart != null)

--- a/src/Orchard/ContentManagement/Drivers/ContentPartDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/ContentPartDriver.cs
@@ -106,6 +106,20 @@ namespace Orchard.ContentManagement.Drivers {
                 Exported(part, context);
         }
 
+        void IContentPartDriver.Cloning(CloneContentContext context) {
+            var originalPart = context.ContentItem.As<TContent>();
+            var clonePart = context.CloneContentItem.As<TContent>();
+            if (originalPart != null && clonePart != null)
+                Cloning(originalPart, clonePart, context);
+        }
+
+        void IContentPartDriver.Cloned(CloneContentContext context) {
+            var originalPart = context.ContentItem.As<TContent>();
+            var clonePart = context.CloneContentItem.As<TContent>();
+            if (originalPart != null && clonePart != null)
+                Cloned(originalPart, clonePart, context);
+        }
+
         protected virtual void GetContentItemMetadata(TContent context, ContentItemMetadata metadata) { }
 
         protected virtual DriverResult Display(TContent part, string displayType, dynamic shapeHelper) { return null; }
@@ -174,6 +188,11 @@ namespace Orchard.ContentManagement.Drivers {
             return part.PartDefinition.Name + "-" + (versioned ? "VersionInfoset" : "Infoset");
         }
 
+        protected virtual void Cloning(TContent originalPart, TContent clonePart, CloneContentContext context) { }
+
+        protected virtual void Cloned(TContent originalPart, TContent clonePart, CloneContentContext context) { }
+
+
         [Obsolete("Provided while transitioning to factory variations")]
         public ContentShapeResult ContentShape(IShape shape) {
             return ContentShapeImplementation(shape.Metadata.Type, ctx => shape).Location("Content");
@@ -237,6 +256,5 @@ namespace Orchard.ContentManagement.Drivers {
 
             return contentPartInfo;
         }
-
     }
 }

--- a/src/Orchard/ContentManagement/Drivers/Coordinators/ContentFieldDriverCoordinator.cs
+++ b/src/Orchard/ContentManagement/Drivers/Coordinators/ContentFieldDriverCoordinator.cs
@@ -8,12 +8,12 @@ using Orchard.Logging;
 
 namespace Orchard.ContentManagement.Drivers.Coordinators {
     public class ContentFieldDriverCoordinator : ContentHandlerBase {
-        private readonly IEnumerable<IContentFieldDriver> _drivers;
+        private readonly IEnumerable<IContentFieldCloningDriver> _drivers;
         private readonly IFieldStorageProviderSelector _fieldStorageProviderSelector;
         private readonly IEnumerable<IFieldStorageEvents> _fieldStorageEvents;
 
         public ContentFieldDriverCoordinator(
-            IEnumerable<IContentFieldDriver> drivers,
+            IEnumerable<IContentFieldCloningDriver> drivers,
             IFieldStorageProviderSelector fieldStorageProviderSelector,
             IEnumerable<IFieldStorageEvents> fieldStorageEvents) {
             _drivers = drivers;

--- a/src/Orchard/ContentManagement/Drivers/Coordinators/ContentFieldDriverCoordinator.cs
+++ b/src/Orchard/ContentManagement/Drivers/Coordinators/ContentFieldDriverCoordinator.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Orchard.ContentManagement.FieldStorage;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Logging;
@@ -107,6 +109,64 @@ namespace Orchard.ContentManagement.Drivers.Coordinators {
             context.Logger = Logger;
             foreach (var contentFieldDriver in _drivers.OrderBy(x => x.GetFieldInfo().First().FieldTypeName)) {
                 contentFieldDriver.Exported(context);
+            }
+        }
+
+        public override void Cloning(CloneContentContext context) {
+            context.Logger = Logger;
+            var dGroups = _drivers.GroupBy(cfd => cfd.GetFieldInfo().FirstOrDefault().FieldTypeName);
+            foreach (var driverGroup in dGroups) {
+                //if no driver implements Cloning, run the fallback for the field
+                //otherwise, invoke Cloning for all these drivers.
+
+                //get baseType of driver (this is ContentFieldDriver<TField>)
+                Type baseDriverType = driverGroup.First().GetType().BaseType;
+
+                bool noCloningImplementation = true;
+                foreach (var contentFieldDriver in driverGroup) {
+                    //if we find an implementation of cloning, break
+                    if (contentFieldDriver.GetType().GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly).Where(mi => mi.Name == "Cloning").FirstOrDefault() != null) {
+                        noCloningImplementation = false;
+                        break;
+                    }
+                }
+                if (noCloningImplementation) {
+                    //fallback
+                    var ecc = new ExportContentContext(context.ContentItem, new System.Xml.Linq.XElement(System.Xml.XmlConvert.EncodeLocalName(context.ContentItem.ContentType)));
+                    ecc.Logger = Logger;
+                    foreach (var contentFieldDriver in driverGroup) {
+                        contentFieldDriver.Exporting(ecc);
+                    }
+                    foreach (var contentFieldDriver in driverGroup) {
+                        contentFieldDriver.Exported(ecc);
+                    }
+                    var importContentSession = new ImportContentSession(context.ContentManager);
+                    var copyId = context.CloneContentItem.Id.ToString();
+                    importContentSession.Set(copyId, ecc.Data.Name.LocalName);
+                    var icc = new ImportContentContext(context.CloneContentItem, ecc.Data, importContentSession);
+                    icc.Logger = Logger;
+                    foreach(var contentFieldDriver in driverGroup) {
+                        contentFieldDriver.Importing(icc);
+                    }
+                    foreach (var contentFieldDriver in driverGroup) {
+                        contentFieldDriver.Imported(icc);
+                    }
+                    foreach (var contentFieldDriver in driverGroup) {
+                        contentFieldDriver.ImportCompleted(icc);
+                    }
+                }
+                else {
+                    foreach (var contentFieldDriver in driverGroup) {
+                        contentFieldDriver.Cloning(context);
+                    }
+                }
+            }
+        }
+
+        public override void Cloned(CloneContentContext context) {
+            context.Logger = Logger;
+            foreach (var contentFieldDriver in _drivers) {
+                contentFieldDriver.Cloned(context);
             }
         }
     }

--- a/src/Orchard/ContentManagement/Drivers/Coordinators/ContentPartDriverCoordinator.cs
+++ b/src/Orchard/ContentManagement/Drivers/Coordinators/ContentPartDriverCoordinator.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Orchard.ContentManagement.Handlers;
 using Orchard.ContentManagement.MetaData;
 using Orchard.Logging;
@@ -31,8 +33,8 @@ namespace Orchard.ContentManagement.Drivers.Coordinators {
             foreach (var typePartDefinition in contentTypeDefinition.Parts) {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var partInfo = partInfos.FirstOrDefault(pi => pi.PartName == partName);
-                var part = partInfo != null 
-                    ? partInfo.Factory(typePartDefinition) 
+                var part = partInfo != null
+                    ? partInfo.Factory(typePartDefinition)
                     : new ContentPart { TypePartDefinition = typePartDefinition };
                 context.Builder.Weld(part);
             }
@@ -93,6 +95,60 @@ namespace Orchard.ContentManagement.Drivers.Coordinators {
         public override void Exported(ExportContentContext context) {
             foreach (var contentPartDriver in _drivers.OrderBy(x => x.GetPartInfo().First().PartName)) {
                 contentPartDriver.Exported(context);
+            }
+        }
+
+        public override void Cloning(CloneContentContext context) {
+            var dGroups = _drivers.GroupBy(cpd => cpd.GetPartInfo().FirstOrDefault().PartName);
+            foreach (var driverGroup in dGroups) {
+                //if no driver implements Cloning, run the fallback for the part
+                //otherwise, invoke Cloning for all these drivers.
+
+                //get baseType of driver (this is ContentPartDriver<TContent>)
+                Type baseDriverType = driverGroup.First().GetType().BaseType;
+
+                bool noCloningImplementation = true;
+                foreach (var contentPartDriver in driverGroup) {
+                    //if we find an implementation of cloning, break
+                    if (contentPartDriver.GetType().GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly).Where(mi => mi.Name == "Cloning").FirstOrDefault() != null) {
+                        noCloningImplementation = false;
+                        break;
+                    }
+                }
+                if (noCloningImplementation) {
+                    //fallback
+                    var ecc = new ExportContentContext(context.ContentItem, new System.Xml.Linq.XElement(System.Xml.XmlConvert.EncodeLocalName(context.ContentItem.ContentType)));
+                    foreach (var contentPartDriver in driverGroup) {
+                        contentPartDriver.Exporting(ecc);
+                    }
+                    foreach (var contentPartDriver in driverGroup) {
+                        contentPartDriver.Exported(ecc);
+                    }
+                    var importContentSession = new ImportContentSession(context.ContentManager);
+                    var copyId = context.CloneContentItem.Id.ToString();
+                    importContentSession.Set(copyId, ecc.Data.Name.LocalName);
+                    var icc = new ImportContentContext(context.CloneContentItem, ecc.Data, importContentSession);
+                    foreach (var contentPartDriver in driverGroup) {
+                        contentPartDriver.Importing(icc);
+                    }
+                    foreach (var contentPartDriver in driverGroup) {
+                        contentPartDriver.Imported(icc);
+                    }
+                    foreach (var contentPartDriver in driverGroup) {
+                        contentPartDriver.ImportCompleted(icc);
+                    }
+                }
+                else {
+                    foreach (var contentPartDriver in driverGroup) {
+                        contentPartDriver.Cloning(context);
+                    }
+                }
+            }
+        }
+
+        public override void Cloned(CloneContentContext context) {
+            foreach (var contentPartDriver in _drivers) {
+                contentPartDriver.Cloned(context);
             }
         }
     }

--- a/src/Orchard/ContentManagement/Drivers/Coordinators/ContentPartDriverCoordinator.cs
+++ b/src/Orchard/ContentManagement/Drivers/Coordinators/ContentPartDriverCoordinator.cs
@@ -12,10 +12,10 @@ namespace Orchard.ContentManagement.Drivers.Coordinators {
     /// It will dispatch BuildDisplay/BuildEditor to all <see cref="IContentPartDriver"/> implementations.
     /// </summary>
     public class ContentPartDriverCoordinator : ContentHandlerBase {
-        private readonly IEnumerable<IContentPartDriver> _drivers;
+        private readonly IEnumerable<IContentPartCloningDriver> _drivers;
         private readonly IContentDefinitionManager _contentDefinitionManager;
 
-        public ContentPartDriverCoordinator(IEnumerable<IContentPartDriver> drivers, IContentDefinitionManager contentDefinitionManager) {
+        public ContentPartDriverCoordinator(IEnumerable<IContentPartCloningDriver> drivers, IContentDefinitionManager contentDefinitionManager) {
             _drivers = drivers;
             _contentDefinitionManager = contentDefinitionManager;
             Logger = NullLogger.Instance;

--- a/src/Orchard/ContentManagement/Drivers/IContentFieldCloningDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/IContentFieldCloningDriver.cs
@@ -1,0 +1,8 @@
+﻿using Orchard.ContentManagement.Handlers;
+
+namespace Orchard.ContentManagement.Drivers {
+    public interface IContentFieldCloningDriver : IDependency, IContentFieldDriver {
+        void Cloning(CloneContentContext context);
+        void Cloned(CloneContentContext context);
+    }
+}

--- a/src/Orchard/ContentManagement/Drivers/IContentFieldDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/IContentFieldDriver.cs
@@ -12,6 +12,8 @@ namespace Orchard.ContentManagement.Drivers {
         void ImportCompleted(ImportContentContext context);
         void Exporting(ExportContentContext context);
         void Exported(ExportContentContext context);
+        void Cloning(CloneContentContext context);
+        void Cloned(CloneContentContext context);
         void Describe(DescribeMembersContext context);
         IEnumerable<ContentFieldInfo> GetFieldInfo();
         void GetContentItemMetadata(GetContentItemMetadataContext context);

--- a/src/Orchard/ContentManagement/Drivers/IContentFieldDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/IContentFieldDriver.cs
@@ -12,8 +12,6 @@ namespace Orchard.ContentManagement.Drivers {
         void ImportCompleted(ImportContentContext context);
         void Exporting(ExportContentContext context);
         void Exported(ExportContentContext context);
-        void Cloning(CloneContentContext context);
-        void Cloned(CloneContentContext context);
         void Describe(DescribeMembersContext context);
         IEnumerable<ContentFieldInfo> GetFieldInfo();
         void GetContentItemMetadata(GetContentItemMetadataContext context);

--- a/src/Orchard/ContentManagement/Drivers/IContentPartCloningDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/IContentPartCloningDriver.cs
@@ -1,0 +1,8 @@
+﻿using Orchard.ContentManagement.Handlers;
+
+namespace Orchard.ContentManagement.Drivers {
+    public interface IContentPartCloningDriver : IDependency, IContentPartDriver {
+        void Cloning(CloneContentContext context);
+        void Cloned(CloneContentContext context);
+    }
+}

--- a/src/Orchard/ContentManagement/Drivers/IContentPartDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/IContentPartDriver.cs
@@ -12,6 +12,8 @@ namespace Orchard.ContentManagement.Drivers {
         void ImportCompleted(ImportContentContext context);
         void Exporting(ExportContentContext context);
         void Exported(ExportContentContext context);
+        void Cloning(CloneContentContext context);
+        void Cloned(CloneContentContext context);
         IEnumerable<ContentPartInfo> GetPartInfo();
         void GetContentItemMetadata(GetContentItemMetadataContext context);
     }

--- a/src/Orchard/ContentManagement/Drivers/IContentPartDriver.cs
+++ b/src/Orchard/ContentManagement/Drivers/IContentPartDriver.cs
@@ -12,8 +12,6 @@ namespace Orchard.ContentManagement.Drivers {
         void ImportCompleted(ImportContentContext context);
         void Exporting(ExportContentContext context);
         void Exported(ExportContentContext context);
-        void Cloning(CloneContentContext context);
-        void Cloned(CloneContentContext context);
         IEnumerable<ContentPartInfo> GetPartInfo();
         void GetContentItemMetadata(GetContentItemMetadataContext context);
     }

--- a/src/Orchard/ContentManagement/Handlers/CloneContentContext.cs
+++ b/src/Orchard/ContentManagement/Handlers/CloneContentContext.cs
@@ -1,6 +1,9 @@
-namespace Orchard.ContentManagement.Handlers {
+﻿namespace Orchard.ContentManagement.Handlers {
     public class CloneContentContext : ContentContextBase {
-        public CloneContentContext(ContentItem contentItem) : base(contentItem) {
+        public ContentItem CloneContentItem { get; set; }
+        public CloneContentContext(ContentItem contentItem, ContentItem cloneContentItem)
+            :base(contentItem) {
+            CloneContentItem = cloneContentItem;
         }
     }
 }

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -172,6 +172,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContentManagement\Drivers\IContentFieldCloningDriver.cs" />
+    <Compile Include="ContentManagement\Drivers\IContentPartCloningDriver.cs" />
     <Compile Include="ContentManagement\Extensions\DriverResultExtensions.cs" />
     <Compile Include="ContentManagement\Handlers\CloneContentContext.cs" />
     <Compile Include="Environment\Configuration\ExtensionLocations.cs" />

--- a/src/Rebracer.xml
+++ b/src/Rebracer.xml
@@ -22,8 +22,8 @@
     </ToolsOptionsCategory>
     <ToolsOptionsCategory name="TextEditor">
       <ToolsOptionsSubCategory name="CSharp-Specific">
-        <PropertyValue name="AddImport_SuggestForTypesInNuGetPackages">0</PropertyValue>
-        <PropertyValue name="AddImport_SuggestForTypesInReferenceAssemblies">0</PropertyValue>
+        <PropertyValue name="AddImport_SuggestForTypesInNuGetPackages">1</PropertyValue>
+        <PropertyValue name="AddImport_SuggestForTypesInReferenceAssemblies">1</PropertyValue>
         <PropertyValue name="AutoComment">1</PropertyValue>
         <PropertyValue name="AutoInsertAsteriskForNewLinesOfBlockComments">1</PropertyValue>
         <PropertyValue name="CSharpClosedFileDiagnostics">-1</PropertyValue>


### PR DESCRIPTION
Since we discussed cloning in the context of localization in #7352, I checked what the cloning feature does in dev.
The goal here is to make the cloning feature by @TFleury (see 87a394854dda9a45b36d757b3d3ce135ac18d24d and #7400) retrocompatible to what is in 1.10.x.

In order to do that, I pulled those commits and reverted everything that was not directly related to Cloning (hence the number of commits in this branch's history).

Additionally, I introduced a fallback logic in the driver coordinators for cloning (see both ContentFieldDriverCoordinator and ContentPartDriverCoordinator): 
The idea is that is a driver does not explicitly implement Cloning, the coordinator will clone the part by using the "old" logic of export/import. As a consequence, if we want a part (or field) to not be cloned, in at least one of its drivers we should declare a Cloning override that does nothing (e.g. see AutoroutePartDriver here).

I think with this fallback the cloning feature introduces no breaking changes to 1.10.x, but I'd like to have other people's opinions, because I might have missed a lot of things.

note:
I reverted most changes in the Orchard.Localization module, even though I liked them better than what's in it right now, to avoid mixing too many concerns in a single pull request. (Also, I'd rather have a Translating feature, that falls back to cloning as a default, than a Cloning feature that may optionally also do translation, but this is not the place to go on about this)