### PR TITLE
Log error when Recipient emailMessage.Recipients is null

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Email/Services/SmtpMessageChannel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Services/SmtpMessageChannel.cs
@@ -57,7 +57,7 @@ namespace Orchard.Email.Services {
                 Attachments = (IEnumerable<string>)(parameters.ContainsKey("Attachments") ? parameters["Attachments"] : new List<string>())
             };
 
-            if (emailMessage.Recipients.Length == 0) {
+            if (string.IsNullOrWhiteSpace(emailMessage.Recipients) || emailMessage.Recipients.Length == 0) {
                 Logger.Error("Email message doesn't have any recipient");
                 return;
             }

--- a/src/Orchard.Web/Modules/Orchard.Email/Services/SmtpMessageChannel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Services/SmtpMessageChannel.cs
@@ -57,7 +57,7 @@ namespace Orchard.Email.Services {
                 Attachments = (IEnumerable<string>)(parameters.ContainsKey("Attachments") ? parameters["Attachments"] : new List<string>())
             };
 
-            if (string.IsNullOrWhiteSpace(emailMessage.Recipients) || emailMessage.Recipients.Length == 0) {
+            if (string.IsNullOrWhiteSpace(emailMessage.Recipients)) {
                 Logger.Error("Email message doesn't have any recipient");
                 return;
             }


### PR DESCRIPTION
When emailMessage.Recipients is null throws so the error is being logged by Orchard.Exceptions instead by the logger in this condition.
Repro steps:
Create a workflow that sends emails when a custom type has been created. 
Attach an email activity when this type has been created and dont fill it.