### PR TITLE
Blog: fix on check permission in BlogAuthorizationEventHandler.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Blogs/Security/BlogAuthorizationEventHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Security/BlogAuthorizationEventHandler.cs
@@ -13,7 +13,8 @@ namespace Orchard.Blogs.Security {
             if (!context.Granted &&
                 context.Content.Is<ICommonPart>()) {
 
-                if (context.Permission.Name == Orchard.Core.Contents.Permissions.PublishContent.Name && context.Content.ContentItem.ContentType == "BlogPost") {
+                if ((context.Permission.Name == Orchard.Core.Contents.Permissions.PublishContent.Name && context.Content.ContentItem.ContentType == "BlogPost")
+                 || (context.Permission.Name == Orchard.Core.Contents.Permissions.PublishOwnContent.Name && context.Content.ContentItem.ContentType == "BlogPost")) {
                     context.Adjusted = true;
                     context.Permission = Permissions.PublishBlogPost;
                 }


### PR DESCRIPTION
Users can publish theirs own blog post if they are granted PublishOwnContent on Orchard.Blogs Feature.