### PR TITLE
Remove duplicate project reference

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Orchard.Taxonomies.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Orchard.Taxonomies.csproj
@@ -260,10 +260,6 @@
       <Name>Orchard.Autoroute</Name>
     </ProjectReference>
     <ProjectReference Include="..\Orchard.Localization\Orchard.Localization.csproj">
-      <Project>{FBC8B571-ED50-49D8-8D9D-64AB7454A0D6}</Project>
-      <Name>Orchard.Localization</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Orchard.Localization\Orchard.Localization.csproj">
       <Project>{fbc8b571-ed50-49d8-8d9d-64ab7454a0d6}</Project>
       <Name>Orchard.Localization</Name>
     </ProjectReference>


### PR DESCRIPTION
This duplicated project reference was causing problems for MSBuild APIs while attempting to test the performance of some of the compiler internals.