### PR TITLE
Improved performance of queries adding indexes

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
@@ -239,6 +239,19 @@ namespace Orchard.Projections {
                 DisplayName = T("Body Part Text").Text,
                 Description = T("The text from the Body part").Text
             });
+            
+            SchemaBuilder.AlterTable("StringFieldIndexRecord", table => table
+                .CreateIndex("IDX_Orchard_Projections_StringFieldIndexRecord", "FieldIndexPartRecord_Id")
+            );
+            SchemaBuilder.AlterTable("IntegerFieldIndexRecord", table => table
+                .CreateIndex("IDX_Orchard_Projections_IntegerFieldIndexRecord", "FieldIndexPartRecord_Id")
+            );
+            SchemaBuilder.AlterTable("DoubleFieldIndexRecord", table => table
+                .CreateIndex("IDX_Orchard_Projections_DoubleFieldIndexRecord", "FieldIndexPartRecord_Id")
+            );
+            SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table
+                .CreateIndex("IDX_Orchard_Projections_DecimalFieldIndexRecords", "FieldIndexPartRecord_Id")
+            );
 
             return 1;
         }


### PR DESCRIPTION
I have added indexes on creation migration, when db is empty, cause for existing sites these créate index opertations could lead to timeout exceptions when there is existing data to be indexed. It was what happened to us in a 30 multitennt environment with a number of queries per tenant. So, it would be a task for the site administrator to add those indexes directly to the db by hand.