### PR TITLE
Made shape placement parsing strategy extendable with providers

### DIFF
--- a/src/Orchard.Tests/DisplayManagement/Descriptors/DefaultShapeTableManagerTests.cs
+++ b/src/Orchard.Tests/DisplayManagement/Descriptors/DefaultShapeTableManagerTests.cs
@@ -247,7 +247,10 @@ namespace Orchard.Tests.DisplayManagement.Descriptors {
 
                 _container.Resolve<TestShapeProvider>().Discover =
                     builder => builder.Describe("Hello").From(TestFeature())
-                                   .Placement(ShapePlacementParsingStrategy.BuildPredicate(c => true, new KeyValuePair<string, string>("Path", path)), new PlacementInfo { Location = "Match" });
+                                   .Placement(ShapePlacementParsingStrategy.BuildPredicate(c => true, 
+                                    new KeyValuePair<string, string>("Path", path), 
+                                    new[] { new PathPlacementParseMatchProvider() }), 
+                                    new PlacementInfo { Location = "Match" });
 
                 var manager = _container.Resolve<IShapeTableManager>();
                 var hello = manager.GetShapeTable(null).Descriptors["Hello"];

--- a/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/DefaultPlacementParseMatchProviders.cs
+++ b/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/DefaultPlacementParseMatchProviders.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+using System.Web;
+
+namespace Orchard.DisplayManagement.Descriptors.ShapePlacementStrategy {
+    public class ContentPartPlacementParseMatchProvider : IPlacementParseMatchProvider {
+        public string Key { get { return "ContentPart"; } }
+
+        public bool Match(ShapePlacementContext context, string expression) {
+            return context.Content != null && context.Content.ContentItem.Parts.Any(part => part.PartDefinition.Name == expression);
+        }
+    }
+
+    public class ContentTypePlacementParseMatchProvider : IPlacementParseMatchProvider {
+        public string Key { get { return "ContentType"; } }
+
+        public bool Match(ShapePlacementContext context, string expression) {
+            if (expression.EndsWith("*")) {
+                var prefix = expression.Substring(0, expression.Length - 1);
+                return (context.ContentType ?? "").StartsWith(prefix) || (context.Stereotype ?? "").StartsWith(prefix);
+            }
+
+            return context.ContentType == expression || context.Stereotype == expression;
+        }
+    }
+
+    public class DisplayTypePlacementParseMatchProvider : IPlacementParseMatchProvider {
+        public string Key { get { return "DisplayType"; } }
+
+        public bool Match(ShapePlacementContext context, string expression) {
+            if (expression.EndsWith("*")) {
+                var prefix = expression.Substring(0, expression.Length - 1);
+                return (context.DisplayType ?? "").StartsWith(prefix);
+            }
+
+            return context.DisplayType == expression;
+        }
+    }
+
+    public class PathPlacementParseMatchProvider : IPlacementParseMatchProvider {
+        public string Key { get { return "Path"; } }
+
+        public bool Match(ShapePlacementContext context, string expression) {
+            var normalizedPath = VirtualPathUtility.IsAbsolute(expression)
+                                            ? VirtualPathUtility.ToAppRelative(expression)
+                                            : VirtualPathUtility.Combine("~/", expression);
+
+            if (normalizedPath.EndsWith("*")) {
+                var prefix = normalizedPath.Substring(0, normalizedPath.Length - 1);
+                return VirtualPathUtility.ToAppRelative(string.IsNullOrEmpty(context.Path) ? "/" : context.Path).StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+            }
+
+            normalizedPath = VirtualPathUtility.AppendTrailingSlash(normalizedPath);
+            return context.Path.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/IPlacementParseMatchProvider.cs
+++ b/src/Orchard/DisplayManagement/Descriptors/ShapePlacementStrategy/IPlacementParseMatchProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace Orchard.DisplayManagement.Descriptors.ShapePlacementStrategy {
+    public interface IPlacementParseMatchProvider : IDependency {
+        string Key { get; }
+        bool Match(ShapePlacementContext context, string expression);
+    }
+}

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -176,6 +176,8 @@
   <ItemGroup>
     <Compile Include="ContentManagement\Extensions\DriverResultExtensions.cs" />
     <Compile Include="ContentManagement\Handlers\CloneContentContext.cs" />
+    <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\DefaultPlacementParseMatchProviders.cs" />
+    <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\IPlacementParseMatchProvider.cs" />
     <Compile Include="Environment\Configuration\ExtensionLocations.cs" />
     <Compile Include="DisplayManagement\IPositioned.cs" />
     <Compile Include="DisplayManagement\PositionWrapper.cs" />


### PR DESCRIPTION
Changes the hardcoded nature of Placement.info match nodes by opening it up so you can match placement on custom conditions using new providers.

Includes default match providers for contentpart, contenttype, displaytype and path to replicate the current match types.

This should allow us to possibly close the following 
#4138
#3671

and solves the problems outlined in #7834