### PR TITLE
Update WidgetCommandsService.cs

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Widgets/Services/WidgetCommandsService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Services/WidgetCommandsService.cs
@@ -77,7 +77,6 @@ namespace Orchard.Widgets.Services {
                 var menu = _menuService.GetMenu(menuName);
 
                 if (menu != null) {
-                    widget.RenderTitle = false;
                     widget.As<MenuWidgetPart>().MenuContentItemId = menu.ContentItem.Id;
                 }
             }


### PR DESCRIPTION
Removed hard coded override of the RenderTitle property for Menu Widgets.  

Fixes issue: https://github.com/OrchardCMS/Orchard/issues/7476