### PR TITLE
Implements #7921 extend query to support latest versions

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/Filter/FilterContext.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/Filter/FilterContext.cs
@@ -5,10 +5,13 @@ namespace Orchard.Projections.Descriptors.Filter {
     public class FilterContext {
         public FilterContext() {
             Tokens = new Dictionary<string, object>();
+            VersionScope = QueryVersionScopeOptions.Published;
         }
 
         public IDictionary<string, object> Tokens { get; set; }
         public dynamic State { get; set; }
         public IHqlQuery Query { get; set; }
+
+        public QueryVersionScopeOptions VersionScope { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/Filter/FilterContext.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/Filter/FilterContext.cs
@@ -1,17 +1,20 @@
 ﻿using System.Collections.Generic;
 using Orchard.ContentManagement;
+using Orchard.Projections.Models;
 
 namespace Orchard.Projections.Descriptors.Filter {
     public class FilterContext {
         public FilterContext() {
             Tokens = new Dictionary<string, object>();
-            VersionScope = QueryVersionScopeOptions.Published;
         }
 
         public IDictionary<string, object> Tokens { get; set; }
         public dynamic State { get; set; }
         public IHqlQuery Query { get; set; }
 
-        public QueryVersionScopeOptions VersionScope { get; set; }
+        public QueryPartRecord QueryPartRecord { get; set; }
+        public string GetFilterColumnName() {
+            return QueryPartRecord != null && QueryPartRecord.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value";
+        }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/SortCriterion/SortCriteriaContext.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/SortCriterion/SortCriteriaContext.cs
@@ -1,17 +1,20 @@
 ﻿using System.Collections.Generic;
 using Orchard.ContentManagement;
+using Orchard.Projections.Models;
 
 namespace Orchard.Projections.Descriptors.SortCriterion {
     public class SortCriterionContext {
         public SortCriterionContext() {
             Tokens = new Dictionary<string, object>();
-            VersionScope = QueryVersionScopeOptions.Published;
         }
 
         public IDictionary<string, object> Tokens { get; set; }
         public dynamic State { get; set; }
         public IHqlQuery Query { get; set; }
 
-        public QueryVersionScopeOptions VersionScope { get; set; }
+        public QueryPartRecord QueryPartRecord { get; set; }
+        public string GetSortColumnName() {
+            return QueryPartRecord != null && QueryPartRecord.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value";
+        }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/SortCriterion/SortCriteriaContext.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/SortCriterion/SortCriteriaContext.cs
@@ -5,10 +5,13 @@ namespace Orchard.Projections.Descriptors.SortCriterion {
     public class SortCriterionContext {
         public SortCriterionContext() {
             Tokens = new Dictionary<string, object>();
+            VersionScope = QueryVersionScopeOptions.Published;
         }
 
         public IDictionary<string, object> Tokens { get; set; }
         public dynamic State { get; set; }
         public IHqlQuery Query { get; set; }
+
+        public QueryVersionScopeOptions VersionScope { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Drivers/QueryPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Drivers/QueryPartDriver.cs
@@ -7,9 +7,10 @@ using Orchard.ContentManagement.Handlers;
 using Orchard.Forms.Services;
 using Orchard.Projections.Models;
 using Orchard.Projections.Services;
+using Orchard.Projections.ViewModels;
 
 namespace Orchard.Projections.Drivers {
-    
+
     public class QueryPartDriver : ContentPartDriver<QueryPart> {
         private readonly IProjectionManager _projectionManager;
         private readonly IFormManager _formManager;
@@ -18,13 +19,25 @@ namespace Orchard.Projections.Drivers {
             _projectionManager = projectionManager;
             _formManager = formManager;
         }
-
-        protected override DriverResult Editor(QueryPart part, IUpdateModel updater, dynamic shapeHelper) {
-            if(updater == null) {
-                return null;
+        protected override string Prefix {
+            get {
+                return "Query_Part";
             }
-
-            return null;
+        }
+        protected override DriverResult Editor(QueryPart part, dynamic shapeHelper) {
+            return Editor(part, null, shapeHelper);
+        }
+        protected override DriverResult Editor(QueryPart part, IUpdateModel updater, dynamic shapeHelper) {
+            var model = new QueryViewModel { VersionScope = part.VersionScope };
+            if (updater != null) {
+                if (updater.TryUpdateModel(model, Prefix, null, null)) {
+                    part.VersionScope = model.VersionScope;
+                }
+            }
+            return ContentShape("Parts_QueryPart_Edit",
+                                () => {
+                                    return shapeHelper.EditorTemplate(TemplateName: "Parts/QueryPart_Edit", Model: model, Prefix: Prefix);
+                                });
         }
 
         protected override void Exporting(QueryPart part, ExportContentContext context) {
@@ -114,16 +127,16 @@ namespace Orchard.Projections.Drivers {
             foreach (var item in queryElement.Element("FilterGroups").Elements("FilterGroup").Select(filterGroup =>
                 new FilterGroupRecord {
                     Filters = filterGroup.Elements("Filter").Select(filter => {
-                        
+
                         var category = filter.Attribute("Category").Value;
                         var type = filter.Attribute("Type").Value;
                         var state = filter.Attribute("State").Value;
-                        
+
                         var descriptor = _projectionManager.GetFilter(category, type);
                         if (descriptor != null) {
                             state = _formManager.Import(descriptor.Form, state, context);
                         }
-                        
+
                         return new FilterRecord {
                             Category = category,
                             Description = filter.Attribute("Description").Value,
@@ -186,7 +199,7 @@ namespace Orchard.Projections.Drivers {
         }
 
         private XElement GetPropertyXml(PropertyRecord property) {
-            if(property == null) {
+            if (property == null) {
                 return null;
             }
 
@@ -226,7 +239,7 @@ namespace Orchard.Projections.Drivers {
         }
 
         private PropertyRecord GetProperty(XElement property) {
-            if(property == null) {
+            if (property == null) {
                 return null;
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/BooleanFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/BooleanFieldTypeEditor.cs
@@ -25,7 +25,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return BooleanFilterForm.GetFilterPredicate(formState, "Value");
+            return BooleanFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/DateTimeFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/DateTimeFieldTypeEditor.cs
@@ -29,7 +29,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return DateTimeFilterForm.GetFilterPredicate(formState, "Value", _clock.UtcNow, true);
+            return DateTimeFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value", _clock.UtcNow, true);
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/DecimalFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/DecimalFieldTypeEditor.cs
@@ -27,7 +27,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return NumericFilterForm.GetFilterPredicate(formState, "Value");
+            return NumericFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/FloatFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/FloatFieldTypeEditor.cs
@@ -28,7 +28,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return NumericFilterForm.GetFilterPredicate(formState, "Value");
+            return NumericFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/IntegerFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/IntegerFieldTypeEditor.cs
@@ -34,7 +34,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return NumericFilterForm.GetFilterPredicate(formState, "Value");
+            return NumericFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/StringFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/StringFieldTypeEditor.cs
@@ -25,7 +25,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return StringFilterForm.GetFilterPredicate(formState, "Value");
+            return StringFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
@@ -309,5 +309,10 @@ namespace Orchard.Projections {
 
             return 5;
         }
+        public int UpdateFrom5() {
+            SchemaBuilder.AlterTable("QueryPartRecord", table => table
+                .AddColumn<string>("VersionScope", c => c.WithLength(15)));
+            return 6;
+        }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
@@ -307,12 +307,9 @@ namespace Orchard.Projections {
             SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
             SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table.CreateIndex("IX_FieldIndexPartRecord_Id", new string[] { "FieldIndexPartRecord_Id" }));
 
-            return 5;
-        }
-        public int UpdateFrom5() {
             SchemaBuilder.AlterTable("QueryPartRecord", table => table
                 .AddColumn<string>("VersionScope", c => c.WithLength(15)));
-            return 6;
+            return 5;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Data;
+﻿using System.Data;
 using Orchard.ContentManagement.MetaData;
 using Orchard.Core.Common.Models;
 using Orchard.Core.Contents.Extensions;
@@ -281,6 +280,30 @@ namespace Orchard.Projections {
                 );
 
             return 4;
+        }
+        public int UpdateFrom4() {
+            SchemaBuilder.AlterTable("StringFieldIndexRecord", table => table
+            .AddColumn<string>("LatestValue", c => c.WithLength(4000)));
+
+            SchemaBuilder.AlterTable("IntegerFieldIndexRecord", table => table
+            .AddColumn<long>("LatestValue"));
+
+            SchemaBuilder.AlterTable("DoubleFieldIndexRecord", table => table
+            .AddColumn<double>("LatestValue"));
+
+            SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table
+            .AddColumn<decimal>("LatestValue"));
+
+            //Adds indexes for better performances in queries
+            SchemaBuilder.AlterTable("StringFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+
+            SchemaBuilder.AlterTable("IntegerFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+
+            SchemaBuilder.AlterTable("DoubleFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+
+            SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+            
+            return 5;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Migrations.cs
@@ -296,13 +296,17 @@ namespace Orchard.Projections {
 
             //Adds indexes for better performances in queries
             SchemaBuilder.AlterTable("StringFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+            SchemaBuilder.AlterTable("StringFieldIndexRecord", table => table.CreateIndex("IX_FieldIndexPartRecord_Id", new string[] { "FieldIndexPartRecord_Id" }));
 
             SchemaBuilder.AlterTable("IntegerFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+            SchemaBuilder.AlterTable("IntegerFieldIndexRecord", table => table.CreateIndex("IX_FieldIndexPartRecord_Id", new string[] { "FieldIndexPartRecord_Id" }));
 
             SchemaBuilder.AlterTable("DoubleFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
+            SchemaBuilder.AlterTable("DoubleFieldIndexRecord", table => table.CreateIndex("IX_FieldIndexPartRecord_Id", new string[] { "FieldIndexPartRecord_Id" }));
 
             SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table.CreateIndex("IX_PropertyName", new string[] { "PropertyName" }));
-            
+            SchemaBuilder.AlterTable("DecimalFieldIndexRecord", table => table.CreateIndex("IX_FieldIndexPartRecord_Id", new string[] { "FieldIndexPartRecord_Id" }));
+
             return 5;
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Models/FieldIndexRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Models/FieldIndexRecord.cs
@@ -8,18 +8,22 @@ namespace Orchard.Projections.Models {
 
     public class StringFieldIndexRecord : FieldIndexRecord {
         public virtual string Value { get; set; }
+        public virtual string LatestValue { get; set; }
     }
 
     public class IntegerFieldIndexRecord : FieldIndexRecord {
         public virtual long? Value { get; set; }
+        public virtual long? LatestValue { get; set; }
     }
 
     public class DoubleFieldIndexRecord : FieldIndexRecord {
         public virtual double? Value { get; set; }
+        public virtual double? LatestValue { get; set; }
     }
 
     public class DecimalFieldIndexRecord : FieldIndexRecord {
         public virtual decimal? Value { get; set; }
+        public virtual decimal? LatestValue { get; set; }
     }
 
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Models/QueryPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Models/QueryPart.cs
@@ -10,6 +10,10 @@ namespace Orchard.Projections.Models {
             set { this.As<TitlePart>().Title = value; }
         }
 
+        public QueryVersionScopeOptions VersionScope {
+            get { return this.Retrieve(x => x.VersionScope); }
+            set { this.Store(x => x.VersionScope, value); }
+        }
         public IList<SortCriterionRecord> SortCriteria {
             get { return Record.SortCriteria; }
         }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Models/QueryPartRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Models/QueryPartRecord.cs
@@ -1,15 +1,19 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
+using Orchard.ContentManagement;
 using Orchard.ContentManagement.Records;
 using Orchard.Data.Conventions;
 
 namespace Orchard.Projections.Models {
     public class QueryPartRecord : ContentPartRecord {
         public QueryPartRecord() {
+            VersionScope = QueryVersionScopeOptions.Published;
             FilterGroups = new List<FilterGroupRecord>();
             SortCriteria = new List<SortCriterionRecord>();
             Layouts = new List<LayoutRecord>();
         }
+
+        public virtual QueryVersionScopeOptions VersionScope { get; set; }
 
         [CascadeAllDeleteOrphan, Aggregate]
         [XmlArray("FilterGroupRecords")]

--- a/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
@@ -177,6 +177,8 @@
     <Compile Include="Providers\Layouts\ShapeLayoutForms.cs" />
     <Compile Include="Providers\Properties\CustomValueProperties.cs" />
     <Compile Include="Navigation\NavigationQueryProvider.cs" />
+    <Compile Include="Services\DraftFieldIndexService.cs" />
+    <Compile Include="Services\IDraftFieldIndexService.cs" />
     <Compile Include="Services\IProjectionManagerExtension.cs" />
     <Compile Include="Shapes.cs" />
     <Compile Include="Descriptors\Layout\LayoutComponentResult.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Providers\Layouts\ShapeLayoutForms.cs" />
     <Compile Include="Providers\Properties\CustomValueProperties.cs" />
     <Compile Include="Navigation\NavigationQueryProvider.cs" />
+    <Compile Include="QueryVersionScopeOptions.cs" />
     <Compile Include="Services\DraftFieldIndexService.cs" />
     <Compile Include="Services\IDraftFieldIndexService.cs" />
     <Compile Include="Services\IProjectionManagerExtension.cs" />
@@ -282,6 +283,7 @@
     <Compile Include="ViewModels\LayoutAddViewModel.cs" />
     <Compile Include="ViewModels\LayoutEditViewModel.cs" />
     <Compile Include="ViewModels\ProjectionPartEditViewModel.cs" />
+    <Compile Include="ViewModels\QueryViewModel.cs" />
     <Compile Include="ViewModels\SortCriteriaAddViewModel.cs" />
     <Compile Include="ViewModels\SortCriteriaEditViewModel.cs" />
     <Compile Include="ViewModels\FilterAddViewModel.cs" />
@@ -324,6 +326,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\EditorTemplates\Parts\QueryPart_Edit.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Orchard.Web/Modules/Orchard.Projections/Placement.info
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Placement.info
@@ -5,7 +5,7 @@
 
   <Place Parts_NavigationQueryPart_Edit="Content:5"/>
   <Place Parts_NavigationQueryPart="-"/>
-
+  <Place Parts_QueryPart_Edit="Content:5" />
   <Match DisplayType="Detail" ContentType="ProjectionPage">
     <Place Parts_Common_Metadata="-" />
   </Match>

--- a/src/Orchard.Web/Modules/Orchard.Projections/Providers/Filters/ContentFieldsFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Providers/Filters/ContentFieldsFilter.cs
@@ -76,7 +76,7 @@ namespace Orchard.Projections.Providers.Filters {
 
             // generate the predicate based on the editor which has been used
             dynamic fullState = context.State;
-            fullState.VersionScope = context.VersionScope;
+            fullState.VersionScope = context.QueryPartRecord.VersionScope;
             Action<IHqlExpressionFactory> predicate = fieldTypeEditor.GetFilterPredicate(fullState);
 
             // combines the predicate with a filter on the specific property name of the storage, as implemented in FieldIndexService

--- a/src/Orchard.Web/Modules/Orchard.Projections/Providers/Filters/ContentFieldsFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Providers/Filters/ContentFieldsFilter.cs
@@ -75,7 +75,9 @@ namespace Orchard.Projections.Providers.Filters {
             var relationship = fieldTypeEditor.GetFilterRelationship(propertyName.ToSafeName());
 
             // generate the predicate based on the editor which has been used
-            Action<IHqlExpressionFactory> predicate = fieldTypeEditor.GetFilterPredicate(context.State);
+            dynamic fullState = context.State;
+            fullState.VersionScope = context.VersionScope;
+            Action<IHqlExpressionFactory> predicate = fieldTypeEditor.GetFilterPredicate(fullState);
 
             // combines the predicate with a filter on the specific property name of the storage, as implemented in FieldIndexService
             Action<IHqlExpressionFactory> andPredicate = x => x.And(y => y.Eq("PropertyName", propertyName), predicate);

--- a/src/Orchard.Web/Modules/Orchard.Projections/Providers/SortCriteria/ContentFieldsSortCriteria.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Providers/SortCriteria/ContentFieldsSortCriteria.cs
@@ -82,8 +82,8 @@ namespace Orchard.Projections.Providers.SortCriteria {
 
             // apply sort
             context.Query = ascending
-                ? context.Query.OrderBy(relationship, x => x.Asc(context.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value"))
-                : context.Query.OrderBy(relationship, x => x.Desc(context.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value"));
+                ? context.Query.OrderBy(relationship, x => x.Asc(context.GetSortColumnName()))
+                : context.Query.OrderBy(relationship, x => x.Desc(context.GetSortColumnName()));
         }
 
         public LocalizedString DisplaySortCriterion(SortCriterionContext context, ContentPartDefinition part, ContentPartFieldDefinition fieldDefinition) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/Providers/SortCriteria/ContentFieldsSortCriteria.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Providers/SortCriteria/ContentFieldsSortCriteria.cs
@@ -32,14 +32,14 @@ namespace Orchard.Projections.Providers.SortCriteria {
         public Localizer T { get; set; }
 
         public void Describe(DescribeSortCriterionContext describe) {
-            foreach(var part in _contentDefinitionManager.ListPartDefinitions()) {
-                if(!part.Fields.Any()) {
+            foreach (var part in _contentDefinitionManager.ListPartDefinitions()) {
+                if (!part.Fields.Any()) {
                     continue;
                 }
 
                 var descriptor = describe.For(part.Name + "ContentFields", T("{0} Content Fields", part.Name.CamelFriendly()), T("Content Fields for {0}", part.Name.CamelFriendly()));
 
-                foreach(var field in part.Fields) {
+                foreach (var field in part.Fields) {
                     var localField = field;
                     var localPart = part;
                     var drivers = _contentFieldDrivers.Where(x => x.GetFieldInfo().Any(fi => fi.FieldTypeName == localField.FieldDefinition.Name)).ToList();
@@ -57,8 +57,8 @@ namespace Orchard.Projections.Providers.SortCriteria {
                                 display: context => DisplaySortCriterion(context, localPart, localField),
                                 form: SortCriterionFormProvider.FormName);
                         });
-                    
-                    foreach(var driver in drivers) {
+
+                    foreach (var driver in drivers) {
                         driver.Describe(membersContext);
                     }
                 }
@@ -79,11 +79,11 @@ namespace Orchard.Projections.Providers.SortCriteria {
 
             // apply where clause
             context.Query = context.Query.Where(relationship, predicate);
-            
+
             // apply sort
-            context.Query = ascending 
-                ? context.Query.OrderBy(relationship, x => x.Asc("Value")) 
-                : context.Query.OrderBy(relationship, x => x.Desc("Value"));
+            context.Query = ascending
+                ? context.Query.OrderBy(relationship, x => x.Asc(context.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value"))
+                : context.Query.OrderBy(relationship, x => x.Desc(context.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value"));
         }
 
         public LocalizedString DisplaySortCriterion(SortCriterionContext context, ContentPartDefinition part, ContentPartFieldDefinition fieldDefinition) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/QueryVersionScopeOptions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/QueryVersionScopeOptions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Orchard.Projections {
+    public enum  QueryVersionScopeOptions {
+        Published,
+        Latest
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/DraftFieldIndexService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/DraftFieldIndexService.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Linq;
+using Orchard.Projections.Models;
+
+namespace Orchard.Projections.Services {
+    public class DraftFieldIndexService : IDraftFieldIndexService {
+
+        public void Set(FieldIndexPart part, string partName, string fieldName, string valueName, object value, Type valueType) {
+            var propertyName = String.Join(".", partName, fieldName, valueName ?? "");
+
+            var typeCode = Type.GetTypeCode(valueType);
+
+            if(valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(Nullable<>)) {
+                typeCode = Type.GetTypeCode(Nullable.GetUnderlyingType(valueType));
+            }
+
+            switch (typeCode) {
+                case TypeCode.Char:
+                case TypeCode.String:
+                    var stringRecord = part.Record.StringFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (stringRecord == null) {
+                        stringRecord = new StringFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.StringFieldIndexRecords.Add(stringRecord);
+                    }
+
+                    // take the first 4000 chars as it is the limit for the field
+                    stringRecord.LatestValue = value == null ? null : value.ToString().Substring(0, Math.Min(value.ToString().Length, 4000));
+
+                    
+                    break;
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                    var integerRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (integerRecord == null) {
+                        integerRecord = new IntegerFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.IntegerFieldIndexRecords.Add(integerRecord);
+                    }
+
+                    integerRecord.LatestValue = value == null ? default(long?) : Convert.ToInt64(value);
+                    break;
+                case TypeCode.DateTime:
+                    var dateTimeRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (dateTimeRecord == null) {
+                        dateTimeRecord = new IntegerFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.IntegerFieldIndexRecords.Add(dateTimeRecord);
+                    }
+
+                    dateTimeRecord.LatestValue = value == null ? default(long?) : ((DateTime)value).Ticks;
+                    break;
+                case TypeCode.Boolean:
+                    var booleanRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (booleanRecord == null) {
+                        booleanRecord = new IntegerFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.IntegerFieldIndexRecords.Add(booleanRecord);
+                    }
+
+                    booleanRecord.LatestValue = value == null ? default(long?) : Convert.ToInt64((bool)value);
+                    break;
+                case TypeCode.Decimal:
+                    var decimalRecord = part.Record.DecimalFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (decimalRecord == null) {
+                        decimalRecord = new DecimalFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.DecimalFieldIndexRecords.Add(decimalRecord);
+                    }
+
+                    decimalRecord.LatestValue = value == null ? default(decimal?) : Convert.ToDecimal((decimal)value);
+                    break;
+                case TypeCode.Single:
+                case TypeCode.Double:
+                    var doubleRecord = part.Record.DoubleFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    if (doubleRecord == null) {
+                        doubleRecord = new DoubleFieldIndexRecord { PropertyName = propertyName };
+                        part.Record.DoubleFieldIndexRecords.Add(doubleRecord);
+                    }
+
+                    doubleRecord.LatestValue = value == null ? default(double?) : Convert.ToDouble(value);
+                    break;
+            }
+        }
+
+        public T Get<T>(FieldIndexPart part, string partName, string fieldName, string valueName) {
+            var propertyName = String.Join(".", partName, fieldName, valueName ?? "");
+
+            var typeCode = Type.GetTypeCode(typeof(T));
+
+            switch (typeCode) {
+                case TypeCode.Char:
+                case TypeCode.String:
+                    var stringRecord = part.Record.StringFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return stringRecord != null ? (T)Convert.ChangeType(stringRecord.LatestValue, typeof(T)) : default(T);
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                    var integerRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return integerRecord != null ? (T)Convert.ChangeType(integerRecord.LatestValue, typeof(T)) : default(T);
+                case TypeCode.Decimal:
+                    var decimalRecord = part.Record.DecimalFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return decimalRecord != null ? (T)Convert.ChangeType(decimalRecord.LatestValue, typeof(T)) : default(T);
+                case TypeCode.Single:
+                case TypeCode.Double:
+                    var doubleRecord = part.Record.DoubleFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return doubleRecord != null ? (T)Convert.ChangeType(doubleRecord.LatestValue, typeof(T)) : default(T);
+                case TypeCode.DateTime:
+                    var dateTimeRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return dateTimeRecord != null ? (T)Convert.ChangeType(new DateTime(Convert.ToInt64(dateTimeRecord.LatestValue)), typeof(T)) : default(T);
+                case TypeCode.Boolean:
+                    var booleanRecord = part.Record.IntegerFieldIndexRecords.FirstOrDefault(r => r.PropertyName == propertyName);
+                    return booleanRecord != null ? (T)Convert.ChangeType(booleanRecord.LatestValue, typeof(T)) : default(T);
+                default:
+                    return default(T);
+            }
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/IDraftFieldIndexService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/IDraftFieldIndexService.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using Orchard.Projections.Models;
+
+namespace Orchard.Projections.Services {
+    public interface IDraftFieldIndexService : IDependency {
+        void Set(FieldIndexPart part, string partName, string fieldName, string valueName, object value, Type valueType);
+        T Get<T>(FieldIndexPart part, string partName, string fieldName, string valueName);
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -169,7 +169,7 @@ namespace Orchard.Projections.Services {
                 var sortCriterionContext = new SortCriterionContext {
                     Query = groupQuery,
                     State = FormParametersHelper.ToDynamic(sortCriterion.State),
-                    VersionScope = queryRecord.VersionScope
+                    QueryPartRecord = queryRecord
                 };
 
                 string category = sortCriterion.Category;
@@ -218,7 +218,7 @@ namespace Orchard.Projections.Services {
                     var filterContext = new FilterContext {
                         Query = contentQuery,
                         State = FormParametersHelper.ToDynamic(tokenizedState),
-                        VersionScope = versionScope
+                        QueryPartRecord = queryRecord
                     };
 
                     string category = filter.Category;
@@ -245,7 +245,7 @@ namespace Orchard.Projections.Services {
                     var sortCriterionContext = new SortCriterionContext {
                         Query = contentQuery,
                         State = FormParametersHelper.ToDynamic(sortCriterion.State),
-                        VersionScope = versionScope
+                        QueryPartRecord= queryRecord
                     };
 
                     string category = sortCriterion.Category;

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -202,7 +202,13 @@ namespace Orchard.Projections.Services {
             // pre-executing all groups 
             foreach (var group in queryRecord.FilterGroups) {
 
-                var contentQuery = _contentManager.HqlQuery().ForVersion(VersionOptions.Published);
+                IHqlQuery contentQuery;
+                if (queryRecord.VersionScope == QueryVersionScopeOptions.Latest) {
+                    contentQuery = _contentManager.HqlQuery().ForVersion(VersionOptions.Latest);
+                }
+                else {
+                    contentQuery = _contentManager.HqlQuery().ForVersion(VersionOptions.Published);
+                }
 
                 // iterate over each filter to apply the alterations to the query object
                 foreach (var filter in group.Filters) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -200,10 +200,11 @@ namespace Orchard.Projections.Services {
             }
 
             // pre-executing all groups 
+            var versionScope = queryRecord.VersionScope;
             foreach (var group in queryRecord.FilterGroups) {
 
                 IHqlQuery contentQuery;
-                if (queryRecord.VersionScope == QueryVersionScopeOptions.Latest) {
+                if (versionScope == QueryVersionScopeOptions.Latest) {
                     contentQuery = _contentManager.HqlQuery().ForVersion(VersionOptions.Latest);
                 }
                 else {
@@ -215,7 +216,8 @@ namespace Orchard.Projections.Services {
                     var tokenizedState = _tokenizer.Replace(filter.State, tokens);
                     var filterContext = new FilterContext {
                         Query = contentQuery,
-                        State = FormParametersHelper.ToDynamic(tokenizedState)
+                        State = FormParametersHelper.ToDynamic(tokenizedState),
+                        VersionScope = versionScope
                     };
 
                     string category = filter.Category;
@@ -241,7 +243,8 @@ namespace Orchard.Projections.Services {
                 foreach (var sortCriterion in sortCriteria.OrderBy(s => s.Position)) {
                     var sortCriterionContext = new SortCriterionContext {
                         Query = contentQuery,
-                        State = FormParametersHelper.ToDynamic(sortCriterion.State)
+                        State = FormParametersHelper.ToDynamic(sortCriterion.State),
+                        VersionScope = versionScope
                     };
 
                     string category = sortCriterion.Category;

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -168,7 +168,8 @@ namespace Orchard.Projections.Services {
             foreach (var sortCriterion in queryRecord.SortCriteria.OrderBy(s => s.Position)) {
                 var sortCriterionContext = new SortCriterionContext {
                     Query = groupQuery,
-                    State = FormParametersHelper.ToDynamic(sortCriterion.State)
+                    State = FormParametersHelper.ToDynamic(sortCriterion.State),
+                    VersionScope = queryRecord.VersionScope
                 };
 
                 string category = sortCriterion.Category;

--- a/src/Orchard.Web/Modules/Orchard.Projections/ViewModels/FilterEditViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/ViewModels/FilterEditViewModel.cs
@@ -7,5 +7,6 @@ namespace Orchard.Projections.ViewModels {
         public string Description { get; set; }
         public FilterDescriptor Filter { get; set; }
         public dynamic Form { get; set; }
+        public QueryVersionScopeOptions VersionScope { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/ViewModels/QueryViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/ViewModels/QueryViewModel.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Orchard.Projections.ViewModels {
+    public class QueryViewModel {
+        public QueryVersionScopeOptions VersionScope { get; set; }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Projections/Views/EditorTemplates/Parts/QueryPart_Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Views/EditorTemplates/Parts/QueryPart_Edit.cshtml
@@ -1,0 +1,8 @@
+﻿@model Orchard.Projections.ViewModels.QueryViewModel
+@using Orchard.Projections;
+
+<fieldset>
+    @Html.LabelFor(m => m.VersionScope, T("Query Version Scope"))
+    @Html.DropDownListFor(m=>m.VersionScope, new SelectList(Enum.GetValues(typeof(QueryVersionScopeOptions)), Model.VersionScope))
+    <span class="hint">@T("The version scope of the query.")</span>
+</fieldset>

--- a/src/Orchard.Web/Modules/Orchard.Projections/Views/EditorTemplates/Parts/QueryPart_Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Views/EditorTemplates/Parts/QueryPart_Edit.cshtml
@@ -2,7 +2,7 @@
 @using Orchard.Projections;
 
 <fieldset>
-    @Html.LabelFor(m => m.VersionScope, T("Query Version Scope"))
+    @Html.LabelFor(m => m.VersionScope, T("Content's version"))
     @Html.DropDownListFor(m=>m.VersionScope, new SelectList(Enum.GetValues(typeof(QueryVersionScopeOptions)), Model.VersionScope))
-    <span class="hint">@T("The version scope of the query.")</span>
+    <span class="hint">@T("The content's version to query.")</span>
 </fieldset>

--- a/src/Orchard.Web/Modules/Upgrade/AdminMenu.cs
+++ b/src/Orchard.Web/Modules/Upgrade/AdminMenu.cs
@@ -13,7 +13,8 @@ namespace Upgrade {
         public void GetNavigation(NavigationBuilder builder) {
             builder
                 .AddImageSet("upgrade")
-                .Add(T("Upgrade to 1.8"), "0", menu => menu.Action("Index", "Route", new { area = "Upgrade" })
+                .Add(T("Upgrade to 1.10.3"), "0", menu => menu.Action("Index", "Route", new { area = "Upgrade" })
+                    .Add(T("Projections (1.10.3)"), "1.0", item => item.Action("Index", "Projections", new { area = "Upgrade" }).LocalNav().Permission(StandardPermissions.SiteOwner))
                     .Add(T("Infoset (1.8)"), "1.0", item => item.Action("Index", "Infoset", new { area = "Upgrade" }).LocalNav().Permission(StandardPermissions.SiteOwner))
                     .Add(T("Messaging (1.8)"), "1.1", item => item.Action("Index", "Messaging", new { area = "Upgrade" }).LocalNav().Permission(StandardPermissions.SiteOwner))
                     .Add(T("Media (1.7)"), "2", item => item.Action("Index", "Media", new { area = "Upgrade" }).LocalNav().Permission(StandardPermissions.SiteOwner))

--- a/src/Orchard.Web/Modules/Upgrade/Controllers/ProjectionsController.cs
+++ b/src/Orchard.Web/Modules/Upgrade/Controllers/ProjectionsController.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Mvc;
+using Orchard;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
+using Orchard.ContentManagement.MetaData;
+using Orchard.Environment.Features;
+using Orchard.Localization;
+using Orchard.Logging;
+using Orchard.Projections.Handlers;
+using Orchard.Security;
+using Orchard.UI.Admin;
+using Orchard.UI.Notify;
+using Upgrade.ViewModels;
+
+namespace Upgrade.Controllers {
+    [Admin]
+    public class ProjectionsController : Controller {
+        private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly IOrchardServices _orchardServices;
+        private readonly IFeatureManager _featureManager;
+        private readonly Lazy<IEnumerable<IContentHandler>> _handlers;
+
+        public ProjectionsController(
+            IContentDefinitionManager contentDefinitionManager,
+            IOrchardServices orchardServices,
+            IFeatureManager featureManager,
+            Lazy<IEnumerable<IContentHandler>> handlers) {
+            _contentDefinitionManager = contentDefinitionManager;
+            _orchardServices = orchardServices;
+            _featureManager = featureManager;
+            _handlers = handlers;
+            Logger = NullLogger.Instance;
+        }
+
+        public Localizer T { get; set; }
+        public ILogger Logger { get; set; }
+
+        public ActionResult Index() {
+            var viewModel = new MigrateViewModel { ContentTypes = new List<ContentTypeEntry>() };
+            foreach (var contentType in _contentDefinitionManager.ListTypeDefinitions().OrderBy(c => c.Name)) {
+                // only display parts with fields
+                if (contentType.Parts.Any(x => x.PartDefinition.Fields.Any())) {
+                    viewModel.ContentTypes.Add(new ContentTypeEntry { ContentTypeName = contentType.Name });
+                }
+            }
+
+            if (!viewModel.ContentTypes.Any()) {
+                _orchardServices.Notifier.Warning(T("There are no content types with custom fields"));
+            }
+
+            if (!_featureManager.GetEnabledFeatures().Any(x => x.Id == "Orchard.Fields")) {
+                _orchardServices.Notifier.Warning(T("You need to enable Orchard.Fields in order to migrate current fields."));
+            }
+
+            return View(viewModel);
+        }
+
+        [HttpPost, ActionName("Index")]
+        public ActionResult IndexPOST() {
+            if (!_orchardServices.Authorizer.Authorize(StandardPermissions.SiteOwner, T("Not allowed to update fields' indexes.")))
+                return new HttpUnauthorizedResult();
+
+            // Get all ContentTypes with fields and Updates the LatestValue if necessary
+            var contentTypesWithFields = _contentDefinitionManager.ListTypeDefinitions().OrderBy(c => c.Name).Where(w => w.Parts.Any(x => x.PartDefinition.Fields.Any()));
+            foreach (var contentTypeWithFields in contentTypesWithFields) {
+                var contents = _orchardServices.ContentManager.HqlQuery().ForType(contentTypeWithFields.Name).ForVersion(VersionOptions.Latest).List();
+                foreach (var content in contents) {
+                    _handlers.Value.Where(x => x.GetType() == typeof(FieldIndexPartHandler)).Invoke(handler => handler.Updated(new UpdateContentContext(content)), Logger);
+                }
+            }
+            _orchardServices.Notifier.Information(T("Fields latest values were indexed successfully"));
+
+            return RedirectToAction("Index");
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
+++ b/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
@@ -120,6 +120,7 @@
     <Content Include="Styles\menu.upgrade-admin.css" />
     <Content Include="Web.config" />
     <Content Include="Styles\Web.config" />
+    <Compile Include="Controllers\ProjectionsController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />
   </ItemGroup>
@@ -145,6 +146,10 @@
     <ProjectReference Include="..\Orchard.MediaLibrary\Orchard.MediaLibrary.csproj">
       <Project>{73a7688a-5bd3-4f7e-adfa-ce36c5a10e3b}</Project>
       <Name>Orchard.MediaLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Orchard.Projections\Orchard.Projections.csproj">
+      <Project>{5531e894-d259-45a3-aa61-26dbe720c1ce}</Project>
+      <Name>Orchard.Projections</Name>
     </ProjectReference>
     <ProjectReference Include="..\Orchard.Widgets\Orchard.Widgets.csproj">
       <Project>{194d3ccc-1153-474d-8176-fde8d7d0d0bd}</Project>
@@ -181,6 +186,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Projections\Index.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Orchard.Web/Modules/Upgrade/Views/Projections/Index.cshtml
+++ b/src/Orchard.Web/Modules/Upgrade/Views/Projections/Index.cshtml
@@ -1,0 +1,24 @@
+﻿@model Upgrade.ViewModels.MigrateViewModel
+@{ Layout.Title = T("Updates projections index tables with fields' latest values.").ToString(); }
+@if (Model.ContentTypes.Count() > 0) {
+    using (Html.BeginFormAntiForgeryPost()) {
+        Html.ValidationSummary();
+        <h2>@T("The update will process fields data and will update their latest value into projections index tables.")</h2>
+        <div>
+            <span>@T("These types will be processed:")</span>
+            <ol>
+                @foreach (var contentTypeEntry in Model.ContentTypes) {
+                <li>
+                    @contentTypeEntry.ContentTypeName
+                </li>
+                }
+            </ol>
+        </div>
+        <fieldset>
+            <button type="submit">@T("Update")</button>
+        </fieldset>
+    }
+}
+else {
+    <h3>@T("There are no content types with custom fields, nothing to upgrade.")</h3>
+}

--- a/src/Orchard.Web/Modules/Upgrade/Views/Projections/Index.cshtml
+++ b/src/Orchard.Web/Modules/Upgrade/Views/Projections/Index.cshtml
@@ -33,7 +33,7 @@ else {
                 $.ajax({
                     type: 'POST',
                     url: importUrl,
-                    async: false,
+                    async: true,
                     data: {
                         __RequestVerificationToken: antiForgeryToken,
                         id: startId // start at index 0

--- a/src/Orchard.Web/Modules/Upgrade/Views/Projections/Index.cshtml
+++ b/src/Orchard.Web/Modules/Upgrade/Views/Projections/Index.cshtml
@@ -1,6 +1,7 @@
 ﻿@model Upgrade.ViewModels.MigrateViewModel
 @{ Layout.Title = T("Updates projections index tables with fields' latest values.").ToString(); }
 @if (Model.ContentTypes.Count() > 0) {
+    <div class="message message-Warning" id="message-progress" style="display: none"></div>
     using (Html.BeginFormAntiForgeryPost()) {
         Html.ValidationSummary();
         <h2>@T("The update will process fields data and will update their latest value into projections index tables.")</h2>
@@ -15,10 +16,53 @@
             </ol>
         </div>
         <fieldset>
-            <button type="submit">@T("Update")</button>
+            <button type="button" class="button button-migrate" data-url="@Url.Action("MigrateLatestValue", "Projections")">@T("Migrate")</button>
         </fieldset>
     }
 }
 else {
     <h3>@T("There are no content types with custom fields, nothing to upgrade.")</h3>
+}
+@using (Script.Foot()) {
+    <script type="text/javascript">
+        $(function() {
+            var antiForgeryToken = '@HttpUtility.JavaScriptStringEncode(Html.AntiForgeryTokenValueOrchard().ToString())';
+            var endMessage = '@HttpUtility.JavaScriptStringEncode(T("All items have been processed").Text)';
+
+            var MigrationBatch = function (importUrl, startId) {
+                $.ajax({
+                    type: 'POST',
+                    url: importUrl,
+                    async: false,
+                    data: {
+                        __RequestVerificationToken: antiForgeryToken,
+                        id: startId // start at index 0
+                    },
+                    success: function (data) {
+                        if (Number(data) == startId) {
+                            $('#message-progress').text(endMessage);
+                        }
+                        else {
+                            startId = Number(data);
+                            $('#message-progress').text('Processing content item ' + startId);
+                            MigrationBatch(importUrl, startId);
+                        }
+                    },
+                    fail: function (result) {
+                        console.log("An error occured: " + result);
+                    }
+                });
+
+            };
+
+            $('.button-migrate').click(function () {
+                var importUrl = $(this).data('url');
+
+                var startId = 0;
+                $('#message-progress').show();
+                MigrationBatch(importUrl, startId);
+
+            });
+        });
+    </script>
 }


### PR DESCRIPTION
Implements #7921, branched from #7920 cause we need the LatestValue column to be there.
When a query is created/edited it is possible to specify the Content Version to query (Published or Latest).
Based on that choice the HqlQuery will filter 
- the right VersionOption 
- the right column of the `(*)IndexFilterRecord`

Based on that choice the HqlQuery will order
- using the right column of the `(*)IndexFilterRecord`