### PR TITLE
Implemented LocalizationSetId and relate logic.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
@@ -14,12 +14,12 @@ namespace Orchard.Localization.Controllers {
     [ValidateInput(false)]
     public class AdminController : Controller, IUpdateModel {
         private readonly IContentManager _contentManager;
-        private readonly ILocalizationService _localizationService;
+        private readonly ILocalizationSetService _localizationService;
 
         public AdminController(
             IOrchardServices orchardServices,
             IContentManager contentManager,
-            ILocalizationService localizationService,
+            ILocalizationSetService localizationService,
             IShapeFactory shapeFactory) {
             _contentManager = contentManager;
             _localizationService = localizationService;

--- a/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
@@ -10,29 +10,30 @@ namespace Orchard.Localization.Drivers {
     public class LocalizationPartDriver : ContentPartDriver<LocalizationPart> {
         private const string TemplatePrefix = "Localization";
         private readonly ICultureManager _cultureManager;
-        private readonly ILocalizationService _localizationService;
+        private readonly ILocalizationSetService _localizationService;
         private readonly IContentManager _contentManager;
 
-        public LocalizationPartDriver(ICultureManager cultureManager, ILocalizationService localizationService, IContentManager contentManager) {
+        public LocalizationPartDriver(ICultureManager cultureManager, ILocalizationSetService localizationService, IContentManager contentManager) {
             _cultureManager = cultureManager;
             _localizationService = localizationService;
             _contentManager = contentManager;
         }
 
         protected override DriverResult Display(LocalizationPart part, string displayType, dynamic shapeHelper) {
-            var masterId = part.HasTranslationGroup
-                               ? part.Record.MasterContentItemId
-                               : part.Id;
+            //var masterId = 
+            //    part.HasTranslationGroup
+            //                   ? part.Record.MasterContentItemId
+            //                   : part.Id;
 
             return Combined(
                 ContentShape("Parts_Localization_ContentTranslations",
-                             () => shapeHelper.Parts_Localization_ContentTranslations(Id: part.ContentItem.Id, MasterId: masterId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Published))),
+                             () => shapeHelper.Parts_Localization_ContentTranslations(Id: part.ContentItem.Id, MasterId: part.LocalizationSetId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Published))),
                 ContentShape("Parts_Localization_ContentTranslations_Summary",
-                             () => shapeHelper.Parts_Localization_ContentTranslations_Summary(Id: part.ContentItem.Id, MasterId: masterId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Published))),
+                             () => shapeHelper.Parts_Localization_ContentTranslations_Summary(Id: part.ContentItem.Id, MasterId: part.LocalizationSetId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Published))),
                 ContentShape("Parts_Localization_ContentTranslations_SummaryAdmin", () => {
                     var siteCultures = _cultureManager.ListCultures();
 
-                    return shapeHelper.Parts_Localization_ContentTranslations_SummaryAdmin(Id: part.ContentItem.Id, MasterId: masterId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Latest), SiteCultures: siteCultures);
+                    return shapeHelper.Parts_Localization_ContentTranslations_SummaryAdmin(Id: part.ContentItem.Id, MasterId: part.LocalizationSetId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Latest), SiteCultures: siteCultures);
                 })
                 );
         }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Handlers/LocalizationPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Handlers/LocalizationPartHandler.cs
@@ -19,6 +19,12 @@ namespace Orchard.Localization.Handlers {
 
             OnActivated<LocalizationPart>(PropertySetHandlers);
 
+            OnCreated<LocalizationPart>((context, part) => {
+                if (part.Record.LocalizationSetId == 0) {
+                    part.Record.LocalizationSetId = part.Id;
+                }
+            });
+
             OnLoading<LocalizationPart>((context, part) => LazyLoadHandlers(part));
             OnVersioning<LocalizationPart>((context, part, versionedPart) => LazyLoadHandlers(versionedPart));
 
@@ -37,6 +43,7 @@ namespace Orchard.Localization.Handlers {
             
             localizationPart.MasterContentItemField.Setter(masterContentItem => {
                 localizationPart.Record.MasterContentItemId = masterContentItem.ContentItem.Id;
+                localizationPart.Record.LocalizationSetId = masterContentItem.As<LocalizationPart>().LocalizationSetId;
                 return masterContentItem;
             });            
         }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Migrations.cs
@@ -1,13 +1,22 @@
 ﻿using Orchard.ContentManagement.MetaData;
 using Orchard.Core.Contents.Extensions;
+using Orchard.Data;
 using Orchard.Data.Migration;
 using Orchard.Environment.Extensions;
+using Orchard.Localization.Models;
+using System.Linq;
 
 namespace Orchard.Localization {
     public class Migrations : DataMigrationImpl {
 
+        private readonly IRepository<LocalizationPartRecord> _repositoryLocalizationPart;
+
+        public Migrations(IRepository<LocalizationPartRecord> repositoryLocalizationPart) {
+            _repositoryLocalizationPart = repositoryLocalizationPart;
+        }
+
         public int Create() {
-            SchemaBuilder.CreateTable("LocalizationPartRecord", 
+            SchemaBuilder.CreateTable("LocalizationPartRecord",
                 table => table
                     .ContentPartRecord()
                     .Column<int>("CultureId")
@@ -24,6 +33,52 @@ namespace Orchard.Localization {
                 .WithDescription("Provides the user interface to localize content items."));
 
             return 2;
+        }
+
+        public int UpdateFrom2() {
+            //We introduced the concept of localization sets, so we need to create them:
+            // - Add the column to the table:
+            SchemaBuilder.AlterTable("LocalizationPartRecord",
+                table => table
+                    .AddColumn<int>("LocalizationSetId")
+                );
+            // - Initialize the value for existing localization parts:
+            //Given a record for a ContentItem with Id CIId, with MasterContentItemId MCId, the LocalizationSetId is:
+            // - CIId, if MCId == 0: this item is its own master
+            // - The MasterContent's LocalizationSetId in all other cases.
+            //Since the MasterContent is the one we translated from (not the one that started the translation chain) we have to check several times
+            // CIId | MCId  | LocalizationSetId we want
+            // 1    | 0     | 1 : this item is its own master
+            // 2    | 1     | 1
+            // 3    | 2     | 1 : this item is a translation of 2, that is in turn a translation of 1
+            if (_repositoryLocalizationPart.Table.Count() > 0) {
+                //TODO: to handle very large dbs, we need to do Skip() Take() both for masters and children. The masters should also be stored
+                //      differently for when we use them for the children. Maybe a List<Tuple<int,List<int>>>.
+                //First we do the items that are their own masters
+                var masters = _repositoryLocalizationPart.Table.Where(lpr => lpr.MasterContentItemId == 0).ToList();
+                masters.ForEach(ma => ma.LocalizationSetId = ma.Id);
+                //Then we do the rest of the items in each localization set
+                var children = _repositoryLocalizationPart.Table.Where(lpr => lpr.MasterContentItemId != 0).ToList();
+                while (children.Count > 0) {
+                    if (masters.Count >= children.Count) {
+                        masters.ForEach(ma => {
+                            children.Where(ch => ch.MasterContentItemId == ma.Id).ToList().ForEach(ch => ch.LocalizationSetId = ma.LocalizationSetId);
+                        });
+                    }
+                    else {
+                        children.ForEach(ch => {
+                            var master = masters.FirstOrDefault(ma => ch.MasterContentItemId == ma.Id);
+                            if (master != null) {
+                                ch.LocalizationSetId = master.LocalizationSetId;
+                            }
+                        });
+                    }
+                    masters.AddRange(children.Where(ch => ch.LocalizationSetId != 0));
+                    children.RemoveAll(lpr => lpr.LocalizationSetId != 0);
+                }
+            }
+
+            return 3;
         }
     }
 

--- a/src/Orchard.Web/Modules/Orchard.Localization/Models/LocalizationPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Models/LocalizationPart.cs
@@ -11,24 +11,35 @@ namespace Orchard.Localization.Models {
         public LazyField<CultureRecord> CultureField { get { return _culture; } }
         public LazyField<IContent> MasterContentItemField { get { return _masterContentItem; } }
 
-        public CultureRecord Culture {
+        public CultureRecord Culture
+        {
             get { return _culture.Value; }
             set { _culture.Value = value; }
         }
 
-        public IContent MasterContentItem {
+        public IContent MasterContentItem
+        {
             get { return _masterContentItem.Value; }
             set { _masterContentItem.Value = value; }
         }
 
-        public bool HasTranslationGroup {
-            get {
+        public bool HasTranslationGroup
+        {
+            get
+            {
                 return Record.MasterContentItemId != 0;
             }
         }
 
-        string ILocalizableAspect.Culture {
+        string ILocalizableAspect.Culture
+        {
             get { return Culture == null ? null : Culture.Culture; }
         }
+
+        public int LocalizationSetId
+        {
+            get { return Record.LocalizationSetId; }
+        }
+
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Models/LocalizationPartRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Models/LocalizationPartRecord.cs
@@ -4,5 +4,6 @@ namespace Orchard.Localization.Models {
     public class LocalizationPartRecord : ContentPartRecord {
         public virtual int CultureId { get; set; }
         public virtual int MasterContentItemId { get; set; }
+        public virtual int LocalizationSetId { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Orchard.Localization.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Orchard.Localization.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Conditions\CultureConditionProvider.cs" />
     <Compile Include="Services\AdminDirectionalityFactory.cs" />
     <Compile Include="Services\AdminCultureSelectorFactory.cs" />
+    <Compile Include="Services\ILocalizationSetService.cs" />
     <Compile Include="Services\LocalizationCultureFilter.cs" />
     <Compile Include="Selectors\CookieCultureSelector.cs" />
     <Compile Include="Drivers\LocalizationPartDriver.cs" />
@@ -118,6 +119,7 @@
     <Compile Include="Services\ITransliterationService.cs" />
     <Compile Include="Providers\LocalizationDateTimeFormatProvider.cs" />
     <Compile Include="Services\LocalizationService.cs" />
+    <Compile Include="Services\LocalizationSetService.cs" />
     <Compile Include="Services\TransliterationService.cs" />
     <Compile Include="Events\TransliterationSlugEventHandler.cs" />
     <Compile Include="ViewModels\ContentLocalizationsViewModel.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/ILocalizationSetService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/ILocalizationSetService.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+using Orchard.ContentManagement;
+using Orchard.Localization.Models;
+
+namespace Orchard.Localization.Services {
+    public interface ILocalizationSetService : ILocalizationService, IDependency {
+        IEnumerable<LocalizationPart> GetLocalizationSet(int localizationSetId, string contentType = "", VersionOptions versionOptions = null);
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationSetService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationSetService.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Orchard.ContentManagement;
+using Orchard.Localization.Models;
+
+namespace Orchard.Localization.Services {
+    public class LocalizationSetService : ILocalizationSetService {
+        private readonly IContentManager _contentManager;
+        private readonly ICultureManager _cultureManager;
+
+        public LocalizationSetService(IContentManager contentManager, ICultureManager cultureManager) {
+            _contentManager = contentManager;
+            _cultureManager = cultureManager;
+        }
+
+        public string GetContentCulture(IContent content) {
+            var localized = content.As<LocalizationPart>();
+            return localized != null && localized.Culture != null
+                ? localized.Culture.Culture
+                : _cultureManager.GetSiteCulture();
+        }
+
+        public void SetContentCulture(IContent content, string culture) {
+            var localized = content.As<LocalizationPart>();
+            if (localized == null)
+                return;
+
+            localized.Culture = _cultureManager.GetCultureByName(culture);
+        }
+
+        public IEnumerable<LocalizationPart> GetLocalizations(IContent content) {
+            // Warning: May contain more than one localization of the same culture.
+            return GetLocalizations(content, null);
+        }
+
+        public  IEnumerable<LocalizationPart> GetLocalizations(IContent content, VersionOptions versionOptions) {
+            if (content.ContentItem.Id == 0)
+                return Enumerable.Empty<LocalizationPart>();
+
+            var localized = content.As<LocalizationPart>();
+            if (localized == null)
+                return Enumerable.Empty<LocalizationPart>();
+
+            return GetLocalizationSet(localized.LocalizationSetId, localized.ContentItem.ContentType, versionOptions).Except(new LocalizationPart[] { localized });
+        }
+
+        public IEnumerable<LocalizationPart> GetLocalizationSet(int localizationSetId, string contentType, VersionOptions versionOptions) {
+            if (localizationSetId <= 0)
+                return Enumerable.Empty<LocalizationPart>();
+
+            var query = _contentManager.Query().ForPart<LocalizationPart>();
+            if (!string.IsNullOrWhiteSpace(contentType))
+                query = query.ForType(contentType);
+            if (versionOptions != null)
+                query = query.ForVersion(versionOptions);
+
+            query = query.Where<LocalizationPartRecord>(lpr => lpr.LocalizationSetId == localizationSetId);
+            return query.List().ToList();
+        }
+
+        public LocalizationPart GetLocalizedContentItem(IContent content, string culture) {
+            // Warning: Returns only the first of same culture localizations.
+            return ((ILocalizationService)this).GetLocalizedContentItem(content, culture, null);
+        }
+
+        public LocalizationPart GetLocalizedContentItem(IContent content, string culture, VersionOptions versionOptions) {
+            var cultureRecord = _cultureManager.GetCultureByName(culture);
+
+            if (cultureRecord == null)
+                return null;
+
+            var localized = content.As<LocalizationPart>();
+
+            if (localized == null)
+                return null;
+
+            var query = versionOptions == null
+                ? _contentManager.Query<LocalizationPart>(localized.ContentItem.ContentType)
+                : _contentManager.Query<LocalizationPart>(versionOptions, localized.ContentItem.ContentType);
+            // Warning: Returns only the first of same culture localizations.
+            return query.Where<LocalizationPartRecord>(lpr => lpr.LocalizationSetId == localized.LocalizationSetId && lpr.CultureId == cultureRecord.Id).Slice(1).FirstOrDefault();
+        }
+    }
+}

--- a/src/Rebracer.xml
+++ b/src/Rebracer.xml
@@ -22,8 +22,8 @@
     </ToolsOptionsCategory>
     <ToolsOptionsCategory name="TextEditor">
       <ToolsOptionsSubCategory name="CSharp-Specific">
-        <PropertyValue name="AddImport_SuggestForTypesInNuGetPackages">0</PropertyValue>
-        <PropertyValue name="AddImport_SuggestForTypesInReferenceAssemblies">0</PropertyValue>
+        <PropertyValue name="AddImport_SuggestForTypesInNuGetPackages">1</PropertyValue>
+        <PropertyValue name="AddImport_SuggestForTypesInReferenceAssemblies">1</PropertyValue>
         <PropertyValue name="AutoComment">1</PropertyValue>
         <PropertyValue name="AutoInsertAsteriskForNewLinesOfBlockComments">1</PropertyValue>
         <PropertyValue name="CSharpClosedFileDiagnostics">-1</PropertyValue>


### PR DESCRIPTION
Functionally, this replaces the MasterContentItem. However, the old service has not been touched to allow retrocompatibility.

This does not solve #7394 because the "old" LocalizationService was not changed. Rather, a new service was created that lives beside it, so that anyone using the original buggy ones and making them work for their needs will see no change.

This is a solution to #7386, because the new service maintains the relationship inside the LocalizationSet.

This may be a to #7348: in testing this PR on my machine I have never seen the issue I saw there in #7348.

This time I have also been a good boy and squashed all my commits.

The migration may take a while on systems with a lot of items. I have been thinking about ways to make it faster, but I'd first like to see if it's needed, because they are not very easy to implement and test.