### PR TITLE
Update CreateDescribeContext to query latest content

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Controllers/ElementController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Controllers/ElementController.cs
@@ -151,7 +151,7 @@ namespace Orchard.Layouts.Controllers {
             if (contentId == null && contentType == null)
                 return DescribeElementsContext.Empty;
 
-            var part = contentId != null && contentId != 0 ? _contentManager.Get<ILayoutAspect>(contentId.Value)
+            var part = contentId != null && contentId != 0 ? _contentManager.Get<ILayoutAspect>(contentId.Value, VersionOptions.Latest)
                 ?? _contentManager.New<ILayoutAspect>(contentType)
                 : _contentManager.New<ILayoutAspect>(contentType);
 


### PR DESCRIPTION
Fixes #7686 , where the ElementDriver.OnDisplaying ElementDisplayingContext.Content not being populated properly when the content item is saved, but not yet published. Instead of query the content only for the published version, use the latest version instead.