### PR TITLE
Sets snippet field properties on blueprint (fixes #7431)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Providers/BlueprintElementHarvester.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Providers/BlueprintElementHarvester.cs
@@ -64,6 +64,10 @@ namespace Orchard.Layouts.Providers {
             foreach (var driver in drivers) {
                 driver.Displaying(context);
             }
+
+            if (element.Descriptor.Displaying != null) {
+                element.Descriptor.Displaying(context);
+            }
         }
     }
 }


### PR DESCRIPTION
Generally, it allows rendering blueprint elements using a Descriptor Displaying event, which snippet element does.