### PR TITLE
Fix the issue #7451 with  strange encoding of taxonomies in the dynamic for…

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/TaxonomyElementDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Drivers/TaxonomyElementDriver.cs
@@ -163,8 +163,8 @@ namespace Orchard.DynamicForms.Drivers {
 
             var projection = terms.Select(x => {
                 var data = new {Content = x};
-                var value = _tokenizer.Replace(valueExpression, data);
-                var text = _tokenizer.Replace(textExpression, data);
+                var value = _tokenizer.Replace(valueExpression, data, new ReplaceOptions { Encoding = ReplaceOptions.NoEncode });
+                var text = _tokenizer.Replace(textExpression, data, new ReplaceOptions { Encoding = ReplaceOptions.NoEncode });
 
                 return new SelectListItem {
                     Text = text,


### PR DESCRIPTION
…ms (Acuité : Acuit&#233).

Basically I modified two lines only : 
These : 
```
var value = _tokenizer.Replace(valueExpression, data);
var text = _tokenizer.Replace(textExpression, data);
```
With these: 
```
var value = _tokenizer.Replace(valueExpression, data, new ReplaceOptions { Encoding = ReplaceOptions.NoEncode });
var text = _tokenizer.Replace(textExpression, data, new ReplaceOptions { Encoding = ReplaceOptions.NoEncode });
```

I added `, new ReplaceOptions { Encoding = ReplaceOptions.NoEncode }` parameter. It does the trick  . 