### PR TITLE
Improved performance when updating tags for a content item

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Tags/Services/TagService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Tags/Services/TagService.cs
@@ -191,20 +191,22 @@ namespace Orchard.Tags.Services {
         }
 
         public void UpdateTagsForContentItem(ContentItem contentItem, IEnumerable<string> tagNamesForContentItem) {
-            var tags = tagNamesForContentItem.Select(CreateTag);
-            var newTagsForContentItem = new List<TagRecord>(tags);
+            var newTagsForContentItem = tagNamesForContentItem.Where(s => s != null).ToList();
             var currentTagsForContentItem = contentItem.As<TagsPart>().Record.Tags;
 
             foreach (var tagContentItem in currentTagsForContentItem) {
-                if (!newTagsForContentItem.Contains(tagContentItem.TagRecord)) {
+                var newTag = newTagsForContentItem.FirstOrDefault(t => t.Equals(tagContentItem.TagRecord.TagName, StringComparison.OrdinalIgnoreCase));
+
+                if (newTag == null) {
                     _contentTagRepository.Delete(tagContentItem);
                 }
-
-                newTagsForContentItem.Remove(tagContentItem.TagRecord);
+                else {
+                    newTagsForContentItem.Remove(newTag);
+                }
             }
 
             foreach (var newTagForContentItem in newTagsForContentItem) {
-                _contentTagRepository.Create(new ContentTagRecord { TagsPartRecord = contentItem.As<TagsPart>().Record, TagRecord = newTagForContentItem });
+                _contentTagRepository.Create(new ContentTagRecord { TagsPartRecord = contentItem.As<TagsPart>().Record, TagRecord = CreateTag(newTagForContentItem) });
             }
 
             contentItem.As<TagsPart>().CurrentTags = tagNamesForContentItem;


### PR DESCRIPTION
`TagService.UpdateTagsForContentItem` calls `CreateTag` for each tag being passed to the method, which queries the database for each tag to see if each one exists, even though no changes to tags may be required.

This change checks whether each tag exists by comparing the values of the tags being passed to the method with those currently assigned to the content item. This improves efficiency by only calling `CreateTag` if necessary, so only requiring a database query for tags that actually need to be added.

I've added the null check on line 194 because in production we've somehow ended up with a null tag value!