### PR TITLE
Binding in ContentType editor

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/ViewModels/EditPartFieldViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/ViewModels/EditPartFieldViewModel.cs
@@ -19,7 +19,7 @@ namespace Orchard.ContentTypes.ViewModels {
         }
 
         public int Index { get; set; }
-        public string Prefix { get { return "Fields[" + Index + "]"; } }
+        public string Prefix { get { return "Fields[" + Name + "]"; } }
         public EditPartViewModel Part { get; set; }
 
         public string Name { get; set; }

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/ViewModels/EditTypePartViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/ViewModels/EditTypePartViewModel.cs
@@ -17,7 +17,7 @@ namespace Orchard.ContentTypes.ViewModels {
         }
 
         public int Index { get; set; }
-        public string Prefix { get { return "Parts[" + Index + "]"; } }
+        public string Prefix { get { return "Parts[" + PartDefinition.Name + "]"; } }
         public EditPartViewModel PartDefinition { get; set; }
         public SettingsDictionary PartSettings { get; set; }
         public SettingsDictionary Settings { get; set; }


### PR DESCRIPTION
For context to this I'll paste my recent posts from gitter:

> @sebastienros There may be an issue in editing ContentTypes, but I am having an hard time reproducing this reliably. Suppose I have a Part in a Type. This part has, for example, 3 fields. Their Names / Ids are: [C, 1], [B, 2], [A, 3]. Sometimes, when a _contentDefinitionService.GetType(id); is called for that type, it returns those fields, correctly in the part, ordered by Id; sometimes it returns them ordered by Name.
> Saving the type definition sometimes flips that order. I have not been able to replicate this for any and every part yet.
> The end result of this is that:
> I have two Types that have my Part with those fields,
> I open the editors for the definition of the two parts at the same time, like in two browser tab
> I save the definition for one, then for the other WITHOUT refreshing the tab
> Now the settings/information for the fields is wrong, because in ContentDefinitonService.AlterType we have a binding done by the order of the fields in the part.
> For example, I did this with three EnumerationFields in a part, and their Options got mixed up (I edendn up having a field for gender with the options for age groups and viceversa).
> Again, I am having trouble reproducing this reliably, but maybe someone has some insight on this?
> note: I have not opened an issue yet, because I don't have working repro steps
> 
> Matteo Piovanelli @MatteoPiovanelli-Laser 11:10
> It looks like
> var contentPartDefinitionRecords = _partDefinitionRepository.Table
>                     .FetchMany(x => x.ContentPartFieldDefinitionRecords)
>                     .ThenFetch(x => x.ContentFieldDefinitionRecord)
>                     .Select(Build)
> The is returning those fields in a different order on different calls. I have not found why yet.
> 
> Matteo Piovanelli @MatteoPiovanelli-Laser 11:36
> It could be it's not ordering the fields by name, but by reverse Id
> 
> Matteo Piovanelli @MatteoPiovanelli-Laser 12:48
> update:
> Talking about what the ContentDefinitionManager does.
> AcquireContentPartDefinitions(): when it's not reading from the cache, it's doing a query that seems to always return things such that fields in parts are ordered by name (I tried this several times on sql amangement studio)
> Acquire(ContentPartDefinition contentPartDefinition): it's reading from the repository directly, and it looks like it's getting the fields in the part ordered by Id.
> Probably something is getting cached somewhere that causes the former, when its run after the latter, to return the different order for the fields in a part
> 
> Matteo Piovanelli @MatteoPiovanelli-Laser 14:15
> @sebastienros the way I see to probably make sure those things return the same stuff in the same order is to actually add a bunch of .OrderBy in a few places (I would have to look for where). I'd rather not, because performance-wise that may escalate quickly (this may not be true, as much is cached anyway), and because it feels like this is an issue with how binding is handled rather than with the repositories and what's being read from them.

In this PR I made changes to the Prefix property of the ViewModels for the editor of ContentType definitions. This appears to have fixed the issue on my end, and I don't think this could be causing any other issues in other places in the code.
Those properties appear to only be used for binding as they are in ContentDefinitionService.

