### PR TITLE
Fixes #7900 the image profile manager returning profile paths when its failed

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
@@ -131,12 +131,11 @@ namespace Orchard.MediaProcessing.Services {
                 // to handle cross machines concurrency
                 lock (String.Intern(path)) {
                     using (var image = GetImage(path)) {
+                        if (image == null) {
+                            return null;
+                        }
 
                         var filterContext = new FilterContext { Media = image, FilePath = _storageProvider.Combine("_Profiles", FormatProfilePath(profileName, System.Web.HttpUtility.UrlDecode(path))) };
-
-                        if (image == null) {
-                            return filterContext.FilePath;
-                        }
 
                         var tokens = new Dictionary<string, object>();
                         // if a content item is provided, use it while tokenizing


### PR DESCRIPTION
Fixes #7900 Fixed the image profile manager returning profile paths when its failed to create an image.