### PR TITLE
Nullable ContentItemId for AuditTrailSummaryAdmin view

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Views/AuditTrailEvent-Content.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Views/AuditTrailEvent-Content.SummaryAdmin.cshtml
@@ -1,11 +1,11 @@
-﻿@using Orchard.AuditTrail.Helpers
+@using Orchard.AuditTrail.Helpers
 @using Orchard.AuditTrail.Services.Models
 @using Orchard.ContentManagement
 @{
     var descriptor = (AuditTrailEventDescriptor)Model.Descriptor;
     var eventData = (IDictionary<string, object>) Model.EventData;
     var eventPastTense = descriptor.Name.Text.ToLower();
-    var contentItemId = (int)Model.ContentItemId;
+    var contentItemId = (int?)Model.ContentItemId;
     var contentItem = (ContentItem) Model.ContentItem;
     var eventVersionNumber = eventData.Get<int>("VersionNumber");
     var isPublishedEvent = eventData.Get<bool>("Published");
@@ -18,14 +18,13 @@
         var isLatest = contentItem.VersionRecord.Number == eventVersionNumber;
         var isRemoved = !contentItem.VersionRecord.Latest && !contentItem.VersionRecord.Published;
         if (isPublishedEvent || isLatest) {
-            @T("{0} of the {1} {2} was {3}.", Html.ActionLink(T("Version {0}", eventVersionNumber).Text, "Detail", "Content", new { area = "Orchard.AuditTrail", id = contentItemId, version = eventVersionNumber }, null), contentType.ToLower(), isRemoved ? Html.Raw("<strong>" + title + "</strong>") : Html.ItemEditLink(title, contentItemId), eventPastTense)
+            @T("{0} of the {1} {2} was {3}.", Html.ActionLink(T("Version {0}", eventVersionNumber).Text, "Detail", "Content", new { area = "Orchard.AuditTrail", id = contentItemId.Value, version = eventVersionNumber }, null), contentType.ToLower(), isRemoved ? Html.Raw("<strong>" + title + "</strong>") : Html.ItemEditLink(title, contentItemId.Value), eventPastTense)
         }
         else if (isRemoved) {
             @T("The {0} <strong>{1}</strong> was {2}.", contentType.ToLower(), title, eventPastTense)
         }
         else {
-            @T("The {0} {1} was {2}.", contentType.ToLower(), Html.ItemEditLink(title, contentItemId), eventPastTense)
-
+            @T("The {0} {1} was {2}.", contentType.ToLower(), Html.ItemEditLink(title, contentItemId.Value), eventPastTense)
         }
     }
     else {


### PR DESCRIPTION
On one of our production environments we have an issue where one of the audit trail pages is throwing a yellow screen because the ContentItemId is null.

I have not been able to find the exact replication steps for how this has been caused, but have fixed this locally by editing values to give me the yellow screen.

![zappshot - 2017-08-21_02-18-02-pm](https://user-images.githubusercontent.com/10059155/29521016-916fb4b4-867b-11e7-8fd4-ac4189c66f92.png)

By making this nullable, the view no longer throws the exception and the backend is already capable of handling the null ContentItemId.