### PR TITLE
Log EmailActivity not sending email because null or empty recipients

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Email/Activities/EmailActivity.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Activities/EmailActivity.cs
@@ -75,7 +75,8 @@ namespace Orchard.Email.Activities {
             if (string.IsNullOrWhiteSpace(recipients)) {
                 Logger.Error("Email message doesn't have any recipient for Workflow {0}", workflowContext.Record.WorkflowDefinitionRecord.Name);
                 yield return T("Not Done");
-            }else {
+            }
+            else {
                 var queued = activityContext.GetState<bool>("Queued");
 
                 if (!queued) {

--- a/src/Orchard.Web/Modules/Orchard.Email/Activities/EmailActivity.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Activities/EmailActivity.cs
@@ -32,7 +32,7 @@ namespace Orchard.Email.Activities {
         public Localizer T { get; set; }
 
         public override IEnumerable<LocalizedString> GetPossibleOutcomes(WorkflowContext workflowContext, ActivityContext activityContext) {
-            return new[] { T("Done"), T("Not Done") };
+            return new[] { T("Done"), T("Failed") };
         }
 
         public override string Form {
@@ -74,7 +74,7 @@ namespace Orchard.Email.Activities {
 
             if (string.IsNullOrWhiteSpace(recipients)) {
                 Logger.Error("Email message doesn't have any recipient for Workflow {0}", workflowContext.Record.WorkflowDefinitionRecord.Name);
-                yield return T("Not Done");
+                yield return T("Failed");
             }
             else {
                 var queued = activityContext.GetState<bool>("Queued");


### PR DESCRIPTION
Right now EmailActivity always returns "Done" as his outcome. This is actually not true when the recipients parameter is empty or null. This happens when the Email Activity hasn't got his fields filled by the user. So I think We should detect this case and return as the outcome "Not Done". Also its nice to log this so we can detect the case. 
In my particular case this change is pretty useful because in the company I work We provide worfklows created by recipes to our clients in which they have to fill the email fields of the activity. They sometimes don't notice this so the e-mail alerting them of an important event is not being sent. Neither We do. With the log and the outcome change we can configure log4net or other Activity to alert us so We can call the client to provide the data.