### PR TITLE
#7055 changes taxonomy weight

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
@@ -49,7 +49,7 @@ namespace Orchard.Taxonomies.Controllers {
             var allTerms = _taxonomyService.GetTermsQuery(taxonomyId).OrderBy(x => x.FullWeight);
             var termsPage = pager.PageSize > 0 ? allTerms.Slice(pager.GetStartIndex(), pager.PageSize) : allTerms.Slice(0, 0);
 
-            var pagerShape = Shape.Pager(pager).TotalItemCount(termsPage.Count());
+            var pagerShape = Shape.Pager(pager).TotalItemCount(allTerms.Count());
 
             var entries = termsPage
                     .Select(term => term.CreateTermEntry())

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
@@ -46,11 +46,10 @@ namespace Orchard.Taxonomies.Controllers {
 
             var taxonomy = _taxonomyService.GetTaxonomy(taxonomyId);
 
-            var allTerms = TermPart.Sort(_taxonomyService.GetTermsQuery(taxonomyId).List());
+            var allTerms = _taxonomyService.GetTermsQuery(taxonomyId).OrderBy(x => x.FullWeight);
+            var termsPage = pager.PageSize > 0 ? allTerms.Slice(pager.GetStartIndex(), pager.PageSize) : allTerms.Slice(0, 0);
 
-            var termsPage = pager.PageSize > 0 ? allTerms.Skip(pager.GetStartIndex()).Take(pager.PageSize) : allTerms;
-
-            var pagerShape = Shape.Pager(pager).TotalItemCount(allTerms.Count());
+            var pagerShape = Shape.Pager(pager).TotalItemCount(termsPage.Count());
 
             var entries = termsPage
                     .Select(term => term.CreateTermEntry())

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
@@ -89,7 +89,9 @@ namespace Orchard.Taxonomies.Controllers {
 
                     foreach (var entry in checkedEntries) {
                         var term = _taxonomyService.GetTerm(entry.Id);
-                        _taxonomyService.DeleteTerm(term);
+                        if (term != null) {
+                            _taxonomyService.DeleteTerm(term);
+                        }
                     }
 
                     Services.Notifier.Information(T.Plural("{0} term has been removed.", "{0} terms have been removed.", checkedEntries.Count));

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TermPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TermPartDriver.cs
@@ -96,19 +96,20 @@ namespace Orchard.Taxonomies.Drivers {
         protected override DriverResult Editor(TermPart termPart, IUpdateModel updater, dynamic shapeHelper) {
             updater.TryUpdateModel(termPart, Prefix, null, null);
             StringBuilder fullWeightBuilder = new StringBuilder();
-            string parentOldFullWeight = termPart.FullWeight == null?termPart.FullWeight: "";
+            string parentOldFullWeight = termPart.FullWeight == null ? termPart.FullWeight : "";
             TermPart containerTerm = termPart;
 
             for (int i = 0; i < termPart.Path.Count(x => x == '/') - 1; i++) {
                 containerTerm = containerTerm.Container.As<TermPart>();
-                fullWeightBuilder.Insert(0, "/" + containerTerm.Weight.ToString("D6"));
+                fullWeightBuilder.Insert(0, containerTerm.Weight.ToString("D6") + "." + containerTerm.Id.ToString() + "/");
             }
-
-            foreach(var childTerm in _taxonomyService.GetChildren(termPart)) {
-                childTerm.FullWeight = _taxonomyService.ProcessChildrenFullWeight(childTerm.FullWeight, termPart.FullWeight, parentOldFullWeight);
-            }
+            fullWeightBuilder.Append(termPart.Weight.ToString("D6") + "." + "/");
 
             termPart.FullWeight = fullWeightBuilder.ToString();
+
+            foreach (var childTerm in _taxonomyService.GetChildren(termPart)) {
+                childTerm.FullWeight = _taxonomyService.ProcessChildrenFullWeight(childTerm.FullWeight, termPart.FullWeight, parentOldFullWeight);
+            }
 
             return Editor(termPart, shapeHelper);
         }
@@ -162,11 +163,11 @@ namespace Orchard.Taxonomies.Drivers {
                 var pathContentItem = context.GetItemFromSession(identityPath);
                 part.Path += pathContentItem.Id + "/";
                 if (createFullWeigth) {
-                    part.FullWeight = part.FullWeight + pathContentItem.As<TermPart>().Weight.ToString("D6") + "/";
+                    part.FullWeight = part.FullWeight + pathContentItem.As<TermPart>().Weight.ToString("D6") + "." + pathContentItem.Id.ToString() + "/";
                 }
             }
             if (createFullWeigth) {
-                part.FullWeight = part.FullWeight + part.Weight.ToString("D6") + "/";
+                part.FullWeight = part.FullWeight + part.Weight.ToString("D6") + "." + part.Id + "/";
             }
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TermPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TermPartDriver.cs
@@ -96,10 +96,16 @@ namespace Orchard.Taxonomies.Drivers {
         protected override DriverResult Editor(TermPart termPart, IUpdateModel updater, dynamic shapeHelper) {
             updater.TryUpdateModel(termPart, Prefix, null, null);
             StringBuilder fullWeightBuilder = new StringBuilder();
+            string parentOldFullWeight = termPart.FullWeight == null?termPart.FullWeight: "";
             TermPart containerTerm = termPart;
+
             for (int i = 0; i < termPart.Path.Count(x => x == '/') - 1; i++) {
                 containerTerm = containerTerm.Container.As<TermPart>();
                 fullWeightBuilder.Insert(0, "/" + containerTerm.Weight.ToString("D6"));
+            }
+
+            foreach(var childTerm in _taxonomyService.GetChildren(termPart)) {
+                childTerm.FullWeight = _taxonomyService.ProcessChildrenFullWeight(childTerm.FullWeight, termPart.FullWeight, parentOldFullWeight);
             }
 
             termPart.FullWeight = fullWeightBuilder.ToString();

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TermPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/TermPartDriver.cs
@@ -13,6 +13,7 @@ using Orchard.Mvc;
 using Orchard.Settings;
 using Orchard.Taxonomies.Settings;
 using Orchard.UI.Navigation;
+using System.Text;
 
 namespace Orchard.Taxonomies.Drivers {
     public class TermPartDriver : ContentPartDriver<TermPart> {
@@ -93,7 +94,15 @@ namespace Orchard.Taxonomies.Drivers {
         }
 
         protected override DriverResult Editor(TermPart termPart, IUpdateModel updater, dynamic shapeHelper) {
-            //Moved to TermPartHandler to work also with Taxonomy Localization feature
+            updater.TryUpdateModel(termPart, Prefix, null, null);
+            StringBuilder fullWeightBuilder = new StringBuilder();
+            TermPart containerTerm = termPart;
+            for (int i = 0; i < termPart.Path.Count(x => x == '/') - 1; i++) {
+                containerTerm = containerTerm.Container.As<TermPart>();
+                fullWeightBuilder.Insert(0, "/" + containerTerm.Weight.ToString("D6"));
+            }
+
+            termPart.FullWeight = fullWeightBuilder.ToString();
 
             return Editor(termPart, shapeHelper);
         }
@@ -102,6 +111,7 @@ namespace Orchard.Taxonomies.Drivers {
             context.Element(part.PartDefinition.Name).SetAttributeValue("Count", part.Count);
             context.Element(part.PartDefinition.Name).SetAttributeValue("Selectable", part.Selectable);
             context.Element(part.PartDefinition.Name).SetAttributeValue("Weight", part.Weight);
+            context.Element(part.PartDefinition.Name).SetAttributeValue("FullWeight", part.FullWeight);
 
             var taxonomy = _contentManager.Get(part.TaxonomyId);
             var identity = _contentManager.GetItemMetadata(taxonomy).Identity.ToString();
@@ -129,6 +139,8 @@ namespace Orchard.Taxonomies.Drivers {
             part.Count = Int32.Parse(context.Attribute(part.PartDefinition.Name, "Count"));
             part.Selectable = Boolean.Parse(context.Attribute(part.PartDefinition.Name, "Selectable"));
             part.Weight = Int32.Parse(context.Attribute(part.PartDefinition.Name, "Weight"));
+            context.ImportAttribute(part.PartDefinition.Name, "FullWeight", s => part.FullWeight = s);
+            bool createFullWeigth = string.IsNullOrWhiteSpace(part.FullWeight);
 
             var identity = context.Attribute(part.PartDefinition.Name, "TaxonomyId");
             var contentItem = context.GetItemFromSession(identity);
@@ -143,6 +155,12 @@ namespace Orchard.Taxonomies.Drivers {
             foreach (var identityPath in context.Attribute(part.PartDefinition.Name, "Path").Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)) {
                 var pathContentItem = context.GetItemFromSession(identityPath);
                 part.Path += pathContentItem.Id + "/";
+                if (createFullWeigth) {
+                    part.FullWeight = part.FullWeight + pathContentItem.As<TermPart>().Weight.ToString("D6") + "/";
+                }
+            }
+            if (createFullWeigth) {
+                part.FullWeight = part.FullWeight + part.Weight.ToString("D6") + "/";
             }
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Migrations.cs
@@ -102,9 +102,10 @@ namespace Orchard.Taxonomies {
             return 7;
         }
         public int UpdateFrom7() {
-            SchemaBuilder.AlterTable("TermPartRecord", table => table
-                .AddColumn("FullWeight", DbType.String)
-            );
+            SchemaBuilder.AlterTable("TermPartRecord", table => {
+                table.AddColumn("FullWeight", DbType.String);
+                table.CreateIndex("IDX_FullWeight", "FullWeight");
+            });
             return 8;
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Migrations.cs
@@ -1,5 +1,5 @@
-﻿using System.Data;
-using Orchard.ContentManagement.MetaData;
+﻿using Orchard.ContentManagement.MetaData;
+using System.Data;
 using Orchard.Data.Migration;
 
 namespace Orchard.Taxonomies {

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Migrations.cs
@@ -1,4 +1,5 @@
-﻿using Orchard.ContentManagement.MetaData;
+﻿using System.Data;
+using Orchard.ContentManagement.MetaData;
 using Orchard.Data.Migration;
 
 namespace Orchard.Taxonomies {
@@ -99,6 +100,12 @@ namespace Orchard.Taxonomies {
                 .CreateIndex("IDX_TermsPartRecord_id_Field", "TermsPartRecord_id", "Field")
             );
             return 7;
+        }
+        public int UpdateFrom7() {
+            SchemaBuilder.AlterTable("TermPartRecord", table => table
+                .AddColumn("FullWeight", DbType.String)
+            );
+            return 8;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
@@ -51,6 +51,11 @@ namespace Orchard.Taxonomies.Models {
             set { Store(x => x.Weight, value); }
         }
 
+        public string FullWeight {
+            get { return Retrieve(x => x.FullWeight,""); }
+            set { Store(x => x.FullWeight, value); }
+        }
+
         public string FullPath { get { return String.Concat(Path, Id); } }
 
         public static IEnumerable<TermPart> Sort(IEnumerable<TermPart> terms) {

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
@@ -64,6 +64,7 @@ namespace Orchard.Taxonomies.Models {
             return list.OrderBy(x => x, new TermsComparer(index));
         }
 
+        [Obsolete]
         private class TermsComparer : IComparer<TermPart> {
             private readonly IDictionary<string, TermPart> _index;
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
@@ -52,8 +52,8 @@ namespace Orchard.Taxonomies.Models {
         }
 
         public string FullWeight {
-            get { return Retrieve(x => x.FullWeight,""); }
-            set { Store(x => x.FullWeight, value); }
+            get { return Record.FullWeight; }
+            set { Record.FullWeight = value; }
         }
 
         public string FullPath { get { return String.Concat(Path, Id); } }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPartRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPartRecord.cs
@@ -9,5 +9,6 @@ namespace Orchard.Taxonomies.Models {
         public virtual int Count { get; set; }
         public virtual bool Selectable { get; set; }
         public virtual int Weight { get; set; }
+        public virtual string FullWeight { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Orchard.Taxonomies.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Orchard.Taxonomies.csproj
@@ -64,6 +64,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/ITaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/ITaxonomyService.cs
@@ -48,6 +48,8 @@ namespace Orchard.Taxonomies.Services {
         void DeleteTerm(TermPart termPart);
         void MoveTerm(TaxonomyPart taxonomy, TermPart term, TermPart parentTerm);
         void ProcessPath(TermPart term);
+        string ProcessChildrenFullWeight(string childrenFullWeight, string parentFullWeight, string parentOldFullWeight);
+
         IContentQuery<TermPart, TermPartRecord> GetTermsQuery(int taxonomyId);
 
         string GenerateTermTypeName(string taxonomyName);

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/ITaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/ITaxonomyService.cs
@@ -48,6 +48,7 @@ namespace Orchard.Taxonomies.Services {
         void DeleteTerm(TermPart termPart);
         void MoveTerm(TaxonomyPart taxonomy, TermPart term, TermPart parentTerm);
         void ProcessPath(TermPart term);
+        void ProcessFullWeight(TermPart term, TermPart parentTerm);
         string ProcessChildrenFullWeight(string childrenFullWeight, string parentFullWeight, string parentOldFullWeight);
 
         IContentQuery<TermPart, TermPartRecord> GetTermsQuery(int taxonomyId);

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -382,6 +382,9 @@ namespace Orchard.Taxonomies.Services {
         }
 
         public string ProcessChildrenFullWeight(string childrenFullWeight, string parentFullWeight, string parentOldFullWeight) {
+            if (string.IsNullOrWhiteSpace(childrenFullWeight)){
+                childrenFullWeight = parentFullWeight;
+            }
             int pos = childrenFullWeight.IndexOf(parentOldFullWeight);
 
             return childrenFullWeight.Substring(0, pos) + parentFullWeight + childrenFullWeight.Substring(pos + parentOldFullWeight.Length);

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -381,7 +381,7 @@ namespace Orchard.Taxonomies.Services {
         }
 
         public void ProcessFullWeight(TermPart term, TermPart parentTerm) {
-            term.FullWeight = (parentTerm != null ? parentTerm.FullWeight : "") + term.Weight.ToString("D6") + "/";
+            term.FullWeight = (parentTerm != null ? parentTerm.FullWeight : "") + term.Weight.ToString("D6") + "." + term.Id + "/";
         }
 
         public string ProcessChildrenFullWeight(string childrenFullWeight, string parentFullWeight, string parentOldFullWeight) {

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -176,6 +176,7 @@ namespace Orchard.Taxonomies.Services {
         public IEnumerable<TermPart> GetRootTerms(int taxonomyId) {
             var result = _contentManager.Query<TermPart, TermPartRecord>()
                 .Where(x => x.TaxonomyId == taxonomyId && x.Path == "/")
+                .OrderBy(x => x.FullWeight)
                 .List();
 
             return result;

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyServiceDraftable.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyServiceDraftable.cs
@@ -97,9 +97,10 @@ namespace Orchard.Taxonomies.Services {
         new public IEnumerable<TermPart> GetTerms(int taxonomyId) {
             var result = _contentManager.Query<TermPart, TermPartRecord>().ForVersion(VersionOptions.Latest)
                 .Where(x => x.TaxonomyId == taxonomyId)
+                .OrderBy(x=>x.FullWeight)
                 .List();
 
-            return TermPart.Sort(result);
+            return result;
         }
 
         new public TermPart GetTermByPath(string path) {
@@ -113,8 +114,10 @@ namespace Orchard.Taxonomies.Services {
         new public IEnumerable<TermPart> GetAllTerms() {
             var result = _contentManager
                 .Query<TermPart, TermPartRecord>().ForVersion(VersionOptions.Latest)
+                .OrderBy(x=>x.TaxonomyId)
+                .OrderBy(x=>x.FullWeight)
                 .List();
-            return TermPart.Sort(result);
+            return result;
         }
 
         new public TermPart GetTerm(int id) {

--- a/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Web.Mvc;
 using Orchard;
+using Orchard.ContentManagement;
 using Orchard.Environment.Features;
 using Orchard.Localization;
 using Orchard.Logging;
 using Orchard.Security;
+using Orchard.Taxonomies.Models;
+using Orchard.Taxonomies.Services;
 using Orchard.UI.Admin;
 using Orchard.UI.Notify;
 using Upgrade.Services;
@@ -15,24 +19,27 @@ namespace Upgrade.Controllers {
     public class TaxonomyController : Controller {
         private readonly IUpgradeService _upgradeService;
         private readonly IOrchardServices _orchardServices;
+        private readonly ITaxonomyService _taxonomyService;
         private readonly IFeatureManager _featureManager;
 
         public TaxonomyController(
             IUpgradeService upgradeService,
             IOrchardServices orchardServices,
-            IFeatureManager featureManager) {
+            IFeatureManager featureManager,
+            ITaxonomyService taxonomyService) {
             _upgradeService = upgradeService;
             _orchardServices = orchardServices;
             _featureManager = featureManager;
+            _taxonomyService = taxonomyService;
         }
 
         public Localizer T { get; set; }
         public ILogger Logger { get; set; }
 
         public ActionResult Index() {
-            ViewBag.CanMigrate = false; 
+            ViewBag.CanMigrate = false;
 
-            if(_featureManager.GetEnabledFeatures().All(x => x.Id != "Orchard.Taxonomies")) {
+            if (_featureManager.GetEnabledFeatures().All(x => x.Id != "Orchard.Taxonomies")) {
                 _orchardServices.Notifier.Warning(T("You need to enable Orchard.Taxonomies in order to migrate Contrib.Taxonomies to Orchard.Taxonomies."));
             }
             else {
@@ -45,7 +52,7 @@ namespace Upgrade.Controllers {
                     _orchardServices.Notifier.Warning(T("This migration step might have been done already."));
                 }
 
-                ViewBag.CanMigrate = true; 
+                ViewBag.CanMigrate = true;
             }
 
             return View();
@@ -57,13 +64,13 @@ namespace Upgrade.Controllers {
                 return new HttpUnauthorizedResult();
             try {
                 _upgradeService.CopyTable("Contrib_Taxonomies_TaxonomyPartRecord", "Orchard_Taxonomies_TaxonomyPartRecord", new string[0]);
-                _upgradeService.CopyTable("Contrib_Taxonomies_TermContentItem", "Orchard_Taxonomies_TermContentItem", new[] {"Id"});
+                _upgradeService.CopyTable("Contrib_Taxonomies_TermContentItem", "Orchard_Taxonomies_TermContentItem", new[] { "Id" });
                 _upgradeService.CopyTable("Contrib_Taxonomies_TermPartRecord", "Orchard_Taxonomies_TermPartRecord", new string[0]);
                 _upgradeService.CopyTable("Contrib_Taxonomies_TermsPartRecord", "Orchard_Taxonomies_TermsPartRecord", new string[0]);
 
                 _orchardServices.Notifier.Success(T("Taxonomies were migrated successfully."));
             }
-            catch(Exception e) {
+            catch (Exception e) {
                 Logger.Error(e, "Unexpected error while migrating to Orchard.Taxonomies. Please check the log.");
                 _orchardServices.Notifier.Error(T("Unexpected error while migrating to Orchard.Taxonomies. Please check the log."));
 
@@ -71,5 +78,21 @@ namespace Upgrade.Controllers {
 
             return RedirectToAction("Index");
         }
+
+        [HttpPost]
+        public ActionResult MigrateTerms() {
+            foreach (var taxonomy in _taxonomyService.GetTaxonomies()) {
+                foreach (var term in _taxonomyService.GetTerms(taxonomy.Id)) {
+                    term.FullWeight = "";
+                    for (int i = 0; i < term.Path.Count(x => x == '/')-1; i++) {
+                        var container = term.Container.As<TermPart>();
+                        term.FullWeight = container.Weight.ToString("D6") + "/" + term.FullWeight;
+                    }
+                    term.FullWeight = term.FullWeight + term.Weight.ToString("D6") + "/";
+                }
+            }
+            return new HttpStatusCodeResult(HttpStatusCode.OK);
+        }
+
     }
 }

--- a/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
@@ -64,13 +64,13 @@ namespace Upgrade.Controllers {
                 return new HttpUnauthorizedResult();
             try {
                 _upgradeService.CopyTable("Contrib_Taxonomies_TaxonomyPartRecord", "Orchard_Taxonomies_TaxonomyPartRecord", new string[0]);
-                _upgradeService.CopyTable("Contrib_Taxonomies_TermContentItem", "Orchard_Taxonomies_TermContentItem", new[] { "Id" });
+                _upgradeService.CopyTable("Contrib_Taxonomies_TermContentItem", "Orchard_Taxonomies_TermContentItem", new[] {"Id"});
                 _upgradeService.CopyTable("Contrib_Taxonomies_TermPartRecord", "Orchard_Taxonomies_TermPartRecord", new string[0]);
                 _upgradeService.CopyTable("Contrib_Taxonomies_TermsPartRecord", "Orchard_Taxonomies_TermsPartRecord", new string[0]);
 
                 _orchardServices.Notifier.Success(T("Taxonomies were migrated successfully."));
             }
-            catch (Exception e) {
+            catch(Exception e) {
                 Logger.Error(e, "Unexpected error while migrating to Orchard.Taxonomies. Please check the log.");
                 _orchardServices.Notifier.Error(T("Unexpected error while migrating to Orchard.Taxonomies. Please check the log."));
 

--- a/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
@@ -80,7 +80,8 @@ namespace Upgrade.Controllers {
         }
 
         [HttpPost]
-        public ActionResult MigrateTerms() {
+        public JsonResult MigrateTerms(int id) {
+            var lastContentItemId = id;
             foreach (var taxonomy in _taxonomyService.GetTaxonomies()) {
                 foreach (var term in _taxonomyService.GetTerms(taxonomy.Id)) {
                     term.FullWeight = "";
@@ -89,9 +90,10 @@ namespace Upgrade.Controllers {
                         term.FullWeight = container.Weight.ToString("D6") + "/" + term.FullWeight;
                     }
                     term.FullWeight = term.FullWeight + term.Weight.ToString("D6") + "/";
+                    lastContentItemId = term.Id;
                 }
             }
-            return new HttpStatusCodeResult(HttpStatusCode.OK);
+            return new JsonResult { Data = lastContentItemId };
         }
 
     }

--- a/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
@@ -83,13 +83,14 @@ namespace Upgrade.Controllers {
         public JsonResult MigrateTerms(int id) {
             var lastContentItemId = id;
             foreach (var taxonomy in _taxonomyService.GetTaxonomies()) {
-                foreach (var term in _taxonomyService.GetTerms(taxonomy.Id)) {
+                foreach (var term in TermPart.Sort(_taxonomyService.GetTerms(taxonomy.Id))) {
                     term.FullWeight = "";
+                    var container = term.Container.As<TermPart>();
                     for (int i = 0; i < term.Path.Count(x => x == '/')-1; i++) {
-                        var container = term.Container.As<TermPart>();
-                        term.FullWeight = container.Weight.ToString("D6") + "/" + term.FullWeight;
+                        term.FullWeight = container.Weight.ToString("D6") + "." + container.Id + "/" + term.FullWeight;
+                        container = container.Container.As<TermPart>();
                     }
-                    term.FullWeight = term.FullWeight + term.Weight.ToString("D6") + "/";
+                    term.FullWeight = term.FullWeight + term.Weight.ToString("D6") + "." + term.Id + "/";
                     lastContentItemId = term.Id;
                 }
             }

--- a/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
@@ -39,7 +39,7 @@ namespace Upgrade.Controllers {
         public ActionResult Index() {
             ViewBag.CanMigrate = false;
 
-            if (_featureManager.GetEnabledFeatures().All(x => x.Id != "Orchard.Taxonomies")) {
+            if(_featureManager.GetEnabledFeatures().All(x => x.Id != "Orchard.Taxonomies")) {
                 _orchardServices.Notifier.Warning(T("You need to enable Orchard.Taxonomies in order to migrate Contrib.Taxonomies to Orchard.Taxonomies."));
             }
             else {

--- a/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
+++ b/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
@@ -146,6 +146,10 @@
       <Project>{73a7688a-5bd3-4f7e-adfa-ce36c5a10e3b}</Project>
       <Name>Orchard.MediaLibrary</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Orchard.Taxonomies\Orchard.Taxonomies.csproj">
+      <Project>{E649EA64-D213-461B-87F7-D67035801443}</Project>
+      <Name>Orchard.Taxonomies</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Orchard.Widgets\Orchard.Widgets.csproj">
       <Project>{194d3ccc-1153-474d-8176-fde8d7d0d0bd}</Project>
       <Name>Orchard.Widgets</Name>

--- a/src/Orchard.Web/Modules/Upgrade/Views/Taxonomy/Index.cshtml
+++ b/src/Orchard.Web/Modules/Upgrade/Views/Taxonomy/Index.cshtml
@@ -1,6 +1,11 @@
 ﻿@using Orchard.Utility.Extensions
 
-@{ Layout.Title = T("Migrate Taxonomies").ToString(); }
+@{ 
+    Script.Require("jQuery");
+    Layout.Title = T("Migrate Taxonomies").ToString(); 
+}
+
+<div class="message message-Warning" id="message-progress" style="display: none"></div>
 
 @using (Html.BeginFormAntiForgeryPost()) {
     Html.ValidationSummary();
@@ -9,9 +14,49 @@
         <span class="hint">@T("This migration step will convert the Contrib.Taxonomies content items to Orchard.Taxonomies.")</span>
         <span class="hint">@T("If you had any Term Widget instance, you will have to replace them with Projection Queries.")</span>
     </fieldset>
+
     <fieldset>
         @if (ViewBag.CanMigrate) {
             <button type="submit">@T("Migrate")</button>
         }
     </fieldset>
+}
+
+<fieldset>
+    <legend>@T("Migrating Terms: ")</legend>
+    <span class="hint">@T("This migration step will update all existing terms so they are lexicographically orderable")</span>
+    <button type="button" class="button button-migrate" data-url="@Url.Action("MigrateTerms", "Taxonomy")">@T("Migrate")</button>
+</fieldset>
+
+@using (Script.Foot()) {
+    <script type="text/javascript">
+        $(function() {
+            var antiForgeryToken = '@HttpUtility.JavaScriptStringEncode(Html.AntiForgeryTokenValueOrchard().ToString())';     
+            var endMessage = '@HttpUtility.JavaScriptStringEncode(T("All terms have been processed").Text)';
+            $('.button-migrate').click(function () {
+                var importUrl = $(this).data('url');
+
+                $('#message-progress').show();
+                var iId = setInterval(function () {
+
+                    $.ajax({
+                        type: 'POST',
+                        url: importUrl,
+                        async: false,
+                        data: {
+                            __RequestVerificationToken: antiForgeryToken
+                        },
+                        success: function () {
+                            $('#message-progress').text(endMessage);
+                        },
+                        fail: function(result) {
+                            console.log("An error occured: " + result);
+                        }
+                    });
+
+                }, 100);
+                
+            });
+        });
+    </script>
 }

--- a/src/Orchard.Web/Modules/Upgrade/Views/Taxonomy/Index.cshtml
+++ b/src/Orchard.Web/Modules/Upgrade/Views/Taxonomy/Index.cshtml
@@ -14,7 +14,6 @@
         <span class="hint">@T("This migration step will convert the Contrib.Taxonomies content items to Orchard.Taxonomies.")</span>
         <span class="hint">@T("If you had any Term Widget instance, you will have to replace them with Projection Queries.")</span>
     </fieldset>
-
     <fieldset>
         @if (ViewBag.CanMigrate) {
             <button type="submit">@T("Migrate")</button>

--- a/src/Orchard.Web/Modules/Upgrade/Views/Taxonomy/Index.cshtml
+++ b/src/Orchard.Web/Modules/Upgrade/Views/Taxonomy/Index.cshtml
@@ -36,6 +36,7 @@
             $('.button-migrate').click(function () {
                 var importUrl = $(this).data('url');
 
+                var startId = 0;
                 $('#message-progress').show();
                 var iId = setInterval(function () {
 
@@ -44,10 +45,18 @@
                         url: importUrl,
                         async: false,
                         data: {
-                            __RequestVerificationToken: antiForgeryToken
+                            __RequestVerificationToken: antiForgeryToken,
+                            id: startId // start at index 0
                         },
-                        success: function () {
-                            $('#message-progress').text(endMessage);
+                        success: function (data) {
+                            if (Number(data) == startId) {
+                                clearInterval(iId);
+                                $('#message-progress').text(endMessage);
+                            }
+                            else {
+                                startId = Number(data);
+                                $('#message-progress').text('Processing content item ' + startId);
+                            }
                         },
                         fail: function(result) {
                             console.log("An error occured: " + result);


### PR DESCRIPTION
This purposed changes add a new property with the full weight of a term(FullWeight) which is made using his weight and id and his parent's weight and id. This way we can lexicographically sort the terms via this property using simple sql and avoid algorithmic logic to sort them. 

The terms update his FullWeight property whenever they are updated in the controller or the driver(including his children terms).Also they can be updated to use this new functionality importing all of them in the Import method using an 'old' recipe or migrating them in the Orchard.Upgrade module if they exist already.