### PR TITLE
Exclude file from gulp

### DIFF
--- a/src/Gulpfile.js
+++ b/src/Gulpfile.js
@@ -97,7 +97,13 @@ function resolveAssetGroupPaths(assetGroup, assetManifestPath) {
     assetGroup.manifestPath = assetManifestPath;
     assetGroup.basePath = path.dirname(assetManifestPath);
     assetGroup.inputPaths = assetGroup.inputs.map(function (inputPath) {
-        return path.resolve(path.join(assetGroup.basePath, inputPath));
+        var excludeFile = false;
+        if (inputPath.startsWith('!')) {
+            inputPath = inputPath.slice(1);
+            excludeFile = true;
+        }
+        var newPath = path.resolve(path.join(assetGroup.basePath, inputPath));
+        return (excludeFile ? '!' : '') + newPath;
     });
     assetGroup.watchPaths = [];
     if (assetGroup.watch) {


### PR DESCRIPTION
Files listed in Assets.json can be included as wildcard or per file, but there is no way to include all except some files. If you put `!` in front of the file name in Assets.json, it will not exclude that file from compiling and copying to destination.