### PR TITLE
Added locks to autoroute service

### DIFF
--- a/src/Orchard.Web/Config/Sites.config
+++ b/src/Orchard.Web/Config/Sites.config
@@ -24,7 +24,7 @@
                 Isolation level for all database transaction. 
                 See http://msdn.microsoft.com/en-us/library/system.transactions.isolationlevel.aspx 
             -->
-            
+            <!--
             <component instance-scope="per-lifetime-scope"
                        type="Orchard.Data.TransactionManager, Orchard.Framework"
                        service="Orchard.Data.ITransactionManager">
@@ -32,7 +32,7 @@
                     <property name="IsolationLevel" value="ReadUncommitted" />
                 </properties>
             </component>
-            
+            -->
 
             <!-- 
                 Delay between background services executions

--- a/src/Orchard.Web/Config/Sites.config
+++ b/src/Orchard.Web/Config/Sites.config
@@ -24,7 +24,7 @@
                 Isolation level for all database transaction. 
                 See http://msdn.microsoft.com/en-us/library/system.transactions.isolationlevel.aspx 
             -->
-            <!--
+            
             <component instance-scope="per-lifetime-scope"
                        type="Orchard.Data.TransactionManager, Orchard.Framework"
                        service="Orchard.Data.ITransactionManager">
@@ -32,7 +32,7 @@
                     <property name="IsolationLevel" value="ReadUncommitted" />
                 </properties>
             </component>
-            -->
+            
 
             <!-- 
                 Delay between background services executions

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Services/AutorouteService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Services/AutorouteService.cs
@@ -13,6 +13,7 @@ using Orchard.Localization.Services;
 using Orchard.Mvc;
 using System.Web;
 using Orchard.ContentManagement.Aspects;
+using System.Collections.Concurrent;
 
 namespace Orchard.Autoroute.Services {
     public class AutorouteService : Component, IAutorouteService {
@@ -25,6 +26,8 @@ namespace Orchard.Autoroute.Services {
         private readonly ICultureManager _cultureManager;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private const string AliasSource = "Autoroute:View";
+
+        private readonly ConcurrentDictionary<string, List<int>> _displayAliasVersions;
 
         public AutorouteService(
             IAliasService aliasService,
@@ -42,6 +45,8 @@ namespace Orchard.Autoroute.Services {
             _routeEvents = routeEvents;
             _cultureManager = cultureManager;
             _httpContextAccessor = httpContextAccessor;
+
+            _displayAliasVersions = new ConcurrentDictionary<string, List<int>>();
         }
 
         public string GenerateAlias(AutoroutePart part) {
@@ -206,22 +211,37 @@ namespace Orchard.Autoroute.Services {
         }
 
         public bool ProcessPath(AutoroutePart part) {
-            var pathsLikeThis = GetSimilarPaths(part.Path).ToArray();
+            bool returnValue = true;
+            
+            var baseAlias = GenerateAlias(part);
 
-            // Don't include *this* part in the list
-            // of slugs to consider for conflict detection.
-            pathsLikeThis = pathsLikeThis.Where(p => p.ContentItem.Id != part.ContentItem.Id).ToArray();
-
-            if (pathsLikeThis.Any()) {
-                var originalPath = part.Path;
-                var newPath = GenerateUniqueSlug(part, pathsLikeThis.Select(p => p.Path));
-                part.DisplayAlias = newPath;
-
-                if (originalPath != newPath)
-                    return false;
+            lock (_displayAliasVersions) {
+                if (_displayAliasVersions.TryAdd(baseAlias, new List<int>())) {
+                    //we had not searched for this path yet
+                    //get the versions out of the db
+                    _displayAliasVersions[baseAlias].AddRange(
+                        GetSimilarPaths(baseAlias)
+                        .Select(ap => new Tuple<int, int?>(ap.ContentItem.Id, GetSlugVersion(baseAlias, ap.Path)))
+                        .Where(tup => tup.Item2.HasValue)
+                        .OrderBy(tup => tup.Item2) //ascending
+                        .Select(tup => tup.Item1) //get the Ids
+                    );
+                }
+                if (_displayAliasVersions[baseAlias].Count == 0) {
+                    _displayAliasVersions[baseAlias].Add(part.ContentItem.Id); //first ever part with this Alias
+                    returnValue = true;
+                }
+                else if (_displayAliasVersions[baseAlias].Contains(part.ContentItem.Id)) {
+                    //this part has already been processed
+                    returnValue = true;
+                }
+                else {
+                    _displayAliasVersions[baseAlias].Add(part.ContentItem.Id);
+                    part.DisplayAlias = string.Format("{0}-{1}", baseAlias, _displayAliasVersions[baseAlias].Count);
+                    returnValue = false;
+                }
             }
-
-            return true;
+            return returnValue;
         }
 
         private SettingsDictionary GetTypePartSettings(string contentType) {


### PR DESCRIPTION
This should fix #7720 
I tested the code on my machine, with both ReadUncommited enabled and disabled.

By my tests, it allows correct concurrency in creating/updating AutoroutePart. I tried this by creating pages all with the same title, as well as by creating them with different titles. 
In the latter case, the parts do not lock each other out of the second part of the ProcessPath method.

I would like someone to test this and confirm my results, as I am not experienced enough to be 100% confident about this solution.

Any comment and review are appreciated.