### PR TITLE
Display correct Comments total at /Admin/Blogs. Fixes #7838.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Comments/Drivers/CommentsContainerPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Drivers/CommentsContainerPartDriver.cs
@@ -13,7 +13,7 @@ namespace Orchard.Comments.Drivers {
 
         protected override DriverResult Display(CommentsContainerPart part, string displayType, dynamic shapeHelper) {
 
-            var commentsForCommentedContent = _commentService.GetCommentsForCommentedContent(part.ContentItem.Id);
+            var commentsForCommentedContent = _commentService.GetCommentsForContainer(part.ContentItem.Id);
             Func<int> pendingCount = () => commentsForCommentedContent.Where(x => x.Status == CommentStatus.Pending).Count();
             Func<int> approvedCount = () => commentsForCommentedContent.Where(x => x.Status == CommentStatus.Approved).Count();
             

--- a/src/Orchard.Web/Modules/Orchard.Comments/Services/CommentService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Services/CommentService.cs
@@ -60,6 +60,11 @@ namespace Orchard.Comments.Services {
         public Localizer T { get; set; } 
         public ILogger Logger { get; set; }
 
+        public IContentQuery<CommentPart, CommentPartRecord> GetCommentsForContainer(int id) {
+            return GetComments()
+                .Where(c => c.CommentedOnContainer == id);
+        }
+
         public CommentPart GetComment(int id) {
             return _orchardServices.ContentManager.Get<CommentPart>(id);
         }

--- a/src/Orchard.Web/Modules/Orchard.Comments/Services/ICommentService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Services/ICommentService.cs
@@ -8,6 +8,7 @@ namespace Orchard.Comments.Services {
         IContentQuery<CommentPart, CommentPartRecord> GetComments(CommentStatus status);
         IContentQuery<CommentPart, CommentPartRecord> GetCommentsForCommentedContent(int id);
         IContentQuery<CommentPart, CommentPartRecord> GetCommentsForCommentedContent(int id, CommentStatus status);
+        IContentQuery<CommentPart, CommentPartRecord> GetCommentsForContainer(int id);
         CommentPart GetComment(int id);
         ContentItemMetadata GetDisplayForCommentedContent(int id);
         ContentItem GetCommentedContent(int id);


### PR DESCRIPTION
The problem was due to CommentsContainerPartDriver getting the comments for a blog post.
The fix adds a new method, **GetCommentsForContainer**, in CommentService that returns the comments created for the blog. The part driver then calls that method instead to calculate the number of comments for the container.