### PR TITLE
[fixes #7348]Changed the SummaryAdmin view to have the same "New Translation" link as the Editor view

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
@@ -54,7 +54,7 @@ namespace Orchard.Localization.Controllers {
             contentItemTranslation.MasterContentItem = masterLocalizationPart.MasterContentItem == null ? masterContentItem : masterLocalizationPart.MasterContentItem;
 
             var content = _contentManager.BuildEditor(contentItemTranslation);
-            
+
             return View(content);
         }
 
@@ -89,14 +89,14 @@ namespace Orchard.Localization.Controllers {
             if (existingTranslation != null) {
                 var existingTranslationMetadata = _contentManager.GetItemMetadata(existingTranslation);
                 return RedirectToAction(
-                    Convert.ToString(existingTranslationMetadata.EditorRouteValues["action"]), 
+                    Convert.ToString(existingTranslationMetadata.EditorRouteValues["action"]),
                     existingTranslationMetadata.EditorRouteValues);
             }
 
             var contentItemTranslation = _contentManager
                 .Create<LocalizationPart>(masterContentItem.ContentType, VersionOptions.Draft, part => {
-                    part.MasterContentItem = masterContentItem;
-            });
+                    part.MasterContentItem = masterLocalizationPart.MasterContentItem == null ? masterContentItem : masterLocalizationPart.MasterContentItem;
+                });
 
             var content = _contentManager.UpdateEditor(contentItemTranslation, this);
 

--- a/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
@@ -51,7 +51,7 @@ namespace Orchard.Localization.Controllers {
             }
 
             var contentItemTranslation = _contentManager.New<LocalizationPart>(masterContentItem.ContentType);
-            contentItemTranslation.MasterContentItem = masterContentItem;
+            contentItemTranslation.MasterContentItem = masterLocalizationPart.MasterContentItem == null ? masterContentItem : masterLocalizationPart.MasterContentItem;
 
             var content = _contentManager.BuildEditor(contentItemTranslation);
             

--- a/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
@@ -20,6 +20,21 @@ namespace Orchard.Localization.Drivers {
         }
 
         protected override DriverResult Display(LocalizationPart part, string displayType, dynamic shapeHelper) {
+
+            return Combined(
+                ContentShape("Parts_Localization_ContentTranslations",
+                             () => shapeHelper.Parts_Localization_ContentTranslations(Id: part.ContentItem.Id, MasterId: ActualMasterId(part), Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Published))),
+                ContentShape("Parts_Localization_ContentTranslations_Summary",
+                             () => shapeHelper.Parts_Localization_ContentTranslations_Summary(Id: part.ContentItem.Id, MasterId: ActualMasterId(part), Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Published))),
+                ContentShape("Parts_Localization_ContentTranslations_SummaryAdmin", () => {
+                    var siteCultures = _cultureManager.ListCultures();
+
+                    return shapeHelper.Parts_Localization_ContentTranslations_SummaryAdmin(Id: part.ContentItem.Id, MasterId: ActualMasterId(part), Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Latest), SiteCultures: siteCultures);
+                })
+                );
+        }
+
+        private int ActualMasterId(LocalizationPart part) {
             var masterId = part.HasTranslationGroup
                                ? part.Record.MasterContentItemId
                                : part.Id;
@@ -27,17 +42,7 @@ namespace Orchard.Localization.Drivers {
                 //the original MasterContentItem has been deleted
                 masterId = part.Id;
             }
-            return Combined(
-                ContentShape("Parts_Localization_ContentTranslations",
-                             () => shapeHelper.Parts_Localization_ContentTranslations(Id: part.ContentItem.Id, MasterId: masterId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Published))),
-                ContentShape("Parts_Localization_ContentTranslations_Summary",
-                             () => shapeHelper.Parts_Localization_ContentTranslations_Summary(Id: part.ContentItem.Id, MasterId: masterId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Published))),
-                ContentShape("Parts_Localization_ContentTranslations_SummaryAdmin", () => {
-                    var siteCultures = _cultureManager.ListCultures();
-
-                    return shapeHelper.Parts_Localization_ContentTranslations_SummaryAdmin(Id: part.ContentItem.Id, MasterId: masterId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Latest), SiteCultures: siteCultures);
-                })
-                );
+            return masterId;
         }
 
         protected override DriverResult Editor(LocalizationPart part, dynamic shapeHelper) {
@@ -45,7 +50,7 @@ namespace Orchard.Localization.Drivers {
 
             var masterContentItem = _contentManager.Get(part.Record.MasterContentItemId, VersionOptions.Latest);
 
-            var missingCultures = part.HasTranslationGroup && masterContentItem != null?
+            var missingCultures = part.HasTranslationGroup && masterContentItem != null ?
                 RetrieveMissingCultures(masterContentItem.As<LocalizationPart>(), true) :
                 RetrieveMissingCultures(part, part.Culture != null);
 

--- a/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
@@ -23,7 +23,10 @@ namespace Orchard.Localization.Drivers {
             var masterId = part.HasTranslationGroup
                                ? part.Record.MasterContentItemId
                                : part.Id;
-
+            if (_contentManager.Get(masterId, VersionOptions.Latest) == null) {
+                //the original MasterContentItem has been deleted
+                masterId = part.Id;
+            }
             return Combined(
                 ContentShape("Parts_Localization_ContentTranslations",
                              () => shapeHelper.Parts_Localization_ContentTranslations(Id: part.ContentItem.Id, MasterId: masterId, Culture: GetCulture(part), Localizations: GetDisplayLocalizations(part, VersionOptions.Published))),
@@ -48,7 +51,7 @@ namespace Orchard.Localization.Drivers {
                 SelectedCulture = GetCulture(part),
                 MissingCultures = missingCultures,
                 ContentItem = part,
-                MasterContentItem = part.HasTranslationGroup ? part.MasterContentItem : null,
+                MasterContentItem = _contentManager.Get(part.Record.MasterContentItemId, VersionOptions.Latest),//part.HasTranslationGroup ? part.MasterContentItem : null,
                 ContentLocalizations = new ContentLocalizationsViewModel(part) { Localizations = localizations }
             };
 

--- a/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
@@ -43,15 +43,17 @@ namespace Orchard.Localization.Drivers {
         protected override DriverResult Editor(LocalizationPart part, dynamic shapeHelper) {
             var localizations = GetEditorLocalizations(part).ToList();
 
-            var missingCultures = part.HasTranslationGroup ?
-                RetrieveMissingCultures(part.MasterContentItem.As<LocalizationPart>(), true) :
+            var masterContentItem = _contentManager.Get(part.Record.MasterContentItemId, VersionOptions.Latest);
+
+            var missingCultures = part.HasTranslationGroup && masterContentItem != null?
+                RetrieveMissingCultures(masterContentItem.As<LocalizationPart>(), true) :
                 RetrieveMissingCultures(part, part.Culture != null);
 
             var model = new EditLocalizationViewModel {
                 SelectedCulture = GetCulture(part),
                 MissingCultures = missingCultures,
                 ContentItem = part,
-                MasterContentItem = _contentManager.Get(part.Record.MasterContentItemId, VersionOptions.Latest),//part.HasTranslationGroup ? part.MasterContentItem : null,
+                MasterContentItem = masterContentItem,
                 ContentLocalizations = new ContentLocalizationsViewModel(part) { Localizations = localizations }
             };
 
@@ -72,7 +74,7 @@ namespace Orchard.Localization.Drivers {
         }
 
         private List<string> RetrieveMissingCultures(LocalizationPart part, bool excludePartCulture) {
-            var editorLocalizations = GetEditorLocalizations(part);
+            var editorLocalizations = GetEditorLocalizations(part.MasterContentItem != null ? part.MasterContentItem.As<LocalizationPart>() : part);
 
             var cultures = _cultureManager
                 .ListCultures()

--- a/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
@@ -1,4 +1,5 @@
 ﻿@model Orchard.Localization.ViewModels.EditLocalizationViewModel
+@using Orchard.ContentManagement
 @using System.Globalization
 @{
     Style.Require("LocalizationAdmin");
@@ -51,7 +52,8 @@
                 }
 
                 if (Model.MissingCultures.Any()) {
-                    var contentItemId = Model.MasterContentItem != null ? Model.MasterContentItem.Id : Model.ContentItem.Id;
+                    var masterContentItem = WorkContext.Resolve<IContentManager>().Get(((dynamic)Model.ContentItem).Record.MasterContentItemId, VersionOptions.Latest);
+                    var contentItemId = masterContentItem != null ? masterContentItem.Id : Model.ContentItem.Id;
 
                     <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new {area = "Orchard.Localization", id = contentItemId}, null)</div>
                 }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
@@ -1,5 +1,4 @@
 ﻿@model Orchard.Localization.ViewModels.EditLocalizationViewModel
-@using Orchard.ContentManagement
 @using System.Globalization
 @{
     Style.Require("LocalizationAdmin");
@@ -52,8 +51,7 @@
                 }
 
                 if (Model.MissingCultures.Any()) {
-                    var masterContentItem = WorkContext.Resolve<IContentManager>().Get(((dynamic)Model.ContentItem).Record.MasterContentItemId, VersionOptions.Latest);
-                    var contentItemId = masterContentItem != null ? masterContentItem.Id : Model.ContentItem.Id;
+                    var contentItemId = Model.MasterContentItem != null ? Model.MasterContentItem.Id : Model.ContentItem.Id;
 
                     <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new {area = "Orchard.Localization", id = contentItemId}, null)</div>
                 }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Views/Parts/Localization.ContentTranslations.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Views/Parts/Localization.ContentTranslations.SummaryAdmin.cshtml
@@ -16,7 +16,7 @@ var localizationLinks = Html.UnorderedList(localizations, (c, i) => Html.ItemEdi
     }
     @if (Model.Culture != null && !((IEnumerable<string>)Model.SiteCultures).All(c => c == Model.Culture || localizations.Any(l => c == l.Culture.Culture)))
     {
-    <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new { area = "Orchard.Localization", id = Model.Id }, null)</div>
+    <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new { area = "Orchard.Localization", id = Model.MasterId }, null)</div>
     }
 </div>
 }

--- a/src/Rebracer.xml
+++ b/src/Rebracer.xml
@@ -22,7 +22,7 @@
     </ToolsOptionsCategory>
     <ToolsOptionsCategory name="TextEditor">
       <ToolsOptionsSubCategory name="CSharp-Specific">
-        <PropertyValue name="AddImport_SuggestForTypesInNuGetPackages">0</PropertyValue>
+        <PropertyValue name="AddImport_SuggestForTypesInNuGetPackages">1</PropertyValue>
         <PropertyValue name="AddImport_SuggestForTypesInReferenceAssemblies">1</PropertyValue>
         <PropertyValue name="AutoComment">1</PropertyValue>
         <PropertyValue name="AutoInsertAsteriskForNewLinesOfBlockComments">1</PropertyValue>
@@ -141,10 +141,10 @@
         <PropertyValue name="EnableExpandPrecedence">false</PropertyValue>
         <PropertyValue name="EnableExpandScopes">false</PropertyValue>
         <PropertyValue name="EnableExtractFunction">false</PropertyValue>
-        <PropertyValue name="EnableSQLiteStoreEngine">false</PropertyValue>
+        <PropertyValue name="EnableSQLiteStoreEngine">true</PropertyValue>
         <PropertyValue name="EnableSingleFileISense">true</PropertyValue>
         <PropertyValue name="EnableSingleFileISenseSquiggles">false</PropertyValue>
-        <PropertyValue name="EnumerateCommentTasks">false</PropertyValue>
+        <PropertyValue name="EnumerateCommentTasks">true</PropertyValue>
         <PropertyValue name="GroupBrackets">true</PropertyValue>
         <PropertyValue name="HideExperimentalAd">true</PropertyValue>
         <PropertyValue name="HighlightMatchingTokens">true</PropertyValue>

--- a/src/Rebracer.xml
+++ b/src/Rebracer.xml
@@ -23,7 +23,7 @@
     <ToolsOptionsCategory name="TextEditor">
       <ToolsOptionsSubCategory name="CSharp-Specific">
         <PropertyValue name="AddImport_SuggestForTypesInNuGetPackages">0</PropertyValue>
-        <PropertyValue name="AddImport_SuggestForTypesInReferenceAssemblies">0</PropertyValue>
+        <PropertyValue name="AddImport_SuggestForTypesInReferenceAssemblies">1</PropertyValue>
         <PropertyValue name="AutoComment">1</PropertyValue>
         <PropertyValue name="AutoInsertAsteriskForNewLinesOfBlockComments">1</PropertyValue>
         <PropertyValue name="CSharpClosedFileDiagnostics">-1</PropertyValue>


### PR DESCRIPTION
This change should prevent the creation of culture duplicates that was caused by having a different "New 
Translation" link between the two views.

fixes #7348