### PR TITLE
[Fixes: #7462] Orchard.OutputCache - Possible NRE in DefaultTagCache ctor when accessing the WorkContext

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultTagCache.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultTagCache.cs
@@ -17,11 +17,15 @@ namespace Orchard.OutputCache.Services {
             var key = shellSettings.Name + ":TagCache";
             var workContext = workContextAccessor.GetContext();
 
-            _dictionary = workContext.HttpContext.Cache.Get(key) as ConcurrentDictionary<string, HashSet<string>>;
+            if ( workContext != null )
+            {
+                _dictionary = workContext.HttpContext.Cache.Get(key) as ConcurrentDictionary<string, HashSet<string>>;
 
-            if (_dictionary == null) {
-                _dictionary = new ConcurrentDictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-                workContext.HttpContext.Cache.Add(key, _dictionary, null, Cache.NoAbsoluteExpiration, Cache.NoSlidingExpiration, CacheItemPriority.Normal, null);
+                if ( _dictionary == null )
+                {
+                    _dictionary = new ConcurrentDictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+                    workContext.HttpContext.Cache.Add(key, _dictionary, null, Cache.NoAbsoluteExpiration, Cache.NoSlidingExpiration, CacheItemPriority.Normal, null);
+                }
             }
         }
 

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultTagCache.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Services/DefaultTagCache.cs
@@ -17,12 +17,10 @@ namespace Orchard.OutputCache.Services {
             var key = shellSettings.Name + ":TagCache";
             var workContext = workContextAccessor.GetContext();
 
-            if ( workContext != null )
-            {
+            if ( workContext != null ) {
                 _dictionary = workContext.HttpContext.Cache.Get(key) as ConcurrentDictionary<string, HashSet<string>>;
 
-                if ( _dictionary == null )
-                {
+                if ( _dictionary == null ) {
                     _dictionary = new ConcurrentDictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
                     workContext.HttpContext.Cache.Add(key, _dictionary, null, Cache.NoAbsoluteExpiration, Cache.NoSlidingExpiration, CacheItemPriority.Normal, null);
                 }


### PR DESCRIPTION
Fixes #7462