### PR TITLE
On Import, the modified url only gets updated in AutoroutePart and not as new Alias (Friendly Url)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Alias/Implementation/Holder/AliasHolder.cs
+++ b/src/Orchard.Web/Modules/Orchard.Alias/Implementation/Holder/AliasHolder.cs
@@ -3,14 +3,27 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Collections.Concurrent;
 using Orchard.Alias.Implementation.Map;
+using Orchard.Alias.Implementation.Updater;
 
 namespace Orchard.Alias.Implementation.Holder {
     public class AliasHolder : IAliasHolder {
-        public AliasHolder() {
+        private readonly Lazy<IAliasHolderUpdater> _aliasHolderUpdater;
+        private readonly ConcurrentDictionary<string, AliasMap> _aliasMaps;
+
+        public AliasHolder(Lazy<IAliasHolderUpdater> aliasHolderUpdater) {
+            _aliasHolderUpdater = aliasHolderUpdater;
             _aliasMaps = new ConcurrentDictionary<string, AliasMap>(StringComparer.OrdinalIgnoreCase);
         }
 
-        private readonly ConcurrentDictionary<string, AliasMap> _aliasMaps;
+        private ConcurrentDictionary<string, AliasMap> aliasMaps {
+            get {
+                lock (_aliasMaps) {
+                    if (_aliasMaps.Count == 0)
+                        _aliasHolderUpdater.Value.Refresh();
+                }
+                return _aliasMaps;
+            }
+        }
 
         public void SetAliases(IEnumerable<AliasInfo> aliases) {
             var grouped = aliases.GroupBy(alias => alias.Area ?? String.Empty, StringComparer.InvariantCultureIgnoreCase);
@@ -25,7 +38,7 @@ namespace Orchard.Alias.Implementation.Holder {
         }
 
         public void SetAlias(AliasInfo alias) {
-            foreach (var map in _aliasMaps.Values) {
+            foreach (var map in aliasMaps.Values) {
                 map.Remove(alias);
             }
 
@@ -33,11 +46,11 @@ namespace Orchard.Alias.Implementation.Holder {
         }
 
         public IEnumerable<AliasMap> GetMaps() {
-            return _aliasMaps.Values;
+            return aliasMaps.Values;
         }
 
         public AliasMap GetMap(string areaName) {
-            return _aliasMaps.GetOrAdd(areaName ?? String.Empty, key => new AliasMap(key));
+            return aliasMaps.GetOrAdd(areaName ?? String.Empty, key => new AliasMap(key));
         }
 
         public void RemoveAlias(AliasInfo aliasInfo) {

--- a/src/Orchard.Web/Modules/Orchard.Alias/Implementation/Holder/AliasHolder.cs
+++ b/src/Orchard.Web/Modules/Orchard.Alias/Implementation/Holder/AliasHolder.cs
@@ -15,14 +15,13 @@ namespace Orchard.Alias.Implementation.Holder {
             _aliasMaps = new ConcurrentDictionary<string, AliasMap>(StringComparer.OrdinalIgnoreCase);
         }
 
-        private ConcurrentDictionary<string, AliasMap> aliasMaps {
-            get {
-                lock (_aliasMaps) {
-                    if (_aliasMaps.Count == 0)
-                        _aliasHolderUpdater.Value.Refresh();
-                }
-                return _aliasMaps;
+        private ConcurrentDictionary<string, AliasMap> GetOrRefreshAliasMaps() {
+            lock (_aliasMaps) {
+                if (_aliasMaps.Count == 0)
+                    _aliasHolderUpdater.Value.Refresh();
             }
+
+            return _aliasMaps;
         }
 
         public void SetAliases(IEnumerable<AliasInfo> aliases) {
@@ -38,7 +37,7 @@ namespace Orchard.Alias.Implementation.Holder {
         }
 
         public void SetAlias(AliasInfo alias) {
-            foreach (var map in aliasMaps.Values) {
+            foreach (var map in GetOrRefreshAliasMaps().Values) {
                 map.Remove(alias);
             }
 
@@ -46,11 +45,11 @@ namespace Orchard.Alias.Implementation.Holder {
         }
 
         public IEnumerable<AliasMap> GetMaps() {
-            return aliasMaps.Values;
+            return GetOrRefreshAliasMaps().Values;
         }
 
         public AliasMap GetMap(string areaName) {
-            return aliasMaps.GetOrAdd(areaName ?? String.Empty, key => new AliasMap(key));
+            return GetOrRefreshAliasMaps().GetOrAdd(areaName ?? String.Empty, key => new AliasMap(key));
         }
 
         public void RemoveAlias(AliasInfo aliasInfo) {

--- a/src/Orchard.Web/Modules/Orchard.Alias/Views/Admin/IndexManaged.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Alias/Views/Admin/IndexManaged.cshtml
@@ -44,7 +44,6 @@
                 <tr>                    
                     <th scope="col">@T("Alias")</th>
                     <th scope="col">@T("Route")</th>                    
-                    <th scope="col">&nbsp;</th>
                 </tr>
             </thead>
             @foreach (var aliasEntry in Model.AliasEntries) {


### PR DESCRIPTION
Fixes #6316

@sebastienros i have used a property to get the aliasMaps. In that property im using lock to make sure no other call is updating it at the same moment. If the count is returned as 0 we call IAliasHolderUpdater.Refresh to refresh the map. Please let me know if this approach is not correct and we need to make any adjustments.

The other shape file had an extra column in the Admin/IndexManaged which has now been removed.