### PR TITLE
Extend ISearchBuilder to support grouping clauses

### DIFF
--- a/src/Orchard.Tests.Modules/Indexing/LuceneSearchBuilderTests.cs
+++ b/src/Orchard.Tests.Modules/Indexing/LuceneSearchBuilderTests.cs
@@ -749,5 +749,73 @@ namespace Orchard.Tests.Modules.Indexing {
             Assert.That(SearchBuilder.WithinRange("number", null, 123.456, true, false).Count(), Is.EqualTo(0));
             Assert.That(SearchBuilder.WithinRange("integer", null, 123, true, false).Count(), Is.EqualTo(0));
         }
+
+        [Test]
+        public void ShouldAllowGroupedClauses() {
+            _provider.CreateIndex("default");
+            _provider.Store("default", _provider.New(1).Add("body", "michael is in the kitchen").Analyze());
+            _provider.Store("default", _provider.New(2).Add("body", "michael has a cousin named michel").Analyze());
+            _provider.Store("default", _provider.New(3).Add("body", "speak inside the mic").Analyze());
+            _provider.Store("default", _provider.New(4).Add("body", "a dog is pursuing a cat").Analyze());
+            _provider.Store("default", _provider.New(5).Add("body", "michael speaks to elephants").Analyze());
+
+            var michael = SearchBuilder.WithField("body", "michael").GetBits();
+            var cousinKitchenOrCat = SearchBuilder.WithField("body", "cousin").WithField("body", "kitchen").WithField("body", "cat").GetBits();
+
+            Assert.That(michael.Count(), Is.EqualTo(3));
+            Assert.That(cousinKitchenOrCat.Count(), Is.EqualTo(3));
+
+            // Contains "michael" AND ("cousin" OR "kitchen" OR "cat")
+            var michaelAndCousinKitchenOrcat = SearchBuilder
+                .WithField("body", "michael").Mandatory()
+                .WithGroup(groupSearchBuilder => groupSearchBuilder
+                    .WithField("body", "kitchen")
+                    .WithField("body", "cousin")
+                    .WithField("body", "cat")).Mandatory().GetBits();
+
+            Assert.That(michaelAndCousinKitchenOrcat.Count(), Is.EqualTo(2));
+            Assert.That(michael.And(cousinKitchenOrCat).Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void ShouldAllowNestedGroupedClauses()
+        {
+            _provider.CreateIndex("default");
+            _provider.Store("default", _provider.New(1).Add("body", "michael is in the kitchen with his cousin").Analyze());
+            _provider.Store("default", _provider.New(2).Add("body", "michael has a cousin named michel").Analyze());
+            _provider.Store("default", _provider.New(3).Add("body", "speak inside the mic").Analyze());
+            _provider.Store("default", _provider.New(4).Add("body", "a dog is pursuing a cat").Analyze());
+            _provider.Store("default", _provider.New(5).Add("body", "michael speaks to elephants").Analyze());
+
+            var michael = SearchBuilder.WithField("body", "michael").GetBits();
+            var elephant = SearchBuilder.WithField("body", "elephant").GetBits();
+            var cousinAndKitchen = SearchBuilder
+                .WithField("body", "cousin").Mandatory()
+                .WithField("body", "kitchen").Mandatory().GetBits();
+
+            // Contains "elephant" OR ("cousin" AND "kitchen")
+            var elephantOrCousinAndKitchen = SearchBuilder
+                .WithField("body", "elephant")
+                    .WithGroup(nestedSearchBuilder => nestedSearchBuilder
+                        .WithField("body", "cousin").Mandatory()
+                        .WithField("body", "kitchen").Mandatory()
+                    ).GetBits();
+
+            // Contains "michael" AND ("elephant" OR ("cousin" AND "kitchen"))
+            var michaelAndElephantOrCousinAndKitchen = SearchBuilder
+                .WithField("body", "michael").Mandatory()
+                .WithGroup(groupSearchBuilder => groupSearchBuilder
+                    .WithField("body", "elephant")
+                    .WithGroup(nestedSearchBuilder => nestedSearchBuilder
+                        .WithField("body", "cousin").Mandatory()
+                        .WithField("body", "kitchen").Mandatory())
+                    ).Mandatory().GetBits();
+
+            Assert.That(michael.Count(), Is.EqualTo(3));
+            Assert.That(elephant.Count(), Is.EqualTo(1));
+            Assert.That(cousinAndKitchen.Count(), Is.EqualTo(1));
+            Assert.That(elephantOrCousinAndKitchen.Count(), Is.EqualTo(2));
+            Assert.That(michaelAndElephantOrCousinAndKitchen.Count(), Is.EqualTo(2));
+        }
     }
 }

--- a/src/Orchard/Indexing/ISearchBuilder.cs
+++ b/src/Orchard/Indexing/ISearchBuilder.cs
@@ -6,6 +6,7 @@ namespace Orchard.Indexing {
         ISearchBuilder Parse(string defaultField, string query, bool escape = true);
         ISearchBuilder Parse(string[] defaultFields, string query, bool escape = true);
 
+        ISearchBuilder WithGroup(Action<ISearchBuilder> groupSearchBuilder);
         ISearchBuilder WithField(string field, bool value);
         ISearchBuilder WithField(string field, DateTime value);
         ISearchBuilder WithField(string field, string value);

--- a/src/Orchard/Indexing/NullSearchBuilder.cs
+++ b/src/Orchard/Indexing/NullSearchBuilder.cs
@@ -12,6 +12,10 @@ namespace Orchard.Indexing {
             return this;
         }
 
+        public ISearchBuilder WithGroup(Action<ISearchBuilder> groupSearchBuilder) {
+            return this;
+        }
+
         public ISearchBuilder WithField(string field, bool value) {
             return this;
         }


### PR DESCRIPTION
Based on DamienLaw's suggested changes in #5764. Needed clause-grouping functionality for a project I'm developing, so implemented these changes and performed some rudimentary testing. Can confirm that this works for simple groups such as Clause A AND (Clause B OR Clause C). Have not tested nesting groups within each other, but I see no reason why that wouldn't work as well.

Would be nice to see this merged soon, as it significantly expands the range of queries that can be constructed with the ISearchBuilder interface.

Not sure if this is necessary, but to be sure I'm in compliance with the CLA:
Submission containing materials of a third party: DamienLaw. Code was offered as a suggested improvement in #5764, and I am not aware of any licenses restricting its use.