### PR TITLE
Fix TaxonomyPartHandler

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TaxonomyPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TaxonomyPartHandler.cs
@@ -1,21 +1,24 @@
-﻿using Orchard.ContentManagement;
+﻿using System.Linq;
+using System.Web.Routing;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
 using Orchard.ContentManagement.MetaData;
 using Orchard.Core.Title.Models;
-using Orchard.Taxonomies.Fields;
-using Orchard.Taxonomies.Services;
-using Orchard.Taxonomies.Models;
-using Orchard.ContentManagement.Handlers;
 using Orchard.Data;
+using Orchard.Localization.Models;
+using Orchard.Localization.Services;
+using Orchard.Taxonomies.Fields;
+using Orchard.Taxonomies.Models;
+using Orchard.Taxonomies.Services;
 using Orchard.Taxonomies.Settings;
-using System;
-using System.Web.Routing;
 
 namespace Orchard.Taxonomies.Handlers {
     public class TaxonomyPartHandler : ContentHandler {
         public TaxonomyPartHandler(
             IRepository<TaxonomyPartRecord> repository,
             ITaxonomyService taxonomyService,
-            IContentDefinitionManager contentDefinitionManager) {
+            IContentDefinitionManager contentDefinitionManager,
+            ILocalizationService localizationService = null) { //Localization feature may not be active
 
             string previousName = null;
 
@@ -33,6 +36,21 @@ namespace Orchard.Taxonomies.Handlers {
                             if (field.FieldDefinition.Name == typeof(TaxonomyField).Name) {
 
                                 if (field.Settings.GetModel<TaxonomyFieldSettings>().Taxonomy == previousName) {
+                                    //could either be a name change, or we could be publishing a translation
+                                    if (localizationService != null) { //Localization feature may not be active
+                                        var locPart = part.ContentItem.As<LocalizationPart>();
+                                        if (locPart != null) {
+                                            var localizedTaxonomies = localizationService
+                                                .GetLocalizations(part.ContentItem) //versions in all cultures
+                                                .Where(pa => pa.ContentItem.Id != part.ContentItem.Id) //but not the one we are publishing
+                                                .Select(pa => {
+                                                    var tax = pa.ContentItem.As<TaxonomyPart>(); //the TaxonomyPart
+                                                return tax == null ? string.Empty : tax.Name; //get its name (with sanity check)
+                                            });
+                                            if (localizedTaxonomies.Contains(previousName))
+                                                continue; //this is a new localization, so move along
+                                        }
+                                    }
                                     contentDefinitionManager.AlterPartDefinition(partDefinition.Name,
                                         cfg => cfg.WithField(field.Name,
                                             builder => builder.WithSetting("TaxonomyFieldSettings.Taxonomy", part.Name)));

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Orchard.Taxonomies.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Orchard.Taxonomies.csproj
@@ -229,6 +229,10 @@
       <Project>{66fccd76-2761-47e3-8d11-b45d0001ddaa}</Project>
       <Name>Orchard.Autoroute</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Orchard.Localization\Orchard.Localization.csproj">
+      <Project>{FBC8B571-ED50-49D8-8D9D-64AB7454A0D6}</Project>
+      <Name>Orchard.Localization</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Orchard.Tokens\Orchard.Tokens.csproj">
       <Project>{6f759635-13d7-4e94-bcc9-80445d63f117}</Project>
       <Name>Orchard.Tokens</Name>


### PR DESCRIPTION
This fixes #7805.

The PR is targeted to 1.10.x, but is really more important for dev, where thanks to the way translations work (by cloning contents) the bug is much easier to replicate.