### PR TITLE
Add static analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,8 @@ src/Orchard.Azure/Orchard.Azure.CloudService/Staging/
 !lib/**/*.*
 **/.vs/*
 src/Rebracer.xml
+
+# =========================
+# Orchard specifics
+# =========================
+.idea

--- a/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
@@ -31,9 +31,7 @@
           <param name="dotNetTestRunner.Type" value="NUnit" />
           <param name="nunit_enabled" value="checked" />
           <param name="nunit_environment" value="v4.0" />
-          <param name="nunit_include"><![CDATA[/src/Orchard.Tests.Modules/bin/Debug/Orchard.Tests.Modules.dll
-/src/Orchard.Core.Tests/bin/Debug/Orchard.Core.Tests.dll
-/src/Orchard.Web.Tests/bin/Debug/Orchard.Web.Tests]]></param>
+          <param name="nunit_include" value="/src/Orchard.Core.Tests/bin/Debug/Orchard.Core.Tests.dll" />
           <param name="nunit_platform" value="MSIL" />
           <param name="nunit_version" value="NUnit-2.5.10" />
           <param name="teamcity.step.mode" value="default" />

--- a/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
@@ -4,6 +4,7 @@
   <description />
   <settings>
     <parameters>
+      <param name="Configuration" value="Debug" />
       <param name="dotnet_sdk" value="1.0.4" />
     </parameters>
     <build-runners>

--- a/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
@@ -31,7 +31,7 @@
           <param name="dotNetTestRunner.Type" value="NUnit" />
           <param name="nunit_enabled" value="checked" />
           <param name="nunit_environment" value="v4.0" />
-          <param name="nunit_include" value="/src/Orchard.Core.Tests/bin/Debug/Orchard.Core.Tests.dll" />
+          <param name="nunit_include" value="/src/Orchard.Core.Tests/bin/%Configuration%/Orchard.Core.Tests.dll" />
           <param name="nunit_platform" value="MSIL" />
           <param name="nunit_version" value="NUnit-2.5.10" />
           <param name="teamcity.step.mode" value="default" />

--- a/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="a1eff9e2-92dc-4432-9e54-2858b4aa7815" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/10.0/project-config.xsd">
+  <name>Orchard_Develop</name>
+  <description />
+  <settings>
+    <parameters>
+      <param name="dotnet_sdk" value="1.0.4" />
+    </parameters>
+    <build-runners>
+      <runner id="RUNNER_5" name="Build" type="simpleRunner">
+        <parameters>
+          <param name="script.content" value="build.cmd" />
+          <param name="teamcity.step.mode" value="default" />
+          <param name="use.custom.script" value="true" />
+        </parameters>
+      </runner>
+      <runner id="RUNNER_12" name="Run Tests" type="NUnit">
+        <parameters>
+          <param name="dotNetCoverage.NCover.HTMLReport.File.Sort" value="0" />
+          <param name="dotNetCoverage.NCover.HTMLReport.File.Type" value="1" />
+          <param name="dotNetCoverage.NCover.platformBitness" value="x86" />
+          <param name="dotNetCoverage.NCover.platformVersion" value="v2.0" />
+          <param name="dotNetCoverage.NCover3.args" value="//ias .*" />
+          <param name="dotNetCoverage.NCover3.platformBitness" value="x86" />
+          <param name="dotNetCoverage.NCover3.platformVersion" value="v2.0" />
+          <param name="dotNetCoverage.NCover3.reporter.executable.args" value="//or FullCoverageReport:Html:{teamcity.report.path}" />
+          <param name="dotNetCoverage.PartCover.includes" value="[*]*" />
+          <param name="dotNetCoverage.PartCover.platformBitness" value="x86" />
+          <param name="dotNetCoverage.PartCover.platformVersion" value="v2.0" />
+          <param name="dotNetCoverage.dotCover.home.path" value="%teamcity.tool.JetBrains.dotCover.CommandLineTools.DEFAULT%" />
+          <param name="dotNetTestRunner.Type" value="NUnit" />
+          <param name="nunit_enabled" value="checked" />
+          <param name="nunit_environment" value="v4.0" />
+          <param name="nunit_include"><![CDATA[/src/Orchard.Tests.Modules/bin/Debug/Orchard.Tests.Modules.dll
+/src/Orchard.Core.Tests/bin/Debug/Orchard.Core.Tests.dll
+/src/Orchard.Web.Tests/bin/Debug/Orchard.Web.Tests]]></param>
+          <param name="nunit_platform" value="MSIL" />
+          <param name="nunit_version" value="NUnit-2.5.10" />
+          <param name="teamcity.step.mode" value="default" />
+        </parameters>
+      </runner>
+    </build-runners>
+    <vcs-settings>
+      <vcs-entry-ref root-id="Orchard_Develop" />
+    </vcs-settings>
+    <requirements />
+    <build-triggers>
+      <build-trigger id="vcsTrigger" type="vcsTrigger">
+        <parameters>
+          <param name="branchFilter" value="+:*" />
+          <param name="enableQueueOptimization" value="true" />
+          <param name="quietPeriodMode" value="DO_NOT_USE" />
+        </parameters>
+      </build-trigger>
+    </build-triggers>
+    <build-extensions>
+      <extension id="BUILD_EXT_1" type="commit-status-publisher">
+        <parameters>
+          <param name="github_authentication_type" value="password" />
+          <param name="github_host" value="https://api.github.com" />
+          <param name="github_username" value="aleksey-pyatlin" />
+          <param name="publisherId" value="githubStatusPublisher" />
+          <param name="secure:github_password" value="zxxa70075bc751d9d27eca19f64cb355703" />
+        </parameters>
+      </extension>
+    </build-extensions>
+    <cleanup />
+  </settings>
+</build-type>
+

--- a/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Develop.xml
@@ -5,7 +5,6 @@
   <settings>
     <parameters>
       <param name="Configuration" value="Debug" />
-      <param name="dotnet_sdk" value="1.0.4" />
     </parameters>
     <build-runners>
       <runner id="RUNNER_5" name="Build" type="simpleRunner">

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -56,8 +56,7 @@
     <build-triggers>
       <build-trigger id="vcsTrigger" type="vcsTrigger">
         <parameters>
-          <param name="branchFilter"><![CDATA[+:*
--:feature/ci-setting]]></param>
+          <param name="branchFilter" value="+:*" />
           <param name="enableQueueOptimization" value="true" />
           <param name="quietPeriodMode" value="DO_NOT_USE" />
         </parameters>

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -42,9 +42,7 @@
           <param name="dotNetTestRunner.Type" value="NUnit" />
           <param name="nunit_enabled" value="checked" />
           <param name="nunit_environment" value="v4.0" />
-          <param name="nunit_include"><![CDATA[/src/Orchard.Tests.Modules/bin/Debug/Orchard.Tests.Modules.dll
-/src/Orchard.Core.Tests/bin/Debug/Orchard.Core.Tests.dll
-/src/Orchard.Web.Tests/bin/Debug/Orchard.Web.Tests]]></param>
+          <param name="nunit_include" value="/src/Orchard.Core.Tests/bin/Debug/Orchard.Core.Tests.dll" />
           <param name="nunit_platform" value="MSIL" />
           <param name="nunit_version" value="NUnit-2.5.10" />
           <param name="teamcity.step.mode" value="default" />

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -3,7 +3,9 @@
   <name>Orchard_Metrics</name>
   <description />
   <settings>
-    <parameters />
+    <parameters>
+      <param name="Configuration" value="Debug" />
+    </parameters>
     <build-runners>
       <runner id="RUNNER_13" name="" type="dotnet-tools-inspectcode">
         <parameters>

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -3,9 +3,7 @@
   <name>Orchard_Metrics</name>
   <description />
   <settings>
-    <parameters>
-      <param name="dotnet_sdk" value="1.0.4" />
-    </parameters>
+    <parameters />
     <build-runners>
       <runner id="RUNNER_13" name="" type="dotnet-tools-inspectcode">
         <parameters>

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -53,15 +53,7 @@
       <vcs-entry-ref root-id="Orchard_Develop" />
     </vcs-settings>
     <requirements />
-    <build-triggers>
-      <build-trigger id="vcsTrigger" type="vcsTrigger">
-        <parameters>
-          <param name="branchFilter" value="+:*" />
-          <param name="enableQueueOptimization" value="true" />
-          <param name="quietPeriodMode" value="DO_NOT_USE" />
-        </parameters>
-      </build-trigger>
-    </build-triggers>
+    <build-triggers />
     <cleanup />
   </settings>
 </build-type>

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -53,7 +53,30 @@
       <vcs-entry-ref root-id="Orchard_Develop" />
     </vcs-settings>
     <requirements />
-    <build-triggers />
+    <build-triggers>
+      <build-trigger id="TRIGGER_1" type="schedulingTrigger">
+        <parameters>
+          <param name="branchFilter" value="+:*" />
+          <param name="cronExpression_dm" value="*" />
+          <param name="cronExpression_dw" value="?" />
+          <param name="cronExpression_hour" value="*" />
+          <param name="cronExpression_min" value="0" />
+          <param name="cronExpression_month" value="*" />
+          <param name="cronExpression_sec" value="0" />
+          <param name="cronExpression_year" value="*" />
+          <param name="dayOfWeek" value="Sunday" />
+          <param name="enableQueueOptimization" value="true" />
+          <param name="hour" value="5" />
+          <param name="minute" value="0" />
+          <param name="promoteWatchedBuild" value="true" />
+          <param name="revisionRule" value="lastFinished" />
+          <param name="revisionRuleBuildBranch" value="&lt;default&gt;" />
+          <param name="schedulingPolicy" value="daily" />
+          <param name="timezone" value="SERVER" />
+          <param name="triggerBuildWithPendingChangesOnly" value="true" />
+        </parameters>
+      </build-trigger>
+    </build-triggers>
     <cleanup />
   </settings>
 </build-type>

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -42,7 +42,7 @@
           <param name="dotNetTestRunner.Type" value="NUnit" />
           <param name="nunit_enabled" value="checked" />
           <param name="nunit_environment" value="v4.0" />
-          <param name="nunit_include" value="/src/Orchard.Core.Tests/bin/Debug/Orchard.Core.Tests.dll" />
+          <param name="nunit_include" value="/src/Orchard.Core.Tests/bin/%Configuration%/Orchard.Core.Tests.dll" />
           <param name="nunit_platform" value="MSIL" />
           <param name="nunit_version" value="NUnit-2.5.10" />
           <param name="teamcity.step.mode" value="default" />

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="20e0f37b-07c3-4f24-ac32-ace119c349cd" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/10.0/project-config.xsd">
+  <name>Orchard_Metrics</name>
+  <description />
+  <settings>
+    <parameters>
+      <param name="dotnet_sdk" value="1.0.4" />
+    </parameters>
+    <build-runners>
+      <runner id="RUNNER_13" name="" type="dotnet-tools-inspectcode">
+        <parameters>
+          <param name="TargetDotNetFramework_4.5.2" value="true" />
+          <param name="dotnet-tools-inspectcode.project.filter" value="Orchard.Web" />
+          <param name="dotnet-tools-inspectcode.solution" value="src/Orchard.sln" />
+          <param name="dotnet-tools-inspectcodeCustomSettingsProfile" value="src/Orchard.5.0.ReSharper" />
+          <param name="jetbrains.resharper-clt.clt-path" value="%teamcity.tool.jetbrains.resharper-clt.DEFAULT%" />
+          <param name="teamcity.step.mode" value="default" />
+        </parameters>
+      </runner>
+      <runner id="RUNNER_5" name="Build" type="simpleRunner">
+        <parameters>
+          <param name="script.content" value="build.cmd" />
+          <param name="teamcity.step.mode" value="default" />
+          <param name="use.custom.script" value="true" />
+        </parameters>
+      </runner>
+      <runner id="RUNNER_12" name="Run All Tests With Coverage" type="NUnit">
+        <parameters>
+          <param name="dotNetCoverage.NCover.HTMLReport.File.Sort" value="0" />
+          <param name="dotNetCoverage.NCover.HTMLReport.File.Type" value="1" />
+          <param name="dotNetCoverage.NCover.platformBitness" value="x86" />
+          <param name="dotNetCoverage.NCover.platformVersion" value="v2.0" />
+          <param name="dotNetCoverage.NCover3.args" value="//ias .*" />
+          <param name="dotNetCoverage.NCover3.platformBitness" value="x86" />
+          <param name="dotNetCoverage.NCover3.platformVersion" value="v2.0" />
+          <param name="dotNetCoverage.NCover3.reporter.executable.args" value="//or FullCoverageReport:Html:{teamcity.report.path}" />
+          <param name="dotNetCoverage.PartCover.includes" value="[*]*" />
+          <param name="dotNetCoverage.PartCover.platformBitness" value="x86" />
+          <param name="dotNetCoverage.PartCover.platformVersion" value="v2.0" />
+          <param name="dotNetCoverage.dotCover.home.path" value="%teamcity.tool.JetBrains.dotCover.CommandLineTools.DEFAULT%" />
+          <param name="dotNetCoverage.tool" value="dotcover" />
+          <param name="dotNetTestRunner.Type" value="NUnit" />
+          <param name="nunit_enabled" value="checked" />
+          <param name="nunit_environment" value="v4.0" />
+          <param name="nunit_include"><![CDATA[/src/Orchard.Tests.Modules/bin/Debug/Orchard.Tests.Modules.dll
+/src/Orchard.Core.Tests/bin/Debug/Orchard.Core.Tests.dll
+/src/Orchard.Web.Tests/bin/Debug/Orchard.Web.Tests]]></param>
+          <param name="nunit_platform" value="MSIL" />
+          <param name="nunit_version" value="NUnit-2.5.10" />
+          <param name="teamcity.step.mode" value="default" />
+        </parameters>
+      </runner>
+    </build-runners>
+    <vcs-settings>
+      <vcs-entry-ref root-id="Orchard_Develop" />
+    </vcs-settings>
+    <requirements />
+    <build-triggers>
+      <build-trigger id="vcsTrigger" type="vcsTrigger">
+        <parameters>
+          <param name="branchFilter"><![CDATA[+:*
+-:feature/ci-setting]]></param>
+          <param name="enableQueueOptimization" value="true" />
+          <param name="quietPeriodMode" value="DO_NOT_USE" />
+        </parameters>
+      </build-trigger>
+    </build-triggers>
+    <cleanup />
+  </settings>
+</build-type>
+

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -66,7 +66,7 @@
           <param name="cronExpression_year" value="*" />
           <param name="dayOfWeek" value="Sunday" />
           <param name="enableQueueOptimization" value="true" />
-          <param name="hour" value="5" />
+          <param name="hour" value="4" />
           <param name="minute" value="0" />
           <param name="promoteWatchedBuild" value="true" />
           <param name="revisionRule" value="lastFinished" />

--- a/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
+++ b/.teamcity/Orchard/buildTypes/Orchard_Metrics.xml
@@ -66,7 +66,7 @@
           <param name="cronExpression_year" value="*" />
           <param name="dayOfWeek" value="Sunday" />
           <param name="enableQueueOptimization" value="true" />
-          <param name="hour" value="4" />
+          <param name="hour" value="1" />
           <param name="minute" value="0" />
           <param name="promoteWatchedBuild" value="true" />
           <param name="revisionRule" value="lastFinished" />

--- a/.teamcity/Orchard/pluginData/plugin-settings.xml
+++ b/.teamcity/Orchard/pluginData/plugin-settings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings />
+

--- a/.teamcity/Orchard/project-config.xml
+++ b/.teamcity/Orchard/project-config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="35060df9-26cc-4784-b28b-6987455338a0" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/10.0/project-config.xsd">
+  <name>Orchard</name>
+  <parameters />
+  <project-extensions>
+    <extension id="PROJECT_EXT_3" type="versionedSettings">
+      <parameters>
+        <param name="buildSettings" value="PREFER_VCS" />
+        <param name="enabled" value="true" />
+        <param name="rootId" value="Orchard_HttpsGithubComAlekseyPyatlinOrchardGitRefsHeadsMaster" />
+        <param name="showChanges" value="false" />
+      </parameters>
+    </extension>
+  </project-extensions>
+  <cleanup />
+</project>
+

--- a/.teamcity/Orchard/project-config.xml
+++ b/.teamcity/Orchard/project-config.xml
@@ -5,7 +5,7 @@
   <project-extensions>
     <extension id="PROJECT_EXT_2" type="versionedSettings">
       <parameters>
-        <param name="buildSettings" value="PREFER_VCS" />
+        <param name="buildSettings" value="ALWAYS_USE_CURRENT" />
         <param name="enabled" value="true" />
         <param name="rootId" value="Orchard_Develop" />
         <param name="showChanges" value="false" />

--- a/.teamcity/Orchard/project-config.xml
+++ b/.teamcity/Orchard/project-config.xml
@@ -5,7 +5,7 @@
   <project-extensions>
     <extension id="PROJECT_EXT_2" type="versionedSettings">
       <parameters>
-        <param name="buildSettings" value="ALWAYS_USE_CURRENT" />
+        <param name="buildSettings" value="PREFER_VCS" />
         <param name="enabled" value="true" />
         <param name="rootId" value="Orchard_Develop" />
         <param name="showChanges" value="false" />

--- a/.teamcity/Orchard/project-config.xml
+++ b/.teamcity/Orchard/project-config.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="35060df9-26cc-4784-b28b-6987455338a0" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/10.0/project-config.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="c58659de-f5ce-44b2-ab74-0aaa2149b179" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/10.0/project-config.xsd">
   <name>Orchard</name>
   <parameters />
   <project-extensions>
-    <extension id="PROJECT_EXT_3" type="versionedSettings">
+    <extension id="PROJECT_EXT_2" type="versionedSettings">
       <parameters>
         <param name="buildSettings" value="PREFER_VCS" />
         <param name="enabled" value="true" />
-        <param name="rootId" value="Orchard_HttpsGithubComAlekseyPyatlinOrchardGitRefsHeadsMaster" />
+        <param name="rootId" value="Orchard_Develop" />
         <param name="showChanges" value="false" />
       </parameters>
     </extension>

--- a/.teamcity/Orchard/vcsRoots/Orchard_Develop.xml
+++ b/.teamcity/Orchard/vcsRoots/Orchard_Develop.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vcs-root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="64256b05-9d45-4726-ba53-4e9a64bf2e2e" type="jetbrains.git" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/10.0/project-config.xsd">
+  <name>Orchard_Develop</name>
+  <param name="agentCleanFilesPolicy" value="ALL_UNTRACKED" />
+  <param name="agentCleanPolicy" value="ON_BRANCH_CHANGE" />
+  <param name="authMethod" value="TEAMCITY_SSH_KEY" />
+  <param name="branch" value="dev" />
+  <param name="ignoreKnownHosts" value="true" />
+  <param name="submoduleCheckout" value="CHECKOUT" />
+  <param name="teamcity:branchSpec" value="+:refs/heads/*" />
+  <param name="teamcitySshKey" value="Orchar_rsa" />
+  <param name="url" value="git@github.com:aleksey-pyatlin/Orchard.git" />
+  <param name="useAlternates" value="true" />
+  <param name="usernameStyle" value="USERID" />
+</vcs-root>
+

--- a/.teamcity/Orchard/vcsRoots/Orchard_Develop.xml
+++ b/.teamcity/Orchard/vcsRoots/Orchard_Develop.xml
@@ -8,7 +8,7 @@
   <param name="ignoreKnownHosts" value="true" />
   <param name="submoduleCheckout" value="CHECKOUT" />
   <param name="teamcity:branchSpec" value="+:refs/heads/*" />
-  <param name="teamcitySshKey" value="Orchar_rsa" />
+  <param name="teamcitySshKey" value="Orchard_rsa" />
   <param name="url" value="git@github.com:aleksey-pyatlin/Orchard.git" />
   <param name="useAlternates" value="true" />
   <param name="usernameStyle" value="USERID" />

--- a/.teamcity/Orchard/vcsRoots/Orchard_HttpsGithubComAlekseyPyatlinOrchardGitRefsHeadsMaster.xml
+++ b/.teamcity/Orchard/vcsRoots/Orchard_HttpsGithubComAlekseyPyatlinOrchardGitRefsHeadsMaster.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vcs-root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="88a3739c-cbd8-48bd-bf9b-c00d80c9f53d" type="jetbrains.git" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/10.0/project-config.xsd">
+  <name>https://github.com/aleksey-pyatlin/Orchard.git#refs/heads/master</name>
+  <param name="agentCleanFilesPolicy" value="ALL_UNTRACKED" />
+  <param name="agentCleanPolicy" value="ON_BRANCH_CHANGE" />
+  <param name="authMethod" value="TEAMCITY_SSH_KEY" />
+  <param name="branch" value="dev" />
+  <param name="ignoreKnownHosts" value="true" />
+  <param name="submoduleCheckout" value="CHECKOUT" />
+  <param name="teamcitySshKey" value="Orchard_rsa" />
+  <param name="url" value="git@github.com:aleksey-pyatlin/Orchard.git" />
+  <param name="useAlternates" value="true" />
+  <param name="usernameStyle" value="USERID" />
+</vcs-root>
+

--- a/src/Orchard.Web/Core/Orchard.Core.csproj
+++ b/src/Orchard.Web/Core/Orchard.Core.csproj
@@ -94,6 +94,15 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
+  <PropertyGroup Condition="'$(StaticAnalysisEnabled)' == 'True'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(StaticAnalysisEnabled)' == 'True'">
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.1.0-beta004/analyzers/dotnet/cs/StyleCop.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\SonarAnalyzer.CSharp.dll" />
+    <Analyzer Include="..\..\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\Google.Protobuf.dll" />
+    <Analyzer Include="..\..\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\SonarAnalyzer.dll" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\Controllers\ErrorController.cs" />
     <Compile Include="Common\DateEditor\DateEditorSettings.cs" />

--- a/src/Orchard.Web/packages.config
+++ b/src/Orchard.Web/packages.config
@@ -16,4 +16,6 @@
   <package id="Npgsql" version="2.2.3" targetFramework="net452" />
   <package id="Orchard.NuGet.Core" version="1.1.0.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="SonarAnalyzer.CSharp" version="6.5.0.3766" targetFramework="net452" />
+  <package id="StyleCop.Analyzers" version="1.1.0-beta004" targetFramework="net452" />
 </packages>

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+test file


### PR DESCRIPTION
Added static analysis to Orchard.Core project by:
* [SonarAnalyzer](https://www.nuget.org/packages/SonarAnalyzer.CSharp/)
* [StyleCop](https://www.nuget.org/packages/StyleCop.Analyzers/1.1.0-beta004)
Analysis is disabled by default. Run `msbuild` with `StaticAnalysisEnabled` parameter set to `true` in order to enable code analysis during build
```
msbuild /p:StaticAnalysisEnabled=true Orchard.sln
```
Right now code analysis gives 6356 errors on Orchard.Core project