### PR TITLE
Fix the bug in representing recipe description in Setup

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Setup/Controllers/SetupController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Setup/Controllers/SetupController.cs
@@ -46,11 +46,11 @@ namespace Orchard.Setup.Controllers {
 
         public ActionResult Index() {
             var initialSettings = _setupService.Prime();
-            var recipes = _setupService.Recipes().ToList();
+            var recipes = _setupService.Recipes().OrderBy(c => c.Name).ToList();
             string recipeDescription = null;
 
             if (recipes.Any()) {
-                recipeDescription = recipes[0].Description;
+                recipeDescription = recipes.First().Description;
             }
 
             // On the first time installation of Orchard, the user gets to the setup screen, which


### PR DESCRIPTION
Previously, it picked the description of the first recipe. The problem is
in the View, the recipes will be sorted based on the name resulted in picking up a
wrong description by controller in case recipes are not sorted by default.