### PR TITLE
1.10.x

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Implementation/DefaultMediaUsername.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Implementation/DefaultMediaUsername.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Orchard.ContentManagement;
+using Orchard.MediaLibrary.Providers;
+using Orchard.Users.Models;
+
+namespace Orchard.MediaLibrary.Implementation {
+    public class DefaultMediaUsername : IMediaFolderProvider {
+        public virtual string GetFolderName(ContentItem content) {
+            if (content.As<UserPart>() != null) {
+                string folder = "";
+                foreach (char c in content.As<UserPart>().UserName) {
+                    if (char.IsLetterOrDigit(c)) {
+                        folder += c;
+                    }
+                    else
+                        folder += "_" + String.Format("{0:X}", Convert.ToInt32(c));
+                }
+                return folder;
+            }
+            else {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
@@ -205,7 +205,7 @@
     <Compile Include="ResourceManifest.cs" />
     <Compile Include="Security\MediaAuthorizationEventHandler.cs" />
     <Compile Include="Services\IMediaLibraryService.cs" />
-    <Compile Include="Providers\MediaFolderProvider.cs" />
+    <Compile Include="Providers\IMediaFolderProvider.cs" />
     <Compile Include="Services\MediaLibraryService.cs" />
     <Compile Include="Services\Shapes.cs" />
     <Compile Include="Services\XmlRpcHandler.cs" />

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Extensions\MediaMetaDataExtensions.cs" />
     <Compile Include="Factories\VectorImageFactory.cs" />
     <Compile Include="Handlers\MediaLibrarySettingsPartHandler.cs" />
+    <Compile Include="Implementation\DefaultMediaUsername.cs" />
     <Compile Include="Models\MediaLibrarySettingsPart.cs" />
     <Compile Include="Models\VectorImagePart.cs" />
     <Compile Include="Models\IMediaFolder.cs" />
@@ -151,6 +152,10 @@
     <ProjectReference Include="..\Orchard.Tokens\Orchard.Tokens.csproj">
       <Project>{6f759635-13d7-4e94-bcc9-80445d63f117}</Project>
       <Name>Orchard.Tokens</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Orchard.Users\Orchard.Users.csproj">
+      <Project>{79AED36E-ABD0-4747-93D3-8722B042454B}</Project>
+      <Name>Orchard.Users</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -200,6 +205,7 @@
     <Compile Include="ResourceManifest.cs" />
     <Compile Include="Security\MediaAuthorizationEventHandler.cs" />
     <Compile Include="Services\IMediaLibraryService.cs" />
+    <Compile Include="Providers\MediaFolderProvider.cs" />
     <Compile Include="Services\MediaLibraryService.cs" />
     <Compile Include="Services\Shapes.cs" />
     <Compile Include="Services\XmlRpcHandler.cs" />

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Providers/IMediaFolderProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Providers/IMediaFolderProvider.cs
@@ -1,0 +1,7 @@
+﻿using Orchard.ContentManagement;
+
+namespace Orchard.MediaLibrary.Providers {
+    public interface IMediaFolderProvider : IDependency {
+        string GetFolderName(ContentItem content);
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/MediaLibraryService.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/MediaLibraryService.cs
@@ -12,6 +12,7 @@ using Orchard.MediaLibrary.Factories;
 using Orchard.MediaLibrary.Models;
 using Orchard.Core.Title.Models;
 using Orchard.Validation;
+using Orchard.MediaLibrary.Providers;
 
 namespace Orchard.MediaLibrary.Services {
     public class MediaLibraryService : IMediaLibraryService {
@@ -19,18 +20,20 @@ namespace Orchard.MediaLibrary.Services {
         private readonly IMimeTypeProvider _mimeTypeProvider;
         private readonly IStorageProvider _storageProvider;
         private readonly IEnumerable<IMediaFactorySelector> _mediaFactorySelectors;
-
+        private readonly IMediaFolderProvider _mediaFolderProvider;
         private static char[] HttpUnallowed = new char[] { '<', '>', '*', '%', '&', ':', '\\', '?', '#' };
 
         public MediaLibraryService(
             IOrchardServices orchardServices,
             IMimeTypeProvider mimeTypeProvider,
             IStorageProvider storageProvider,
-            IEnumerable<IMediaFactorySelector> mediaFactorySelectors) {
+            IEnumerable<IMediaFactorySelector> mediaFactorySelectors,
+            IMediaFolderProvider mediaFolderProvider) {
             _orchardServices = orchardServices;
             _mimeTypeProvider = mimeTypeProvider;
             _storageProvider = storageProvider;
             _mediaFactorySelectors = mediaFactorySelectors;
+            _mediaFolderProvider = mediaFolderProvider;
 
             T = NullLocalizer.Instance;
         }
@@ -229,8 +232,7 @@ namespace Orchard.MediaLibrary.Services {
 
             if (_orchardServices.Authorizer.Authorize(Permissions.ManageOwnMedia)) {
                 var currentUser = _orchardServices.WorkContext.CurrentUser;
-                var userPath = _storageProvider.Combine("Users", currentUser.UserName);
-
+                var userPath = _storageProvider.Combine("Users", _mediaFolderProvider.GetFolderName(currentUser.ContentItem));
                 return new MediaFolder() {
                     Name = currentUser.UserName,
                     MediaPath = userPath


### PR DESCRIPTION
Implemented what described on issue 7404
Manage Own Media permission, created Users/UserName folder that sounds as having some problems. Now creates Users/UserNameEncoded folder in order to prevent:

Media Folder name broken with special chars

Added interface for change the default behavior
