### PR TITLE
Fix #7903 adding the appropriate columns to index fields latest values

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Data;
+﻿using System.Data;
 using Orchard.ContentManagement.MetaData;
 using Orchard.Core.Common.Models;
 using Orchard.Core.Contents.Extensions;
@@ -281,6 +280,30 @@ namespace Orchard.Projections {
                 );
 
             return 4;
+        }
+        public int UpdateFrom4() {
+            SchemaBuilder.AlterTable("StringFieldIndexRecord", table => table
+            .AddColumn<string>("LatestValue", c => c.WithLength(4000)));
+
+            SchemaBuilder.AlterTable("IntegerFieldIndexRecord", table => table
+            .AddColumn<long>("LatestValue"));
+
+            SchemaBuilder.AlterTable("DoubleFieldIndexRecord", table => table
+            .AddColumn<double>("LatestValue"));
+
+            SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table
+            .AddColumn<decimal>("LatestValue"));
+
+            //Adds indexes for better performances in queries
+            SchemaBuilder.AlterTable("StringFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+
+            SchemaBuilder.AlterTable("IntegerFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+
+            SchemaBuilder.AlterTable("DoubleFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+
+            SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+            
+            return 5;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
@@ -296,13 +296,17 @@ namespace Orchard.Projections {
 
             //Adds indexes for better performances in queries
             SchemaBuilder.AlterTable("StringFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+            SchemaBuilder.AlterTable("StringFieldIndexRecord", table => table.CreateIndex("IX_FieldIndexPartRecord_Id", new string[] { "FieldIndexPartRecord_Id" }));
 
             SchemaBuilder.AlterTable("IntegerFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+            SchemaBuilder.AlterTable("IntegerFieldIndexRecord", table => table.CreateIndex("IX_FieldIndexPartRecord_Id", new string[] { "FieldIndexPartRecord_Id" }));
 
             SchemaBuilder.AlterTable("DoubleFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+            SchemaBuilder.AlterTable("DoubleFieldIndexRecord", table => table.CreateIndex("IX_FieldIndexPartRecord_Id", new string[] { "FieldIndexPartRecord_Id" }));
 
             SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
-            
+            SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table.CreateIndex("IX_FieldIndexPartRecord_Id", new string[] { "FieldIndexPartRecord_Id" }));
+
             return 5;
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Models/FieldIndexRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Models/FieldIndexRecord.cs
@@ -8,18 +8,22 @@ namespace Orchard.Projections.Models {
 
     public class StringFieldIndexRecord : FieldIndexRecord {
         public virtual string Value { get; set; }
+        public virtual string LatestValue { get; set; }
     }
 
     public class IntegerFieldIndexRecord : FieldIndexRecord {
         public virtual long? Value { get; set; }
+        public virtual long? LatestValue { get; set; }
     }
 
     public class DoubleFieldIndexRecord : FieldIndexRecord {
         public virtual double? Value { get; set; }
+        public virtual double? LatestValue { get; set; }
     }
 
     public class DecimalFieldIndexRecord : FieldIndexRecord {
         public virtual decimal? Value { get; set; }
+        public virtual decimal? LatestValue { get; set; }
     }
 
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
@@ -177,6 +177,8 @@
     <Compile Include="Providers\Layouts\ShapeLayoutForms.cs" />
     <Compile Include="Providers\Properties\CustomValueProperties.cs" />
     <Compile Include="Navigation\NavigationQueryProvider.cs" />
+    <Compile Include="Services\DraftFieldIndexService.cs" />
+    <Compile Include="Services\IDraftFieldIndexService.cs" />
     <Compile Include="Services\IProjectionManagerExtension.cs" />
     <Compile Include="Shapes.cs" />
     <Compile Include="Descriptors\Layout\LayoutComponentResult.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/DraftFieldIndexService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/DraftFieldIndexService.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Linq;
+using Orchard.Projections.Models;
+
+namespace Orchard.Projections.Services {
+    public class DraftFieldIndexService : IDraftFieldIndexService {
+
+        public void Set(FieldIndexPart part, string partName, string fieldName, string valueName, object value, Type valueType) {
+            var propertyName = String.Join(".", partName, fieldName, valueName ?? "");
+
+            var typeCode = Type.GetTypeCode(valueType);
+
+            if(valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(Nullable<>)) {
+                typeCode = Type.GetTypeCode(Nullable.GetUnderlyingType(valueType));
+            }
+
+            switch (typeCode) {
+                case TypeCode.Char:
+                case TypeCode.String:
+                    var stringRecord = part.Record.StringFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (stringRecord == null) {
+                        stringRecord = new StringFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.StringFieldIndexRecords.Add(stringRecord);
+                    }
+
+                    // take the first 4000 chars as it is the limit for the field
+                    stringRecord.LatestValue = value == null ? null : value.ToString().Substring(0, Math.Min(value.ToString().Length, 4000));
+
+                    
+                    break;
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                    var integerRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (integerRecord == null) {
+                        integerRecord = new IntegerFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.IntegerFieldIndexRecords.Add(integerRecord);
+                    }
+
+                    integerRecord.LatestValue = value == null ? default(long?) : Convert.ToInt64(value);
+                    break;
+                case TypeCode.DateTime:
+                    var dateTimeRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (dateTimeRecord == null) {
+                        dateTimeRecord = new IntegerFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.IntegerFieldIndexRecords.Add(dateTimeRecord);
+                    }
+
+                    dateTimeRecord.LatestValue = value == null ? default(long?) : ((DateTime)value).Ticks;
+                    break;
+                case TypeCode.Boolean:
+                    var booleanRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (booleanRecord == null) {
+                        booleanRecord = new IntegerFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.IntegerFieldIndexRecords.Add(booleanRecord);
+                    }
+
+                    booleanRecord.LatestValue = value == null ? default(long?) : Convert.ToInt64((bool)value);
+                    break;
+                case TypeCode.Decimal:
+                    var decimalRecord = part.Record.DecimalFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (decimalRecord == null) {
+                        decimalRecord = new DecimalFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.DecimalFieldIndexRecords.Add(decimalRecord);
+                    }
+
+                    decimalRecord.LatestValue = value == null ? default(decimal?) : Convert.ToDecimal((decimal)value);
+                    break;
+                case TypeCode.Single:
+                case TypeCode.Double:
+                    var doubleRecord = part.Record.DoubleFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (doubleRecord == null) {
+                        doubleRecord = new DoubleFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.DoubleFieldIndexRecords.Add(doubleRecord);
+                    }
+
+                    doubleRecord.LatestValue = value == null ? default(double?) : Convert.ToDouble(value);
+                    break;
+            }
+        }
+
+        public T Get<T>(FieldIndexPart part, string partName, string fieldName, string valueName) {
+            var propertyName = String.Join(".", partName, fieldName, valueName ?? "");
+
+            var typeCode = Type.GetTypeCode(typeof(T));
+
+            switch (typeCode) {
+                case TypeCode.Char:
+                case TypeCode.String:
+                    var stringRecord = part.Record.StringFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return stringRecord != null ? (T)Convert.ChangeType(stringRecord.LatestValue, typeof(T)) : default(T);
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                    var integerRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return integerRecord != null ? (T)Convert.ChangeType(integerRecord.LatestValue, typeof(T)) : default(T);
+                case TypeCode.Decimal:
+                    var decimalRecord = part.Record.DecimalFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return decimalRecord != null ? (T)Convert.ChangeType(decimalRecord.LatestValue, typeof(T)) : default(T);
+                case TypeCode.Single:
+                case TypeCode.Double:
+                    var doubleRecord = part.Record.DoubleFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return doubleRecord != null ? (T)Convert.ChangeType(doubleRecord.LatestValue, typeof(T)) : default(T);
+                case TypeCode.DateTime:
+                    var dateTimeRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return dateTimeRecord != null ? (T)Convert.ChangeType(new DateTime(Convert.ToInt64(dateTimeRecord.LatestValue)), typeof(T)) : default(T);
+                case TypeCode.Boolean:
+                    var booleanRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return booleanRecord != null ? (T)Convert.ChangeType(booleanRecord.LatestValue, typeof(T)) : default(T);
+                default:
+                    return default(T);
+            }
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/IDraftFieldIndexService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/IDraftFieldIndexService.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using Orchard.Projections.Models;
+
+namespace Orchard.Projections.Services {
+    public interface IDraftFieldIndexService : IDependency {
+        void Set(FieldIndexPart part, string partName, string fieldName, string valueName, object value, Type valueType);
+        T Get<T>(FieldIndexPart part, string partName, string fieldName, string valueName);
+    }
+}

--- a/src/Orchard.Web/Modules/Upgrade/AdminMenu.cs
+++ b/src/Orchard.Web/Modules/Upgrade/AdminMenu.cs
@@ -13,7 +13,8 @@ namespace Upgrade {
         public void GetNavigation(NavigationBuilder builder) {
             builder
                 .AddImageSet("upgrade")
-                .Add(T("Upgrade to 1.8"), "0", menu => menu.Action("Index", "Route", new { area = "Upgrade" })
+                .Add(T("Upgrade to 1.10.3"), "0", menu => menu.Action("Index", "Route", new { area = "Upgrade" })
+                    .Add(T("Projections (1.10.3)"), "1.0", item => item.Action("Index", "Projections", new { area = "Upgrade" }).LocalNav().Permission(StandardPermissions.SiteOwner))
                     .Add(T("Infoset (1.8)"), "1.0", item => item.Action("Index", "Infoset", new { area = "Upgrade" }).LocalNav().Permission(StandardPermissions.SiteOwner))
                     .Add(T("Messaging (1.8)"), "1.1", item => item.Action("Index", "Messaging", new { area = "Upgrade" }).LocalNav().Permission(StandardPermissions.SiteOwner))
                     .Add(T("Media (1.7)"), "2", item => item.Action("Index", "Media", new { area = "Upgrade" }).LocalNav().Permission(StandardPermissions.SiteOwner))

--- a/src/Orchard.Web/Modules/Upgrade/Controllers/ProjectionsController.cs
+++ b/src/Orchard.Web/Modules/Upgrade/Controllers/ProjectionsController.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Mvc;
+using Orchard;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
+using Orchard.ContentManagement.MetaData;
+using Orchard.Environment.Features;
+using Orchard.Localization;
+using Orchard.Logging;
+using Orchard.Projections.Handlers;
+using Orchard.Security;
+using Orchard.UI.Admin;
+using Orchard.UI.Notify;
+using Upgrade.ViewModels;
+
+namespace Upgrade.Controllers {
+    [Admin]
+    public class ProjectionsController : Controller {
+        private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly IOrchardServices _orchardServices;
+        private readonly IFeatureManager _featureManager;
+        private readonly Lazy<IEnumerable<IContentHandler>> _handlers;
+
+        public ProjectionsController(
+            IContentDefinitionManager contentDefinitionManager,
+            IOrchardServices orchardServices,
+            IFeatureManager featureManager,
+            Lazy<IEnumerable<IContentHandler>> handlers) {
+            _contentDefinitionManager = contentDefinitionManager;
+            _orchardServices = orchardServices;
+            _featureManager = featureManager;
+            _handlers = handlers;
+            Logger = NullLogger.Instance;
+        }
+
+        public Localizer T { get; set; }
+        public ILogger Logger { get; set; }
+
+        public ActionResult Index() {
+            var viewModel = new MigrateViewModel { ContentTypes = new List<ContentTypeEntry>() };
+            foreach (var contentType in _contentDefinitionManager.ListTypeDefinitions().OrderBy(c => c.Name)) {
+                // only display parts with fields
+                if (contentType.Parts.Any(x => x.PartDefinition.Fields.Any())) {
+                    viewModel.ContentTypes.Add(new ContentTypeEntry { ContentTypeName = contentType.Name });
+                }
+            }
+
+            if (!viewModel.ContentTypes.Any()) {
+                _orchardServices.Notifier.Warning(T("There are no content types with custom fields"));
+            }
+
+            if (!_featureManager.GetEnabledFeatures().Any(x => x.Id == "Orchard.Fields")) {
+                _orchardServices.Notifier.Warning(T("You need to enable Orchard.Fields in order to migrate current fields."));
+            }
+
+            return View(viewModel);
+        }
+
+        [HttpPost, ActionName("Index")]
+        public ActionResult IndexPOST() {
+            if (!_orchardServices.Authorizer.Authorize(StandardPermissions.SiteOwner, T("Not allowed to update fields' indexes.")))
+                return new HttpUnauthorizedResult();
+
+            // Get all ContentTypes with fields and Updates the LatestValue if necessary
+            var contentTypesWithFields = _contentDefinitionManager.ListTypeDefinitions().OrderBy(c => c.Name).Where(w => w.Parts.Any(x => x.PartDefinition.Fields.Any()));
+            foreach (var contentTypeWithFields in contentTypesWithFields) {
+                var contents = _orchardServices.ContentManager.HqlQuery().ForType(contentTypeWithFields.Name).ForVersion(VersionOptions.Latest).List();
+                foreach (var content in contents) {
+                    _handlers.Value.Where(x => x.GetType() == typeof(FieldIndexPartHandler)).Invoke(handler => handler.Updated(new UpdateContentContext(content)), Logger);
+                }
+            }
+            _orchardServices.Notifier.Information(T("Fields latest values were indexed successfully"));
+
+            return RedirectToAction("Index");
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
+++ b/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
@@ -120,6 +120,7 @@
     <Content Include="Styles\menu.upgrade-admin.css" />
     <Content Include="Web.config" />
     <Content Include="Styles\Web.config" />
+    <Compile Include="Controllers\ProjectionsController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
@@ -145,6 +146,10 @@
     <ProjectReference Include="..\Orchard.MediaLibrary\Orchard.MediaLibrary.csproj">
       <Project>{73a7688a-5bd3-4f7e-adfa-ce36c5a10e3b}</Project>
       <Name>Orchard.MediaLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Orchard.Projections\Orchard.Projections.csproj">
+      <Project>{5531e894-d259-45a3-aa61-26dbe720c1ce}</Project>
+      <Name>Orchard.Projections</Name>
     </ProjectReference>
     <ProjectReference Include="..\Orchard.Widgets\Orchard.Widgets.csproj">
       <Project>{194d3ccc-1153-474d-8176-fde8d7d0d0bd}</Project>
@@ -181,6 +186,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Projections\Index.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Orchard.Web/Modules/Upgrade/Views/Projections/Index.cshtml
+++ b/src/Orchard.Web/Modules/Upgrade/Views/Projections/Index.cshtml
@@ -1,0 +1,24 @@
+﻿@model Upgrade.ViewModels.MigrateViewModel
+@{ Layout.Title = T("Updates projections index tables with fields' latest values.").ToString(); }
+@if (Model.ContentTypes.Count() > 0) {
+    using (Html.BeginFormAntiForgeryPost()) {
+        Html.ValidationSummary();
+        <h2>@T("The update will process fields data and will update their latest value into projections index tables.")</h2>
+        <div>
+            <span>@T("These types will be processed:")</span>
+            <ol>
+                @foreach (var contentTypeEntry in Model.ContentTypes) {
+                <li>
+                    @contentTypeEntry.ContentTypeName
+                </li>
+                }
+            </ol>
+        </div>
+        <fieldset>
+            <button type="submit">@T("Update")</button>
+        </fieldset>
+    }
+}
+else {
+    <h3>@T("There are no content types with custom fields, nothing to upgrade.")</h3>
+}


### PR DESCRIPTION
Fix #7903
- Adds the column LatestValue to all type of FieldIndexRecord
- Adds Indexes to increase performances in queries
- Adds Handler to store LatestValue during Update event
- Adds Service to Get and Set the LatestValue of a field
- Adds heavy projections index tables update to the Upgrade module