### PR TITLE
Allow Feature Prefix override in TableDbName

### DIFF
--- a/src/Orchard/Data/Migration/Schema/SchemaBuilder.cs
+++ b/src/Orchard/Data/Migration/Schema/SchemaBuilder.cs
@@ -33,8 +33,8 @@ namespace Orchard.Data.Migration.Schema {
         /// <summary>
         /// Translate Table name into database table name - including prefixes.
         /// </summary>
-        public virtual string TableDbName(string srcTable) {
-            return _interpreter.PrefixTableName(String.Concat(FormatPrefix(FeaturePrefix), srcTable));
+        public virtual string TableDbName(string srcTable, string FeaturePrefixOverride = null) {
+            return _interpreter.PrefixTableName(String.Concat(FormatPrefix(FeaturePrefixOverride??FeaturePrefix), srcTable));
         }
 
         /// <summary>

--- a/src/Orchard/Data/Migration/Schema/SchemaBuilder.cs
+++ b/src/Orchard/Data/Migration/Schema/SchemaBuilder.cs
@@ -33,8 +33,8 @@ namespace Orchard.Data.Migration.Schema {
         /// <summary>
         /// Translate Table name into database table name - including prefixes.
         /// </summary>
-        public virtual string TableDbName(string srcTable, string FeaturePrefixOverride = null) {
-            return _interpreter.PrefixTableName(String.Concat(FormatPrefix(FeaturePrefixOverride??FeaturePrefix), srcTable));
+        public virtual string TableDbName(string srcTable, string featurePrefixOverride = null) {
+            return _interpreter.PrefixTableName(FormatPrefix(featurePrefixOverride ?? FeaturePrefix) + srcTable);
         }
 
         /// <summary>


### PR DESCRIPTION
Schema builder can be used with tables from more than one feature.  In this case, it assumes the "current" feature prefix for all tables, which will be incorrect for some tables.  Allow a manual override of the feature prefix in these cases.  

For example:
public int UpdateFrom18()
        {
            string productPartRecordTableName = SchemaBuilder.TableDbName(nameof(ProductPartRecord));
            string contentItemVersionRecordTableName = SchemaBuilder.TableDbName(nameof(ContentItemVersionRecord), "Orchard_Framework");
...
}