### PR TITLE
7638: C# 5 compatibility for Orchard.Glimpse

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Glimpse/ADO/GlimpseDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/ADO/GlimpseDriver.cs
@@ -52,8 +52,8 @@ namespace Orchard.Glimpse.ADO {
             _decoratedService.AdjustCommand(command);
         }
 
-        public bool SupportsMultipleOpenReaders => _decoratedService.SupportsMultipleOpenReaders;
+        public bool SupportsMultipleOpenReaders { get { return _decoratedService.SupportsMultipleOpenReaders; } }
 
-        public bool SupportsMultipleQueries => _decoratedService.SupportsMultipleQueries;
+        public bool SupportsMultipleQueries { get { return _decoratedService.SupportsMultipleQueries; } }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/AlternateImplementation/GlimpseCacheServiceDecorator.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/AlternateImplementation/GlimpseCacheServiceDecorator.cs
@@ -23,7 +23,7 @@ namespace Orchard.Glimpse.AlternateImplementation {
                     Key = key,
                     Result = r == null ? "Miss" : "Hit",
                     Value = r
-                }, TimelineCategories.Cache, r => $"Get ({(r == null ? "Miss" : "Hit")})", r => key).ActionResult;
+                }, TimelineCategories.Cache, r => string.Format("Get ({0})", (r == null ? "Miss" : "Hit")), r => key).ActionResult;
         }
 
         public void Put<T>(string key, T value) {

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/AlternateImplementation/GlimpseContentManagerDecorator.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/AlternateImplementation/GlimpseContentManagerDecorator.cs
@@ -177,7 +177,7 @@ namespace Orchard.Glimpse.AlternateImplementation {
                 return "Unknown content type.";
             }
 
-            return options.VersionRecordId == 0 ? $"Content item: {id} is not published." : "Unknown content type.";
+            return options.VersionRecordId == 0 ? string.Format("Content item: {0} is not published.", id): "Unknown content type.";
         }
 
         public void CompleteImport(XElement element, ImportContentSession importContentSession) {

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/AlternateImplementation/GlimpseWidgetContentManagerDecorator.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/AlternateImplementation/GlimpseWidgetContentManagerDecorator.cs
@@ -161,7 +161,7 @@ namespace Orchard.Glimpse.AlternateImplementation {
                     TechnicalName = widgetPart.Name,
                     EditUrl = GlimpseHelpers.AppendReturnUrl(_urlHelper.ItemAdminUrl(content), _urlHelper),
                     Duration = t.Duration
-                }, TimelineCategories.Widgets, $"Build Display: {widgetPart.ContentItem.ContentType}", widgetPart.Title).ActionResult;
+                }, TimelineCategories.Widgets, string.Format("Build Display: {0}", widgetPart.ContentItem.ContentType), widgetPart.Title).ActionResult;
         }
 
         public dynamic BuildEditor(IContent content, string groupId = "") {

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Extensions/TabSectionExtensions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Extensions/TabSectionExtensions.cs
@@ -15,7 +15,7 @@ namespace Orchard.Glimpse.Extensions {
             var row = section.AddRow();
 
             var itemCount = messages.Count();
-            row.Column($"{itemCount} item{(itemCount == 1 ? "" : "s")}");
+            row.Column(string.Format("{0} item{1}", itemCount, (itemCount == 1 ? "" : "s")));
 
             for (int i = 0; i < columnCount - 3; i++) {
                 row.Column("");

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Extensions/TimespanExtensions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Extensions/TimespanExtensions.cs
@@ -8,7 +8,7 @@ namespace Orchard.Glimpse.Extensions {
         }
 
         public static string ToTimingString(this double milliseconds) {
-            return $"{milliseconds:0,0.00} ms";
+            return string.Format("{0} ms", milliseconds.ToString("0,0.00"));
         }
 
         public static string ToReadableString(this TimeSpan span) {
@@ -23,7 +23,7 @@ namespace Orchard.Glimpse.Extensions {
         }
 
         private static string GetTimeSpanSegment(int value, string unit) {
-            return value > 0 ? $"{value:0} {unit}{(value == 1 ? string.Empty : "s")}" : null;
+            return value > 0 ? string.Format("{0} {1}{2}", value.ToString("0"), unit, (value == 1 ? string.Empty : "s")) : null;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/GlimpseExtensions/WhitelistedIpAddressesSecurityPolicy.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/GlimpseExtensions/WhitelistedIpAddressesSecurityPolicy.cs
@@ -18,6 +18,6 @@ namespace Orchard.Glimpse.GlimpseExtensions {
             return whitelistedIpAddresses.Contains(request.UserHostAddress) ? RuntimePolicy.On : RuntimePolicy.Off;
         }
 
-        public RuntimeEvent ExecuteOn => RuntimeEvent.EndRequest | RuntimeEvent.ExecuteResource;
+        public RuntimeEvent ExecuteOn { get { return RuntimeEvent.EndRequest | RuntimeEvent.ExecuteResource; } }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Models/GlimpseDriverResult.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Models/GlimpseDriverResult.cs
@@ -12,8 +12,8 @@ namespace Orchard.Glimpse.Models {
             _glimpseService = glimpseService;
             OriginalDriverResult = originalDriverResult;
 
-            ContentField = originalDriverResult?.ContentField;
-            ContentPart = originalDriverResult?.ContentPart;
+            ContentField = originalDriverResult == null ? null : originalDriverResult.ContentField;
+            ContentPart = originalDriverResult == null ? null : originalDriverResult.ContentPart;
         }
         public DriverResult OriginalDriverResult { get; set; }
 
@@ -23,7 +23,7 @@ namespace Orchard.Glimpse.Models {
                 ContentName = context.ContentItem.GetContentName(),
                 ContentType = context.ContentItem.ContentType,
                 DisplayType = context.DisplayType,
-                PartDefinition = context.ContentPart?.PartDefinition,
+                PartDefinition = context.ContentPart == null ? null : context.ContentPart.PartDefinition,
                 Duration = t.Duration
             }, TimelineCategories.Parts, "Display Part: " + (ContentPart == null ? context.ContentItem.ContentType : ContentPart.PartDefinition.Name), context.ContentItem.GetContentName());
         }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Orchard.Glimpse.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Orchard.Glimpse.csproj
@@ -36,6 +36,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\..\..\OrchardBasicCorrectness.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -46,6 +47,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Services/DefaultGlimpseService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Services/DefaultGlimpseService.cs
@@ -123,19 +123,31 @@ namespace Orchard.Glimpse.Services {
 
             _messageInterceptors.Invoke(i => i.MessageReceived(message), Logger);
 
-            broker?.Publish(message);
+            if (broker != null) broker.Publish(message);
         }
 
         private IExecutionTimer GetTimer() {
             var context = HttpContext.Current;
 
-            return ((GlimpseRuntime) context?.Application.Get("__GlimpseRuntime"))?.Configuration.TimerStrategy.Invoke();
+            if (context != null) {
+                GlimpseRuntime glimpseRuntime = (GlimpseRuntime)context.Application.Get("__GlimpseRuntime");
+
+                if (glimpseRuntime != null) return glimpseRuntime.Configuration.TimerStrategy.Invoke();
+            }
+
+            return null;
         }
 
         private IMessageBroker GetMessageBroker() {
             var context = HttpContext.Current;
 
-            return ((GlimpseRuntime) context?.Application.Get("__GlimpseRuntime"))?.Configuration.MessageBroker;
+            if (context != null) {
+                GlimpseRuntime glimpseRuntime = (GlimpseRuntime)context.Application.Get("__GlimpseRuntime");
+
+                if (glimpseRuntime != null) return glimpseRuntime.Configuration.MessageBroker;
+            }
+
+            return null;
         }
     }
 

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Authorizer/AuthorizerMessagesConverter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Authorizer/AuthorizerMessagesConverter.cs
@@ -7,12 +7,16 @@ namespace Orchard.Glimpse.Tabs.Authorizer {
     public class AuthorizerMessagesConverter : SerializationConverter<IEnumerable<AuthorizerMessage>> {
         public override object Convert(IEnumerable<AuthorizerMessage> messages) {
             var root = new TabSection("Permission", "Content Id", "Content Type", "Content Name", "User Is Authorized?", "Message", "Time Taken");
+            bool hasContent;
+
             foreach (var message in messages) {
+                hasContent = message.Content != null;
+
                 root.AddRow()
                     .Column(message.Permission)
-                    .Column(message.Content?.Id.ToString())
-                    .Column(message.Content?.ContentItem.ContentType)
-                    .Column(message.Content?.ContentItem.GetContentName())
+                    .Column(hasContent ? message.Content.Id.ToString() : null)
+                    .Column(hasContent ? message.Content.ContentItem.ContentType : null)
+                    .Column(hasContent ? message.Content.ContentItem.GetContentName() : null)
                     .Column(message.Result ? "Yes" : "No")
                     .Column(message.Result ? null : message.Message)
                     .Column(message.Duration.ToTimingString());

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Authorizer/AuthorizerTab.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Authorizer/AuthorizerTab.cs
@@ -14,14 +14,14 @@ namespace Orchard.Glimpse.Tabs.Authorizer {
             return messages;
         }
 
-        public override string Name => "Authorizer";
+        public override string Name { get { return "Authorizer"; } }
 
         public void Setup(ITabSetupContext context) {
             context.PersistMessages<AuthorizerMessage>();
         }
 
-        public string Key => "glimpse_orchard_authorizer";
+        public string Key { get { return "glimpse_orchard_authorizer"; } }
 
-        public bool KeysHeadings => false;
+        public bool KeysHeadings { get { return false; } }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Cache/CacheMessagesConverter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Cache/CacheMessagesConverter.cs
@@ -10,7 +10,7 @@ namespace Orchard.Glimpse.Tabs.Cache {
             foreach (var message in messages) {
                 root.AddRow()
                     .Column(message.Action)
-                    .Column(message.ValidFor?.ToReadableString())
+                    .Column(message.ValidFor == null ? null : message.ValidFor.Value.ToReadableString())
                     .Column(message.Key)
                     .Column(message.Result)
                     .Column(message.Value)

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Cache/CacheTab.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Cache/CacheTab.cs
@@ -14,14 +14,14 @@ namespace Orchard.Glimpse.Tabs.Cache {
             return messages;
         }
 
-        public override string Name => "Cache Service";
+        public override string Name { get { return "Cache Service"; } }
 
         public void Setup(ITabSetupContext context) {
             context.PersistMessages<CacheMessage>();
         }
 
-        public string Key => "glimpse_orchard_cache";
+        public string Key { get { return "glimpse_orchard_cache"; } }
 
-        public bool KeysHeadings => false;
+        public bool KeysHeadings { get { return false; } }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/ContentManager/ContentManagerTab.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/ContentManager/ContentManagerTab.cs
@@ -14,14 +14,14 @@ namespace Orchard.Glimpse.Tabs.ContentManager {
             return messages;
         }
 
-        public override string Name => "Content Manager";
+        public override string Name { get { return "Content Manager"; } }
 
         public void Setup(ITabSetupContext context) {
             context.PersistMessages<ContentManagerGetMessage>();
         }
 
-        public string Key => "glimpse_orchard_contentmanager";
+        public string Key { get { return "glimpse_orchard_contentmanager"; } }
 
-        public bool KeysHeadings => false;
+        public bool KeysHeadings { get { return false; } }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Layers/LayerTab.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Layers/LayerTab.cs
@@ -14,12 +14,12 @@ namespace Orchard.Glimpse.Tabs.Layers {
             return messages;
         }
 
-        public override string Name => "Layers";
+        public override string Name { get { return "Layers"; } }
 
         public void Setup(ITabSetupContext context) {
             context.PersistMessages<LayerMessage>();
         }
 
-        public string Key => "glimpse_orchard_layers";
+        public string Key { get { return "glimpse_orchard_layers"; } }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Parts/PartMessagesConverter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Parts/PartMessagesConverter.cs
@@ -13,7 +13,7 @@ namespace Orchard.Glimpse.Tabs.Parts {
                     .Column(message.ContentId)
                     .Column(message.ContentName)
                     .Column(message.ContentType.CamelFriendly())
-                    .Column(message.PartDefinition?.Name.CamelFriendly())
+                    .Column(message.PartDefinition == null ? null : message.PartDefinition.Name.CamelFriendly())
                     .Column(message.DisplayType)
                     .Column(message.Duration.ToTimingString());
             }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Parts/PartTab.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Parts/PartTab.cs
@@ -14,12 +14,12 @@ namespace Orchard.Glimpse.Tabs.Parts {
             return messages;
         }
 
-        public override string Name => "Parts";
+        public override string Name { get { return "Parts"; } }
 
         public void Setup(ITabSetupContext context) {
             context.PersistMessages<PartMessage>();
         }
 
-        public string Key => "glimpse_orchard_parts";
+        public string Key { get { return "glimpse_orchard_parts"; } }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Shapes/ShapesMessage.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Shapes/ShapesMessage.cs
@@ -16,21 +16,21 @@ namespace Orchard.Glimpse.Tabs.Shapes {
         public string BindingName { get; set; }
         public string BindingSource { get; set; }
 
-        public string Type => _metaData.Type;
+        public string Type { get { return _metaData.Type; } }
 
-        public string DisplayType => _metaData.DisplayType;
+        public string DisplayType { get { return _metaData.DisplayType; } }
 
-        public string Position => _metaData.Position;
+        public string Position { get { return _metaData.Position; } }
 
-        public string PlacementSource => _metaData.PlacementSource;
+        public string PlacementSource { get { return _metaData.PlacementSource; } }
 
-        public string Prefix => _metaData.Prefix;
+        public string Prefix { get { return _metaData.Prefix; } }
 
-        public IList<string> Wrappers => _metaData.Wrappers.Any() ? _metaData.Wrappers : null;
+        public IList<string> Wrappers { get { return _metaData.Wrappers.Any() ? _metaData.Wrappers : null; } }
 
-        public IList<string> Alternates => _metaData.Alternates.Any() ? _metaData.Alternates : null;
+        public IList<string> Alternates { get { return _metaData.Alternates.Any() ? _metaData.Alternates : null; } }
 
-        public IList<string> BindingSources => _metaData.BindingSources.Any() ? _metaData.BindingSources : null;
+        public IList<string> BindingSources { get { return _metaData.BindingSources.Any() ? _metaData.BindingSources : null; } }
 
         public TimeSpan Duration { get; set; }
     }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Shapes/ShapesTab.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Shapes/ShapesTab.cs
@@ -14,14 +14,14 @@ namespace Orchard.Glimpse.Tabs.Shapes {
             return messages;
         }
 
-        public override string Name => "Shapes";
+        public override string Name { get { return "Shapes"; } }
 
         public void Setup(ITabSetupContext context) {
             context.PersistMessages<ShapeMessage>();
         }
 
-        public string Key => "glimpse_orchard_shapes";
+        public string Key { get { return "glimpse_orchard_shapes"; } }
 
-        public bool KeysHeadings => false;
+        public bool KeysHeadings { get { return false; } }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Widgets/WidgetTab.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Tabs/Widgets/WidgetTab.cs
@@ -14,12 +14,12 @@ namespace Orchard.Glimpse.Tabs.Widgets {
             return messages;
         }
 
-        public override string Name => "Widgets";
+        public override string Name { get { return "Widgets"; } }
 
         public void Setup(ITabSetupContext context) {
             context.PersistMessages<WidgetMessage>();
         }
 
-        public string Key => "glimpse_orchard_widgets";
+        public string Key { get { return "glimpse_orchard_widgets"; } }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/TimelineCategories.cs
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/TimelineCategories.cs
@@ -2,12 +2,12 @@
 
 namespace Orchard.Glimpse {
     public class TimelineCategories {
-        public static TimelineCategoryItem Cache => new TimelineCategoryItem("Cache", "#154B87", "#154B87");
-        public static TimelineCategoryItem Layers => new TimelineCategoryItem("Layers", "#E6261D", "#E6261D");
-        public static TimelineCategoryItem Parts => new TimelineCategoryItem("Parts", "#169871", "#169871");
-        public static TimelineCategoryItem ContentManager => new TimelineCategoryItem("Content Manager", "#603182", "#603182");
-        public static TimelineCategoryItem Shapes => new TimelineCategoryItem("Shapes", "#bcbb27", "#bcbb27");
-        public static TimelineCategoryItem Authorizer => new TimelineCategoryItem("Authorizer", "#da7520", "#da7520");
-        public static TimelineCategoryItem Widgets => new TimelineCategoryItem("Widgets", "#84DCC6", "#84DCC6");
+        public static TimelineCategoryItem Cache { get { return new TimelineCategoryItem("Cache", "#154B87", "#154B87"); } }
+        public static TimelineCategoryItem Layers { get { return new TimelineCategoryItem("Layers", "#E6261D", "#E6261D"); } }
+        public static TimelineCategoryItem Parts { get { return new TimelineCategoryItem("Parts", "#169871", "#169871"); } }
+        public static TimelineCategoryItem ContentManager { get { return new TimelineCategoryItem("Content Manager", "#603182", "#603182"); } }
+        public static TimelineCategoryItem Shapes { get { return new TimelineCategoryItem("Shapes", "#bcbb27", "#bcbb27"); } }
+        public static TimelineCategoryItem Authorizer { get { return new TimelineCategoryItem("Authorizer", "#da7520", "#da7520"); } }
+        public static TimelineCategoryItem Widgets { get { return new TimelineCategoryItem("Widgets", "#84DCC6", "#84DCC6"); } }
     }
 }


### PR DESCRIPTION
Adding LangVersion 5 to Orchard.Glimpse.csproj and removing C# 6 code from the Glimpse module, fixes #7638