### PR TITLE
Adds LifecycleStatus to Feature Descriptor

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Modules/Views/Admin/Features.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Modules/Views/Admin/Features.cshtml
@@ -71,7 +71,7 @@
                     continue;
                 }
                 //hmmm...I feel like I've done this before...
-                var lifecycleStatus = feature.Descriptor.Extension.LifecycleStatus;
+                var lifecycleStatus = feature.Descriptor.LifecycleStatus;
                 var featureId = feature.Descriptor.Id.AsFeatureId(n => T(n));
                 var featureName = string.IsNullOrEmpty(feature.Descriptor.Name) ? feature.Descriptor.Id : feature.Descriptor.Name;
                 var featureState = feature.IsEnabled ? "enabled" : "disabled";

--- a/src/Orchard/Environment/Extensions/Folders/ExtensionHarvester.cs
+++ b/src/Orchard/Environment/Extensions/Folders/ExtensionHarvester.cs
@@ -247,7 +247,8 @@ namespace Orchard.Environment.Extensions.Folders {
                 Description = GetValue(manifest, FeatureDescriptionSection) ?? GetValue(manifest, DescriptionSection) ?? string.Empty,
                 Dependencies = ParseFeatureDependenciesEntry(GetValue(manifest, DependenciesSection)),
                 Extension = extensionDescriptor,
-                Category = GetValue(manifest, CategorySection)
+                Category = GetValue(manifest, CategorySection),
+                LifecycleStatus = GetValue(manifest, LifecycleStatusSection, extensionDescriptor.LifecycleStatus)
             };
 
             featureDescriptors.Add(defaultFeature);
@@ -306,6 +307,12 @@ namespace Orchard.Environment.Extensions.Folders {
                                         break;
                                     case DependenciesSection:
                                         featureDescriptor.Dependencies = ParseFeatureDependenciesEntry(featureField[1]);
+                                        break;
+                                    case LifecycleStatusSection:
+                                        LifecycleStatus lifecycleStatus;
+                                        featureDescriptor.LifecycleStatus = Enum.TryParse(featureField[1], out lifecycleStatus)
+                                            ? lifecycleStatus
+                                            : extensionDescriptor.LifecycleStatus;
                                         break;
                                 }
                             }

--- a/src/Orchard/Environment/Extensions/Models/FeatureDescriptor.cs
+++ b/src/Orchard/Environment/Extensions/Models/FeatureDescriptor.cs
@@ -5,6 +5,7 @@ namespace Orchard.Environment.Extensions.Models {
     public class FeatureDescriptor {
         public FeatureDescriptor() {
             Dependencies = Enumerable.Empty<string>();
+            LifecycleStatus = LifecycleStatus.Production;
         }
 
         public ExtensionDescriptor Extension { get; set; }
@@ -14,6 +15,7 @@ namespace Orchard.Environment.Extensions.Models {
         public string Description { get; set; }
         public string Category { get; set; }
         public int Priority { get; set; }
+        public LifecycleStatus LifecycleStatus { get; set; }
         public IEnumerable<string> Dependencies { get; set; }
     }
 }


### PR DESCRIPTION
We hit a use case were we are starting to deprecate certain features contained within modules, although that module is not deprecated that feature is, Found out that a feature contained inside a module can not use the LifecycleStatus to show that it is deprecated on the frontend.

This adds LifecycleStatus to the feature descriptor class so that a feature can now have its own LifecycleStatus, if one is not set it will default to the Extension LifecycleStatus (like it currently does)