### PR TITLE
Fix for Query Filter on DateTime fields

### DIFF
--- a/src/Orchard/ContentManagement/IHqlCriterion.cs
+++ b/src/Orchard/ContentManagement/IHqlCriterion.cs
@@ -134,7 +134,7 @@ namespace Orchard.ContentManagement {
                     return EncodeQuotes(Convert.ToString(value, CultureInfo.InvariantCulture));
                 case TypeCode.DateTime:
                     // convert the date time to a valid string representation for Hql
-                    var sortableDateTime = ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                    var sortableDateTime = ((DateTime)value).ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
                     return quoteStrings ? String.Concat("'", EncodeQuotes(sortableDateTime), "'") : sortableDateTime;
             }
 


### PR DESCRIPTION
DateTime value is now parsed to String in ISO 8601 format.
This PR should solve issue #7432.