### PR TITLE
Adds support to LocalizationStreamParser for po entrys spanning multiple lines

### DIFF
--- a/src/Orchard/Localization/Services/LocalizationStreamParser.cs
+++ b/src/Orchard/Localization/Services/LocalizationStreamParser.cs
@@ -1,8 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Orchard.Logging;
 
 namespace Orchard.Localization.Services {
     
@@ -14,59 +13,94 @@ namespace Orchard.Localization.Services {
             { 't', '\t' }
         };
 
-        public LocalizationStreamParser() {
-            Logger = NullLogger.Instance;
-        }
-
-        public ILogger Logger { get; private set; }
+        private const string HashtagScope = "#:";
+        private const string MsgctxtScope = "msgctxt";
+        private const string MsgidScope = "msgid";
+        private const string MsgstrScope = "msgstr";
 
         public void ParseLocalizationStream(string text, IDictionary<string, string> translations, bool merge) {
             var reader = new StringReader(text);
-            string poLine;
             var scopes = new List<string>();
             var id = string.Empty;
+            var activeScope = string.Empty;
 
-            while ((poLine = reader.ReadLine()) != null) {
-                if (poLine.StartsWith("#:")) {
-                    scopes.Add(ParseScope(poLine));
-                    continue;
+            string currentPoLine = reader.ReadLine() ?? "";
+
+            do
+            {
+                if (currentPoLine.StartsWith(HashtagScope))
+                {
+                    currentPoLine = Parse(HashtagScope, currentPoLine);
+                    activeScope = HashtagScope;
+                }
+                else if (currentPoLine.StartsWith(MsgctxtScope))
+                {
+                    currentPoLine = Parse(MsgctxtScope, currentPoLine);
+                    activeScope = MsgctxtScope;
+                }
+                else if (currentPoLine.StartsWith(MsgidScope))
+                {
+                    currentPoLine = Parse(MsgidScope, currentPoLine);
+                    activeScope = MsgidScope;
+                }
+                else if (currentPoLine.StartsWith(MsgstrScope))
+                {
+                    currentPoLine = Parse(MsgstrScope, currentPoLine);
+                    activeScope = MsgstrScope;
                 }
 
-                if (poLine.StartsWith("msgctxt")) {
-                    scopes.Add(ParseContext(poLine));
-                    continue;
+                string nextPoLine = reader.ReadLine() ?? "";
+
+                while (nextPoLine != null && (!nextPoLine.StartsWith("#") && !nextPoLine.StartsWith(MsgctxtScope) &&
+                                              !nextPoLine.StartsWith(MsgidScope) && !nextPoLine.StartsWith(MsgstrScope)))
+                {
+                    currentPoLine = string.Concat(currentPoLine, TrimQuote(nextPoLine));
+                    nextPoLine = reader.ReadLine();
                 }
 
-                if (poLine.StartsWith("msgid")) {
-                    id = ParseId(poLine);
-                    continue;
-                }
+                switch (activeScope)
+                {
+                    case HashtagScope:
+                    case MsgctxtScope:
+                        scopes.Add(currentPoLine);
+                        break;
 
-                if (poLine.StartsWith("msgstr")) {
-                    var translation = ParseTranslation(poLine);
-                    // ignore incomplete localizations (empty msgid or msgstr)
-                    if (!string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(translation)) {
-                        if(scopes.Count == 0) {
-                            scopes.Add(string.Empty);
-                        }
-                        foreach (var scope in scopes) {
-                            var scopedKey = (scope + "|" + id).ToLowerInvariant();
-                            if (!translations.ContainsKey(scopedKey)) {
-                                translations.Add(scopedKey, translation);
+                    case MsgidScope:
+                        id = currentPoLine;
+                        break;
+
+                    case MsgstrScope:
+                        if (!string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(currentPoLine))
+                        {
+                            if (scopes.Count == 0)
+                            {
+                                scopes.Add(string.Empty);
                             }
-                            else {
-                                if (merge) {
-                                    translations[scopedKey] = translation;
+                            foreach (var scope in scopes)
+                            {
+                                var scopedKey = (scope + "|" + id).ToLowerInvariant();
+                                if (!translations.ContainsKey(scopedKey))
+                                {
+                                    translations.Add(scopedKey, currentPoLine);
+                                }
+                                else
+                                {
+                                    if (merge)
+                                    {
+                                        translations[scopedKey] = currentPoLine;
+                                    }
                                 }
                             }
                         }
-                    }
 
-                    id = string.Empty;
-                    scopes = new List<string>();
+                        id = string.Empty;
+                        scopes = new List<string>();
+                        break;
                 }
 
-            }
+                currentPoLine = nextPoLine;
+                activeScope = string.Empty;
+            } while (currentPoLine != null);
         }
 
         private static string Unescape(string str) {
@@ -103,34 +137,17 @@ namespace Orchard.Localization.Services {
             return sb == null ? str : sb.ToString();
         }
 
-        private string TrimQuote(string str) {
+        private static string TrimQuote(string str) {
             if (str.StartsWith("\"") && str.EndsWith("\"")) {
-                if (str.Length == 1) {
-                    // Handle corner case - string containing single quote
-                    Logger.Warning("Invalid localization string detected: " + str);
-                    return "";
-                }
-
                 return str.Substring(1, str.Length - 2);
             }
 
             return str;
         }
 
-        private string ParseTranslation(string poLine) {
-            return Unescape(TrimQuote(poLine.Substring(6).Trim()));
-        }
-
-        private string ParseId(string poLine) {
-            return Unescape(TrimQuote(poLine.Substring(5).Trim()));
-        }
-
-        private string ParseScope(string poLine) {
-            return Unescape(TrimQuote(poLine.Substring(2).Trim()));
-        }
-
-        private string ParseContext(string poLine) {
-            return Unescape(TrimQuote(poLine.Substring(7).Trim()));
+        private static string Parse(string str, string poLine)
+        {
+            return Unescape(TrimQuote(poLine.Substring(str.Length).Trim()));
         }
     }
 }


### PR DESCRIPTION
After spending some time making our gulp localization task work I came across an issue were some PO entries were half complete and noticed that they had been shifted into a new line by the task - after reviewing it, it wraps at 78 characters which seemed like an issue, but after some research, string wrapping is perfectly fine: http://pology.nedohodnik.net/doc/user/en_US/ch-poformat.html

The summary of my change is instead of reading line by line and determining what we are working with later on... do the following.

- Work out what scope we are looking at
- Check the next line, if its not another scope, append it to the current line and loop through till we find another scope (hence building the key, string, comment or scope)

Afterwards, check what scope we started with and do the required action.