### PR TITLE
TaxonomyField was running Update when it should not

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/LocalizedTaxonomyFieldHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/LocalizedTaxonomyFieldHandler.cs
@@ -98,11 +98,11 @@ namespace Orchard.Taxonomies.Handlers {
 
         protected override void UpdateEditorShape(UpdateEditorContext context) {
             // case contentitem without localization and taxonomyfield localized
-            if (context.ContentItem.As<LocalizationPart>() != null) {
+            if (context.ContentItem.As<LocalizationPart>() == null) {
                 return;
             }
             var partFieldDefinitions = context.ContentItem.Parts.SelectMany(p => p.PartDefinition.Fields).Where(x => x.FieldDefinition.Name == "TaxonomyField");
-            if (partFieldDefinitions == null) {
+            if (partFieldDefinitions == null || !partFieldDefinitions.Any()) {
                 return;
             }
             base.UpdateEditorShape(context);


### PR DESCRIPTION
The UpdateEditorShape was doing the wrong checks to see whether it should process stuff. Basically, it was running when the ContentItem that contains the field does not have a LocalizationPart. That did not seem to break anything, really, but lead to weird validation messages, because they notifications from line 125 would pop up in the validation summary