### PR TITLE
Fix #7552 Avoid deleting terms twice when deleting a taxonomy

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/ITaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/ITaxonomyService.cs
@@ -41,6 +41,7 @@ namespace Orchard.Taxonomies.Services {
 
 
         IEnumerable<TermPart> GetTerms(int taxonomyId);
+        IEnumerable<TermPart> GetRootTerms(int taxonomyId);
         int GetTermsCount(int taxonomyId);
         TermPart GetTerm(int id);
         TermPart GetTermByName(int taxonomyId, string name);

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -117,7 +117,7 @@ namespace Orchard.Taxonomies.Services {
             _contentManager.Remove(taxonomy.ContentItem);
 
             // Removing terms
-            foreach (var term in GetTerms(taxonomy.Id)) {
+            foreach (var term in GetRootTerms(taxonomy.Id)) {
                 DeleteTerm(term);
             }
 
@@ -166,6 +166,14 @@ namespace Orchard.Taxonomies.Services {
         public IEnumerable<TermPart> GetTerms(int taxonomyId) {
             var result = _contentManager.Query<TermPart, TermPartRecord>()
                 .Where(x => x.TaxonomyId == taxonomyId)
+                .List();
+
+            return TermPart.Sort(result);
+        }
+
+        public IEnumerable<TermPart> GetRootTerms(int taxonomyId) {
+            var result = _contentManager.Query<TermPart, TermPartRecord>()
+                .Where(x => x.TaxonomyId == taxonomyId && x.Path == "/")
                 .List();
 
             return TermPart.Sort(result);


### PR DESCRIPTION
Avoid deleting terms twice just getting the root terms on DeleteTaxonomy method

#7552