### PR TITLE
Fix the error of ScheduledTaskExecutor

### DIFF
--- a/src/Orchard.Web/Core/Scheduling/Services/ScheduledTaskExecutor.cs
+++ b/src/Orchard.Web/Core/Scheduling/Services/ScheduledTaskExecutor.cs
@@ -54,6 +54,9 @@ namespace Orchard.Core.Scheduling.Services {
                     // removing record first helps avoid concurrent execution
                     _repository.Delete(taskRecord);
 
+                    // persisting the change so it takes effect in the other async operations
+                    _repository.Flush();
+
                     var context = new ScheduledTaskContext {
                         Task = new Task(_contentManager, taskRecord)
                     };


### PR DESCRIPTION
In heavy load on TaskExecutor, not persisting the deleted task causes the following error on MySql database

Unexpected row count: 0; expected: 1
   at NHibernate.Linq.DefaultQueryProvider.ExecuteQuery(NhLinqExpression nhLinqExpression, IQuery query, NhLinqExpression nhQuery)
   at NHibernate.Linq.DefaultQueryProvider.Execute(Expression expression)
   at NHibernate.Linq.DefaultQueryProvider.Execute[TResult](Expression expression)
   at S22.IMAP.Handlers.IMAPClientTaskHandler.ScheduleNextTask(DateTime date)
   at S22.IMAP.Handlers.IMAPClientTaskHandler.Process(ScheduledTaskContext context)
