### PR TITLE
Improved performance of Count Hql queries

### DIFF
--- a/src/Orchard/ContentManagement/DefaultHqlQuery.cs
+++ b/src/Orchard/ContentManagement/DefaultHqlQuery.cs
@@ -208,7 +208,6 @@ namespace Orchard.ContentManagement {
         public int Count() {
             ApplyHqlVersionOptionsRestrictions(_versionOptions);
             var hql = ToHql(true);
-            hql = "select count(Id) from Orchard.ContentManagement.Records.ContentItemVersionRecord where Id in ( " + hql + " )";
             return Convert.ToInt32(_session.CreateQuery(hql)
                            .SetCacheable(true)
                            .UniqueResult())
@@ -219,7 +218,7 @@ namespace Orchard.ContentManagement {
             var sb = new StringBuilder();
 
             if (count) {
-                sb.Append("select distinct civ.Id as Id").AppendLine();
+                sb.Append("select count(distinct civ.Id)").AppendLine();
             }
             else {
                 sb.Append("select distinct civ.Id as Id");


### PR DESCRIPTION
In a previous version of Orchard src we stored locally we improved a lot the performance of queries avoiding the IN operator in Count hql. It had a relevant impact on pagination cause It used queries based on Count.
So I think it is good to share this improvement providing this PR