### PR TITLE
New feature "Orchard.MediaLibrary.LocalizationExtensions"

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Controllers/AdminController.cs
@@ -6,6 +6,7 @@ using Orchard.Localization.Services;
 using Orchard.UI.Notify;
 using System;
 using System.Web.Mvc;
+using System.Linq;
 
 namespace Orchard.Localization.Controllers
 {
@@ -72,6 +73,14 @@ namespace Orchard.Localization.Controllers
             Services.Notifier.Success(T("Successfully cloned. The translated content was saved as a draft."));
 
             var editorRouteValues = _contentManager.GetItemMetadata(contentItemTranslation).EditorRouteValues;
+            // adds request variables of current controller to the new redirect route 
+            // for example the returnUrl parameter
+            foreach (var key in Request.Form.AllKeys.Where(x=> !x.StartsWith("__") && !editorRouteValues.Keys.Contains(x))) {
+                editorRouteValues.Add(key, Request.Form[key]);
+            }
+            foreach (var key in Request.QueryString.AllKeys.Where(x => !x.StartsWith("__") && !editorRouteValues.Keys.Contains(x))) {
+                editorRouteValues.Add(key, Request.QueryString[key]);
+            }
             return RedirectToRoute(editorRouteValues);
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/ILocalizationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/ILocalizationService.cs
@@ -8,7 +8,6 @@ namespace Orchard.Localization.Services {
         LocalizationPart GetLocalizedContentItem(IContent content, string culture, VersionOptions versionOptions);
         string GetContentCulture(IContent content);
         void SetContentCulture(IContent content, string culture);
-        void SetContentCulture(IContent content, IContent masterContent, string culture);
         IEnumerable<LocalizationPart> GetLocalizations(IContent content);
         IEnumerable<LocalizationPart> GetLocalizations(IContent content, VersionOptions versionOptions);
     }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/ILocalizationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/ILocalizationService.cs
@@ -8,6 +8,7 @@ namespace Orchard.Localization.Services {
         LocalizationPart GetLocalizedContentItem(IContent content, string culture, VersionOptions versionOptions);
         string GetContentCulture(IContent content);
         void SetContentCulture(IContent content, string culture);
+        void SetContentCulture(IContent content, IContent masterContent, string culture);
         IEnumerable<LocalizationPart> GetLocalizations(IContent content);
         IEnumerable<LocalizationPart> GetLocalizations(IContent content, VersionOptions versionOptions);
     }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Orchard.ContentManagement;
 using Orchard.Localization.Models;
@@ -29,11 +30,12 @@ namespace Orchard.Localization.Services {
             if (localized == null)
                 return null;
 
+            var masterContent = content.ContentItem.As<LocalizationPart>().MasterContentItem != null ? content.ContentItem.As<LocalizationPart>().MasterContentItem : content;
             // Warning: Returns only the first of same culture localizations.
             return _contentManager
                 .Query<LocalizationPart>(versionOptions, content.ContentItem.ContentType)
                 .Where<LocalizationPartRecord>(l =>
-                (l.Id == content.ContentItem.Id || l.MasterContentItemId == content.ContentItem.Id)
+                (l.Id == masterContent.Id || l.MasterContentItemId == masterContent.Id)
                 && l.CultureId == cultureRecord.Id)
                 .Slice(1)
                 .FirstOrDefault();
@@ -47,11 +49,17 @@ namespace Orchard.Localization.Services {
         }
 
         void ILocalizationService.SetContentCulture(IContent content, string culture) {
+            SetContentCulture(content, null, culture);
+        }
+        public void SetContentCulture(IContent content, IContent masterContent, string culture) {
             var localized = content.As<LocalizationPart>();
             if (localized == null)
                 return;
 
             localized.Culture = _cultureManager.GetCultureByName(culture);
+            if (masterContent != null) {
+                localized.MasterContentItem = masterContent;
+            }
         }
 
         IEnumerable<LocalizationPart> ILocalizationService.GetLocalizations(IContent content) {
@@ -92,5 +100,6 @@ namespace Orchard.Localization.Services {
             // Warning: May contain more than one localization of the same culture.
             return query.List().ToList();
         }
+
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Services/LocalizationService.cs
@@ -49,17 +49,11 @@ namespace Orchard.Localization.Services {
         }
 
         void ILocalizationService.SetContentCulture(IContent content, string culture) {
-            SetContentCulture(content, null, culture);
-        }
-        public void SetContentCulture(IContent content, IContent masterContent, string culture) {
             var localized = content.As<LocalizationPart>();
             if (localized == null)
                 return;
 
             localized.Culture = _cultureManager.GetCultureByName(culture);
-            if (masterContent != null) {
-                localized.MasterContentItem = masterContent;
-            }
         }
 
         IEnumerable<LocalizationPart> ILocalizationService.GetLocalizations(IContent content) {

--- a/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
@@ -2,37 +2,44 @@
 @using System.Globalization
 @{
     Style.Require("LocalizationAdmin");
+    string returnUrl = Request.QueryString["ReturnUrl"] ?? "";
 }
 <fieldset class="localization culture-selection">
     <label for="@Html.FieldIdFor(m => m.SelectedCulture)">@T("Content Localization")</label>
     <div>
-        @if (!string.IsNullOrEmpty(Model.SelectedCulture))
-        {
+        @if (!string.IsNullOrEmpty(Model.SelectedCulture)) {
             @T("This is the <em>{0}</em> variation of the content",
                 Html.Encode(Model.SelectedCulture))
 
-            if (Model.ContentLocalizations.Localizations.Any())
-            {
+            if (Model.ContentLocalizations.Localizations.Any()) {
                 <dl class="content-localization">
                     <dt>@T("Other translations:")</dt>
                     <dd class="content-localizations">
-                        @Html.UnorderedList(Model.ContentLocalizations.Localizations, (c, i) =>
-                            Html.ItemEditLink(c.Culture.Culture, c), "localizations")
+                        @if (returnUrl != "") {
+                            @Html.UnorderedList(Model.ContentLocalizations.Localizations, (c, i) =>
+             Html.ItemEditLink(c.Culture.Culture, c, new { ReturnUrl = returnUrl }), "localizations")
+                        }
+                        else {
+                            @Html.UnorderedList(Model.ContentLocalizations.Localizations, (c, i) =>
+             Html.ItemEditLink(c.Culture.Culture, c), "localizations")
+                        }
                     </dd>
                 </dl>
             }
 
-            if (Model.MissingCultures.Any())
-            {
+            if (Model.MissingCultures.Any()) {
                 var contentItemId = Model.MasterContentItem != null ? Model.MasterContentItem.Id : Model.ContentItem.Id;
-
-                <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new { area = "Orchard.Localization", id = contentItemId }, new { itemprop = "UnsafeUrl" })</div>
+                if (returnUrl != "") {
+                    <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new { area = "Orchard.Localization", id = contentItemId, ReturnUrl = returnUrl }, new { itemprop = "UnsafeUrl" })</div>
+                }
+                else {
+                    <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new { area = "Orchard.Localization", id = contentItemId }, new { itemprop = "UnsafeUrl" })</div>
+                }
             }
 
             @Html.Hidden(Html.FieldNameFor(m => m.SelectedCulture), Model.SelectedCulture)
         }
-        else if (Model.MasterContentItem != null)
-        {
+        else if (Model.MasterContentItem != null) {
             @T("This is the <em>{0}</em> variation of {1}",
                     BuildSelectedCultureList(
                         Html.FieldIdFor(m => m.SelectedCulture),
@@ -41,19 +48,23 @@
                         Model.SelectedCulture),
                     Html.ItemEditLink(Model.MasterContentItem))
 
-            if (Model.ContentLocalizations.Localizations.Any())
-            {
+            if (Model.ContentLocalizations.Localizations.Any()) {
                 <dl class="content-localization">
                     <dt>@T("Other translations:")</dt>
                     <dd class="content-localizations">
+                        @if (returnUrl != "") {
+                            @Html.UnorderedList(Model.ContentLocalizations.Localizations, (c, i) =>
+                            Html.ItemEditLink(c.Culture.Culture, c, new { ReturnUrl = returnUrl }), "localizations");
+                        }
+                        else {
                         @Html.UnorderedList(Model.ContentLocalizations.Localizations, (c, i) =>
-                            Html.ItemEditLink(c.Culture.Culture, c), "localizations")
+                            Html.ItemEditLink(c.Culture.Culture, c), "localizations");
+                        }
                     </dd>
                 </dl>
             }
         }
-        else
-        {
+        else {
             @T("This is the <em>{0}</em> variation of the content",
                 BuildSelectedCultureList(
                     Html.FieldIdFor(m => m.SelectedCulture),
@@ -76,7 +87,7 @@
             TagBuilder optionTag = new TagBuilder("option");
             optionTag.Attributes["data-content-dir"] = CultureInfo.GetCultureInfo(siteCulture).TextInfo.IsRightToLeft ? "rtl" : "ltr";
 
-            if(string.IsNullOrEmpty(culture)) {
+            if (string.IsNullOrEmpty(culture)) {
                 if (siteCulture == WorkContext.CurrentSite.SiteCulture) {
                     optionTag.Attributes["selected"] = "selected";
                 }
@@ -95,32 +106,32 @@
 }
 @using (Script.Foot()) {
     <script type="text/javascript">
-//<![CDATA[
-    (function($) {
-        "use strict";
+        //<![CDATA[
+        (function ($) {
+            "use strict";
 
-        var culture = $("#@Html.FieldIdFor(m => m.SelectedCulture)");
+            var culture = $("#@Html.FieldIdFor(m => m.SelectedCulture)");
 
-        function flipCulture() {
-            var optionDirectionality = $("option:selected", culture).attr("data-content-dir");
-            var contentZone = $(".zone-content");
-            if (contentZone.hasClass(optionDirectionality))
-                return;
+            function flipCulture() {
+                var optionDirectionality = $("option:selected", culture).attr("data-content-dir");
+                var contentZone = $(".zone-content");
+                if (contentZone.hasClass(optionDirectionality))
+                    return;
 
-            var oldClass = optionDirectionality === "ltr" ? "rtl" : "";
+                var oldClass = optionDirectionality === "ltr" ? "rtl" : "";
 
-            contentZone.removeClass("content-" + oldClass);
-            contentZone.addClass("content-" + optionDirectionality);
+                contentZone.removeClass("content-" + oldClass);
+                contentZone.addClass("content-" + optionDirectionality);
 
-            $(document).trigger("localization.ui.directionalitychanged", optionDirectionality);
-        }
+                $(document).trigger("localization.ui.directionalitychanged", optionDirectionality);
+            }
 
-        culture.change(function () {
+            culture.change(function () {
+                flipCulture();
+            });
+
             flipCulture();
-        });
-
-        flipCulture();
-    })(jQuery);
-//]]>
+        })(jQuery);
+        //]]>
     </script>
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/LocalizedMediaController.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/LocalizedMediaController.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Mvc;
+using Orchard.ContentManagement;
+using Orchard.Core.Common.Models;
+using Orchard.Core.Title.Models;
+using Orchard.Environment.Extensions;
+using Orchard.Indexing;
+using Orchard.Localization;
+using Orchard.Localization.Models;
+using Orchard.Localization.Services;
+using Orchard.Logging;
+using Orchard.MediaLibrary.Models;
+using Orchard.MediaLibrary.Services;
+using Orchard.MediaLibrary.ViewModels;
+using Orchard.Themes;
+using Orchard.UI.Admin;
+
+namespace Orchard.MediaLibrary.Controllers {
+    [Admin]
+    [Themed(false)]
+    [OrchardFeature("Orchard.MediaLibrary.LocalizationExtensions")]
+    public class LocalizedMediaController : Controller {
+        private readonly IContentManager _contentManager;
+        private readonly IMediaLibraryService _mediaLibraryService;
+        private readonly ICultureManager _cultureManager;
+
+        public LocalizedMediaController(IOrchardServices services,
+                                        IContentManager contentManager, 
+                                        ICultureManager cultureManager,
+                                        IMediaLibraryService mediaLibraryService) {
+            _contentManager = contentManager;
+            _mediaLibraryService = mediaLibraryService;
+            _cultureManager = cultureManager;
+            Services = services;
+
+            T = NullLocalizer.Instance;
+            Logger = NullLogger.Instance;
+
+        }
+        public IOrchardServices Services { get; set; }
+        public Localizer T { get; set; }
+        public ILogger Logger { get; set; }
+        public ActionResult MediaItems(string folderPath, int skip = 0, int count = 0, string order = "created", string mediaType = "", string culture = "") {
+            if (String.IsNullOrWhiteSpace(folderPath)) {
+                folderPath = null;
+            }
+            if (!_mediaLibraryService.CheckMediaFolderPermission(Permissions.SelectMediaContent, folderPath)) {
+                Services.Notifier.Add(UI.Notify.NotifyType.Error, T("Cannot select media"));
+                var model = new MediaManagerMediaItemsViewModel {
+                    MediaItems = new List<MediaManagerMediaItemViewModel>(),
+                    MediaItemsCount = 0,
+                    FolderPath = folderPath
+                };
+
+                return View(model);
+            }
+
+            // Check permission
+            if (!_mediaLibraryService.CheckMediaFolderPermission(Permissions.SelectMediaContent, folderPath) && !_mediaLibraryService.CanManageMediaFolder(folderPath)) {
+                var model = new MediaManagerMediaItemsViewModel {
+                    MediaItems = new List<MediaManagerMediaItemViewModel>(),
+                    MediaItemsCount = 0,
+                    FolderPath = folderPath
+                };
+
+                return View(model);
+            }
+
+            IEnumerable<MediaPart> mediaParts;
+            var mediaPartsCount = 0;
+            if (culture == "") {
+                mediaParts = _mediaLibraryService.GetMediaContentItems(folderPath, skip, count, order, mediaType, VersionOptions.Latest);
+                mediaPartsCount = _mediaLibraryService.GetMediaContentItemsCount(folderPath, mediaType, VersionOptions.Latest);
+            }
+            else {
+                var cultureId = _cultureManager.GetCultureByName(culture).Id;
+                var query = BuildGetMediaContentItemsQuery(Services.ContentManager, folderPath, order: order, mediaType: mediaType, versionOptions: VersionOptions.Latest)
+                    .Join<LocalizationPartRecord>()
+                    .Where(x => x.CultureId == cultureId)
+                    .Join<MediaPartRecord>();
+                mediaParts = query
+                    .Slice(skip, count);
+                mediaPartsCount = query.Count();
+            }
+
+            var mediaItems = mediaParts.Select(x => new MediaManagerMediaItemViewModel {
+                MediaPart = x,
+                Shape = Services.ContentManager.BuildDisplay(x.ContentItem, "Thumbnail")
+            }).ToList();
+
+            var viewModel = new MediaManagerMediaItemsViewModel {
+                MediaItems = mediaItems,
+                MediaItemsCount = mediaPartsCount,
+                FolderPath = folderPath
+            };
+            return View(viewModel);
+        }
+
+        //TODO: extract the logic from MediaLibraryService and insert a method definition into IMediaLibraryService in order to give a point of extension
+        private static IContentQuery<MediaPart> BuildGetMediaContentItemsQuery(
+            IContentManager contentManager, string folderPath = null, bool recursive = false, string order = null, string mediaType = null, VersionOptions versionOptions = null) {
+
+            var query = contentManager.Query<MediaPart>(versionOptions);
+
+            query = query.Join<MediaPartRecord>();
+
+            if (!String.IsNullOrEmpty(mediaType)) {
+                query = query.ForType(new[] { mediaType });
+            }
+
+            if (!String.IsNullOrEmpty(folderPath)) {
+                if (recursive) {
+                    query = query.Join<MediaPartRecord>().Where(m => m.FolderPath.StartsWith(folderPath));
+                }
+                else {
+                    query = query.Join<MediaPartRecord>().Where(m => m.FolderPath == folderPath);
+                }
+            }
+
+            switch (order) {
+                case "title":
+                    query = query.Join<TitlePartRecord>()
+                        .OrderBy(x => x.Title)
+                        .Join<MediaPartRecord>();
+                    break;
+
+                case "modified":
+                    query = query.Join<CommonPartRecord>()
+                        .OrderByDescending(x => x.ModifiedUtc)
+                        .Join<MediaPartRecord>();
+                    break;
+
+                case "published":
+                    query = query.Join<CommonPartRecord>()
+                        .OrderByDescending(x => x.PublishedUtc)
+                        .Join<MediaPartRecord>();
+                    break;
+
+                default:
+                    query = query.Join<CommonPartRecord>()
+                        .OrderByDescending(x => x.CreatedUtc)
+                        .Join<MediaPartRecord>();
+                    break;
+            }
+
+            query = query.Join<MediaPartRecord>();
+
+            return query;
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/AudioPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/AudioPartDriver.cs
@@ -1,4 +1,5 @@
 ﻿using Orchard.ContentManagement.Drivers;
+using Orchard.ContentManagement.Handlers;
 using Orchard.MediaLibrary.Models;
 
 namespace Orchard.MediaLibrary.Drivers {
@@ -25,6 +26,9 @@ namespace Orchard.MediaLibrary.Drivers {
             context.ImportAttribute(part.PartDefinition.Name, "Length", length =>
                 part.Length = int.Parse(length)
             );
+        }
+        protected override void Cloning(AudioPart originalPart, AudioPart clonePart, CloneContentContext context) {
+            clonePart.Length = originalPart.Length;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/DocumentPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/DocumentPartDriver.cs
@@ -1,4 +1,5 @@
 ﻿using Orchard.ContentManagement.Drivers;
+using Orchard.ContentManagement.Handlers;
 using Orchard.MediaLibrary.Models;
 
 namespace Orchard.MediaLibrary.Drivers {
@@ -25,6 +26,9 @@ namespace Orchard.MediaLibrary.Drivers {
             context.ImportAttribute(part.PartDefinition.Name, "Length", length =>
                 part.Length = int.Parse(length)
             );
+        }
+        protected override void Cloning(DocumentPart originalPart, DocumentPart clonePart, CloneContentContext context) {
+            clonePart.Length = originalPart.Length;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/ImagePartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/ImagePartDriver.cs
@@ -1,5 +1,6 @@
 ﻿using Orchard.ContentManagement;
 using Orchard.ContentManagement.Drivers;
+using Orchard.ContentManagement.Handlers;
 using Orchard.MediaLibrary.Models;
 
 namespace Orchard.MediaLibrary.Drivers {
@@ -32,6 +33,11 @@ namespace Orchard.MediaLibrary.Drivers {
             context.ImportAttribute(part.PartDefinition.Name, "Width", width =>
                 part.Width = int.Parse(width)
             );
+        }
+
+        protected override void Cloning(ImagePart originalPart, ImagePart clonePart, CloneContentContext context) {
+            clonePart.Height = originalPart.Height;
+            clonePart.Width = originalPart.Width;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryExplorerLocalizationExtensionsPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryExplorerLocalizationExtensionsPartDriver.cs
@@ -1,0 +1,19 @@
+﻿using Orchard.ContentManagement.Drivers;
+using Orchard.Environment.Extensions;
+using Orchard.Localization.Services;
+using Orchard.MediaLibrary.Models;
+
+namespace Orchard.MediaLibrary.Drivers {
+    [OrchardFeature("Orchard.MediaLibrary.LocalizationExtensions")]
+    public class MediaLibraryExplorerLocalizationExtensionsPartDriver : ContentPartDriver<MediaLibraryExplorerPart> {
+        private readonly ICultureManager _cultureManager;
+        public MediaLibraryExplorerLocalizationExtensionsPartDriver(ICultureManager cultureManager) {
+            _cultureManager = cultureManager;
+
+        }
+        protected override DriverResult Display(MediaLibraryExplorerPart part, string displayType, dynamic shapeHelper) {
+            var cultures = _cultureManager.ListCultures();
+            return ContentShape("Parts_MediaLibraryLocalization_Actions", () => shapeHelper.Parts_MediaLibraryLocalization_Actions(Cultures: cultures));
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaPartDriver.cs
@@ -1,11 +1,11 @@
 ﻿using Orchard.ContentManagement;
 using Orchard.ContentManagement.Drivers;
+using Orchard.ContentManagement.Handlers;
 using Orchard.Localization;
 using Orchard.MediaLibrary.Models;
 
 namespace Orchard.MediaLibrary.Drivers {
     public class MediaPartDriver : ContentPartDriver<MediaPart> {
-
         protected override string Prefix {
             get { return "MediaPart"; }
         }
@@ -27,7 +27,7 @@ namespace Orchard.MediaLibrary.Drivers {
         }
 
         protected override DriverResult Editor(MediaPart part, IUpdateModel updater, dynamic shapeHelper) {
-            updater.TryUpdateModel(part, Prefix, new[] {"Caption", "AlternateText"}, null);
+            updater.TryUpdateModel(part, Prefix, new[] { "Caption", "AlternateText" }, null);
             return Editor(part, shapeHelper);
         }
 
@@ -73,6 +73,15 @@ namespace Orchard.MediaLibrary.Drivers {
             context.Element(part.PartDefinition.Name).SetAttributeValue("FolderPath", part.FolderPath);
             context.Element(part.PartDefinition.Name).SetAttributeValue("FileName", part.FileName);
             context.Element(part.PartDefinition.Name).SetAttributeValue("LogicalType", part.LogicalType);
+        }
+
+        protected override void Cloning(MediaPart originalPart, MediaPart clonePart, CloneContentContext context) {
+            clonePart.Caption = originalPart.Caption;
+            clonePart.FileName = originalPart.FileName;
+            clonePart.FolderPath = originalPart.FolderPath;
+            clonePart.LogicalType = originalPart.LogicalType;
+            clonePart.AlternateText = originalPart.AlternateText;
+            clonePart.MimeType = originalPart.MimeType;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/OEmbedPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/OEmbedPartDriver.cs
@@ -4,9 +4,10 @@ using Orchard.ContentManagement.FieldStorage.InfosetStorage;
 using Orchard.MediaLibrary.Models;
 using System.Xml;
 using System.Xml.Linq;
+using Orchard.ContentManagement.Handlers;
+using System.Collections;
 
-namespace Orchard.MediaLibrary.Drivers
-{
+namespace Orchard.MediaLibrary.Drivers {
     public class OEmbedPartDriver : ContentPartDriver<OEmbedPart> {
         protected override DriverResult Display(OEmbedPart part, string displayType, dynamic shapeHelper) {
             return Combined(
@@ -53,6 +54,27 @@ namespace Orchard.MediaLibrary.Drivers
                 partElement = new XElement(partName);
                 element.Add(partElement);
                 partElement.Add(xmlElement.Elements());
+            }
+        }
+
+        protected override void Cloning(OEmbedPart originalPart, OEmbedPart clonePart, CloneContentContext context) {
+            var partName = XmlConvert.EncodeName(typeof(OEmbedPart).Name);
+
+            var infosetOriginalPart = originalPart.As<InfosetPart>();
+            var infosetClonePart = clonePart.As<InfosetPart>();
+            if (infosetOriginalPart != null && infosetClonePart != null) {
+                // OEmbedPart is not versionable thats why using Infoset.Element instead of VersionInfoset.Element
+                var originalElement = infosetOriginalPart.Infoset.Element;
+                var partOriginalElement = originalElement.Element(partName);
+                var cloneElement = infosetClonePart.Infoset.Element;
+                var partCloneElement = cloneElement.Element(partName);
+
+                if (partCloneElement != null)
+                    partCloneElement.Remove();
+
+                partCloneElement = new XElement(partName);
+                cloneElement.Add(partCloneElement);
+                partCloneElement.Add(partOriginalElement.Elements());
             }
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/VectorImagePartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/VectorImagePartDriver.cs
@@ -1,4 +1,5 @@
 ﻿using Orchard.ContentManagement.Drivers;
+using Orchard.ContentManagement.Handlers;
 using Orchard.MediaLibrary.Models;
 
 namespace Orchard.MediaLibrary.Drivers {
@@ -11,6 +12,10 @@ namespace Orchard.MediaLibrary.Drivers {
                 ContentShape("Parts_VectorImage", () => shapeHelper.Parts_VectorImage()),
                 ContentShape("Parts_VectorImage_SummaryAdmin", () => shapeHelper.Parts_VectorImage_SummaryAdmin())
             );
+        }
+
+        protected override void Cloning(VectorImagePart originalPart, VectorImagePart clonePart, CloneContentContext context) {
+            // nothing todo at the moment cause the part is only defined
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/VideoPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/VideoPartDriver.cs
@@ -1,4 +1,5 @@
 ﻿using Orchard.ContentManagement.Drivers;
+using Orchard.ContentManagement.Handlers;
 using Orchard.MediaLibrary.Models;
 
 namespace Orchard.MediaLibrary.Drivers {
@@ -25,6 +26,10 @@ namespace Orchard.MediaLibrary.Drivers {
             context.ImportAttribute(part.PartDefinition.Name, "Length", length =>
                 part.Length = int.Parse(length)
             );
+        }
+
+        protected override void Cloning(VideoPart originalPart, VideoPart clonePart, CloneContentContext context) {
+            clonePart.Length = originalPart.Length;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
@@ -81,7 +81,11 @@ namespace Orchard.MediaLibrary.Handlers {
                                             if (!settings.RemoveItemsWithoutLocalization) {
                                                 // The media supports translations but have not a localized version, so it will be cloned in the right language
                                                 var clonedMedia = _contentManager.Clone(mediaItem);
-                                                _localizationServices.SetContentCulture(clonedMedia, contentCulture);
+                                                var mediaLocalizationPart = mediaItem.As<LocalizationPart>();
+                                                if (mediaLocalizationPart != null) {
+                                                    _localizationServices.SetContentCulture(clonedMedia, contentCulture);
+                                                    clonedMedia.As<LocalizationPart>().MasterContentItem = mediaLocalizationPart.MasterContentItem == null ? mediaItem : mediaLocalizationPart.MasterContentItem;
+                                                }
                                                 clonedMedia.As<LocalizationPart>().MasterContentItem = mediaItem;
                                                 _contentManager.Publish(clonedMedia);
                                                 mediaIds.Add(clonedMedia.Id);

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
@@ -115,11 +115,11 @@ namespace Orchard.MediaLibrary.Handlers {
                                 }
                             }
                         }
-                        if (mediaIds.Count > 0) {
-                            field.Ids = mediaIds.Distinct().ToArray();
-                        }
-                        else if (fieldSettings.Required) {
-                            context.Updater.AddModelError("Id", T("The {0} field is required.", field.DisplayName)); 
+
+                        field.Ids = mediaIds.Distinct().ToArray();
+
+                        if (field.Ids.Length == 0 && fieldSettings.Required) {
+                            context.Updater.AddModelError("Id", T("The {0} field is required.", field.DisplayName));
                         }
                     }
                 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
@@ -1,0 +1,124 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
+using Orchard.Environment.Extensions;
+using Orchard.Localization;
+using Orchard.Localization.Models;
+using Orchard.Localization.Services;
+using Orchard.MediaLibrary.Fields;
+using Orchard.MediaLibrary.Models;
+using Orchard.MediaLibrary.Settings;
+using Orchard.UI.Notify;
+
+namespace Orchard.MediaLibrary.Handlers {
+    [OrchardFeature("Orchard.MediaLibrary.LocalizationExtensions")]
+    public class MediaLibraryPickerFieldLocalizationExtensionHandler : ContentHandler {
+        private readonly IContentManager _contentManager;
+        private readonly ILocalizationService _localizationServices;
+        private readonly IOrchardServices _orchardServices;
+
+        public MediaLibraryPickerFieldLocalizationExtensionHandler(
+            IOrchardServices orchardServices,
+            IContentManager contentManager,
+            ILocalizationService localizationServices) {
+            _contentManager = contentManager;
+            _orchardServices = orchardServices;
+            _localizationServices = localizationServices;
+            T = NullLocalizer.Instance;
+        }
+
+        public Localizer T { get; set; }
+
+        protected override void UpdateEditorShape(UpdateEditorContext context) {
+            //Here we implement the logic based on the settings introduced in MediaLibraryPickerFieldLocalizationSettings
+            //These settings should only be active if the ContentItem that is being updated has a LocalizationPart
+            if (context.ContentItem.Parts.Any(part => part is LocalizationPart)) {
+                var lPart = (LocalizationPart)context.ContentItem.Parts.Single(part => part is LocalizationPart);
+                var fields = context.ContentItem.Parts.SelectMany(x => x.Fields.Where(f => f.FieldDefinition.Name == typeof(MediaLibraryPickerField).Name)).Cast<MediaLibraryPickerField>();
+                var contentCulture = context.ContentItem.As<LocalizationPart>().Culture != null ? context.ContentItem.As<LocalizationPart>().Culture.Culture : null;
+                foreach (var field in fields) {
+                    var fieldSettings = field.PartFieldDefinition.Settings.GetModel<MediaLibraryPickerFieldSettings>();
+                    var settings = field.PartFieldDefinition.Settings.GetModel<MediaLibraryPickerFieldLocalizationSettings>();
+
+                    if (settings.TryToLocalizeMedia) {
+                        //try to replace items in the field with their translation
+                        var itemsInField = _contentManager.GetMany<ContentItem>(field.Ids, VersionOptions.Latest, QueryHints.Empty);
+                        var mediaIds = new List<int>();
+                        foreach (var item in itemsInField) {
+                            // negatives id whoud be localized
+                            var mediaItem = _contentManager.Get(item.Id, VersionOptions.Latest);
+                            var mediaIsLocalizable = mediaItem.As<LocalizationPart>() != null;
+                            var mediaCulture = mediaIsLocalizable && mediaItem.As<LocalizationPart>().Culture != null ? mediaItem.As<LocalizationPart>().Culture.Culture : null;
+                            if (mediaItem != null && mediaIsLocalizable) {
+                                // The media is localizable
+                                if (contentCulture == mediaCulture) {
+                                    // The content culture and the media culture match
+                                    mediaIds.Add(mediaItem.Id);
+                                }
+                                else {
+                                    if (mediaCulture == null) {
+                                        // The media has not a culture, so it takes the content culture
+                                        _localizationServices.SetContentCulture(mediaItem, contentCulture);
+                                        _orchardServices.Notifier.Warning(T(
+                                            "{0}: the media item {1} was culture neutral and it has been localized",
+                                            field.DisplayName,
+                                            mediaItem.As<MediaPart>().FileName));
+                                    }
+                                    else {
+                                        // The media has a culture
+                                        var localizedMedia = _localizationServices.GetLocalizedContentItem(mediaItem, contentCulture);
+                                        if (localizedMedia != null) {
+                                            // The media has a translation, so the field will replace current media with the right localized one.
+                                            mediaIds.Add(localizedMedia.Id);
+                                            _orchardServices.Notifier.Warning(T(
+                                                "{0}: the media item {1} has been replaced by its localized version",
+                                                field.DisplayName,
+                                                mediaItem.As<MediaPart>().FileName));
+                                        }
+                                        else {
+                                            if (!settings.RemoveItemsWithoutLocalization) {
+                                                // The media supports translations but have not a localized version, so it will be cloned in the right language
+                                                var clonedMedia = _contentManager.Clone(mediaItem);
+                                                _localizationServices.SetContentCulture(clonedMedia, mediaItem, contentCulture);
+                                                _contentManager.Publish(clonedMedia);
+                                                mediaIds.Add(clonedMedia.Id);
+                                                _orchardServices.Notifier.Warning(T(
+                                                    "{0}: a localized version of media item {1} has been created",
+                                                    field.DisplayName,
+                                                    mediaItem.As<MediaPart>().FileName));
+                                            }
+                                            else {
+                                                _orchardServices.Notifier.Warning(T(
+                                                    "{0}: the media item {1} has been removed from the field because its culture differs from content's culture",
+                                                    field.DisplayName,
+                                                    mediaItem.As<MediaPart>().FileName));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            else if (mediaItem != null && !mediaIsLocalizable) {
+                                if (!settings.RemoveItemsWithNoLocalizationPart) {
+                                    mediaIds.Add(mediaItem.Id);
+                                }
+                                else {
+                                    _orchardServices.Notifier.Warning(T(
+                                        "{0}: the media item {1} has been removed from the field because culture neutral",
+                                        field.DisplayName,
+                                        mediaItem.As<MediaPart>().FileName));
+                                }
+                            }
+                        }
+                        if (mediaIds.Count > 0) {
+                            field.Ids = mediaIds.Distinct().ToArray();
+                        }
+                        else if (fieldSettings.Required) {
+                            context.Updater.AddModelError("Id", T("The {0} field is required.", field.DisplayName)); 
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
@@ -86,7 +86,6 @@ namespace Orchard.MediaLibrary.Handlers {
                                                     _localizationServices.SetContentCulture(clonedMedia, contentCulture);
                                                     clonedMedia.As<LocalizationPart>().MasterContentItem = mediaLocalizationPart.MasterContentItem == null ? mediaItem : mediaLocalizationPart.MasterContentItem;
                                                 }
-                                                clonedMedia.As<LocalizationPart>().MasterContentItem = mediaItem;
                                                 _contentManager.Publish(clonedMedia);
                                                 mediaIds.Add(clonedMedia.Id);
                                                 _orchardServices.Notifier.Warning(T(

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
@@ -81,7 +81,8 @@ namespace Orchard.MediaLibrary.Handlers {
                                             if (!settings.RemoveItemsWithoutLocalization) {
                                                 // The media supports translations but have not a localized version, so it will be cloned in the right language
                                                 var clonedMedia = _contentManager.Clone(mediaItem);
-                                                _localizationServices.SetContentCulture(clonedMedia, mediaItem, contentCulture);
+                                                _localizationServices.SetContentCulture(clonedMedia, contentCulture);
+                                                clonedMedia.As<LocalizationPart>().MasterContentItem = mediaItem;
                                                 _contentManager.Publish(clonedMedia);
                                                 mediaIds.Add(clonedMedia.Id);
                                                 _orchardServices.Notifier.Warning(T(

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Handlers/MediaLibraryPickerFieldLocalizationExtensionHandler.cs
@@ -60,6 +60,7 @@ namespace Orchard.MediaLibrary.Handlers {
                                     if (mediaCulture == null) {
                                         // The media has not a culture, so it takes the content culture
                                         _localizationServices.SetContentCulture(mediaItem, contentCulture);
+                                        mediaIds.Add(mediaItem.Id);
                                         _orchardServices.Notifier.Warning(T(
                                             "{0}: the media item {1} was culture neutral and it has been localized",
                                             field.DisplayName,

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/MediaLocalizationMigrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/MediaLocalizationMigrations.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq;
+using Orchard.ContentManagement.MetaData;
+using Orchard.Core.Contents.Extensions;
+using Orchard.Data.Migration;
+using Orchard.Environment.Extensions;
+using Orchard.Localization.Models;
+
+namespace Orchard.MediaLibrary {
+
+    [OrchardFeature("Orchard.MediaLibrary.LocalizationExtensions")]
+    public class MediaLocalizationMigrations : DataMigrationImpl {
+        public int Create() {
+            var mediaContentTypes = ContentDefinitionManager.ListTypeDefinitions().Where(x => x.Settings.ContainsKey("Stereotype") && x.Settings["Stereotype"].Equals("Media", System.StringComparison.InvariantCultureIgnoreCase));
+            // adds LocalizationPart to all "Media" stereotypes
+            foreach (var mediaCT in mediaContentTypes) {
+                ContentDefinitionManager.AlterTypeDefinition(mediaCT.Name, td => td
+                .WithPart("LocalizationPart"));
+            }
+            return 1;
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Module.txt
@@ -11,3 +11,8 @@ Features:
         Description: Provides enhanced Media management tools.
         Dependencies: Title, Orchard.ContentTypes, Orchard.MediaProcessing, Orchard.Tokens, Orchard.Resources
         Category: Media
+    Orchard.MediaLibrary.LocalizationExtensions:
+		Name: Media Library Localization Extensions
+		Description: Provides settings to enable advanced localization behaviours for Media Library and Media Library Picker Field.
+        Dependencies: Orchard.MediaLibrary, Orchard.Localization
+        Category: Media

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
@@ -128,13 +128,17 @@
     </Content>
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
+    <Compile Include="Controllers\LocalizedMediaController.cs" />
+    <Compile Include="Drivers\MediaLibraryExplorerLocalizationExtensionsPartDriver.cs" />
     <Compile Include="Drivers\VectorImagePartDriver.cs" />
     <Compile Include="Extensions\ContentItemExtensions.cs" />
     <Compile Include="Extensions\MediaMetaDataExtensions.cs" />
     <Compile Include="Factories\VectorImageFactory.cs" />
     <Compile Include="Handlers\MediaItemHandler.cs" />
+    <Compile Include="Handlers\MediaLibraryPickerFieldLocalizationExtensionHandler.cs" />
     <Compile Include="Handlers\MediaLibrarySettingsPartHandler.cs" />
     <Compile Include="Implementation\DefaultMediaUsername.cs" />
+    <Compile Include="MediaLocalizationMigrations.cs" />
     <Compile Include="Models\MediaLibrarySettingsPart.cs" />
     <Compile Include="Models\VectorImagePart.cs" />
     <Compile Include="Models\IMediaFolder.cs" />
@@ -158,6 +162,10 @@
     <ProjectReference Include="..\Orchard.ContentTypes\Orchard.ContentTypes.csproj">
       <Project>{0E7646E8-FE8F-43C1-8799-D97860925EC4}</Project>
       <Name>Orchard.ContentTypes</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Orchard.Localization\Orchard.Localization.csproj">
+      <Project>{FBC8B571-ED50-49D8-8D9D-64AB7454A0D6}</Project>
+      <Name>Orchard.Localization</Name>
     </ProjectReference>
     <ProjectReference Include="..\Orchard.Tokens\Orchard.Tokens.csproj">
       <Project>{6f759635-13d7-4e94-bcc9-80445d63f117}</Project>
@@ -215,6 +223,8 @@
     <Compile Include="Services\MediaLibraryService.cs" />
     <Compile Include="Services\Shapes.cs" />
     <Compile Include="Services\XmlRpcHandler.cs" />
+    <Compile Include="Settings\MediaLibraryPickerFieldLocalizationEditorEvents.cs" />
+    <Compile Include="Settings\MediaLibraryPickerFieldLocalizationSettings.cs" />
     <Compile Include="Settings\MediaLibraryPickerFieldEditorEvents.cs" />
     <Compile Include="Settings\MediaLibraryPickerFieldSettings.cs" />
     <Compile Include="Tokens\FieldTokens.cs" />
@@ -415,6 +425,28 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Parts\Localization.ContentTranslations.SummaryAdmin-Image.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Parts\Localization.ContentTranslations.SummaryAdmin-Audio.cshtml" />
+    <Content Include="Views\Parts\Localization.ContentTranslations.SummaryAdmin-Document.cshtml" />
+    <Content Include="Views\Parts\Localization.ContentTranslations.SummaryAdmin-OEmbed.cshtml" />
+    <Content Include="Views\Parts\Localization.ContentTranslations.SummaryAdmin-VectorImage.cshtml" />
+    <Content Include="Views\Parts\Localization.ContentTranslations.SummaryAdmin-Video.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Localization.ContentTranslations.SummaryAdmin.ForMedia.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\DefinitionTemplates\MediaLibraryPickerFieldLocalizationSettings.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Parts\MediaLibraryLocalization.Actions.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\LocalizedMedia\MediaItems.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Placement.info
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Placement.info
@@ -132,4 +132,10 @@
       Parts_MediaLibrary_Navigation="Navigation:5"
   />
 
+  <Place
+  Parts_MediaLibraryLocalization_Actions="Actions:6"
+  Parts_MediaLibraryLocalization_Navigation="Navigation:1"
+  />
+
+
 </Placement>

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Scripts/media-library.js
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Scripts/media-library.js
@@ -118,8 +118,10 @@ $(function () {
                 return css;
             });
 
-            self.publicationStatus = ko.computed(function() {
-                return self.data.published ? "" : draftText;
+            self.mediaInfos = ko.computed(function () {
+                var pubStatus = self.data.published ? "" : draftText;
+                var localization = (self.data.localization != "" ? "(" + self.data.localization + ")" : "");
+                return pubStatus + " " + localization;
             });
 
             // operations

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/MediaLibraryService.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/MediaLibraryService.cs
@@ -80,7 +80,8 @@ namespace Orchard.MediaLibrary.Services {
             return BuildGetMediaContentItemsQuery(_orchardServices.ContentManager, folderPath, true, mediaType: mediaType, versionOptions: versionOptions)
                 .Count();
         }
-
+        
+        //TODO: extract the logic from MediaLibraryService and add a method definition into IMediaLibraryService in order to give a point of extension
         private static IContentQuery<MediaPart> BuildGetMediaContentItemsQuery(
             IContentManager contentManager, string folderPath = null, bool recursive = false, string order = null, string mediaType = null, VersionOptions versionOptions = null) {
 

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Settings/MediaLibraryPickerFieldLocalizationEditorEvents.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Settings/MediaLibraryPickerFieldLocalizationEditorEvents.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.MetaData;
+using Orchard.ContentManagement.MetaData.Builders;
+using Orchard.ContentManagement.MetaData.Models;
+using Orchard.ContentManagement.ViewModels;
+using Orchard.Environment.Extensions;
+
+namespace Orchard.MediaLibrary.Settings {
+    [OrchardFeature("Orchard.MediaLibrary.LocalizationExtensions")]
+    public class MediaLibraryPickerFieldLocalizationEditorEvents : ContentDefinitionEditorEventsBase {
+
+        public override IEnumerable<TemplateViewModel> PartFieldEditor(ContentPartFieldDefinition definition) {
+            if (definition.FieldDefinition.Name == "MediaLibraryPickerField") {
+                var model = definition.Settings.GetModel<MediaLibraryPickerFieldLocalizationSettings>();
+                yield return DefinitionTemplate(model);
+            }
+        }
+
+        public override IEnumerable<TemplateViewModel> PartFieldEditorUpdate(ContentPartFieldDefinitionBuilder builder, IUpdateModel updateModel) {
+            if (builder.FieldType != "MediaLibraryPickerField") {
+                yield break;
+            }
+
+            var model = new MediaLibraryPickerFieldLocalizationSettings();
+            if (updateModel.TryUpdateModel(model, "MediaLibraryPickerFieldLocalizationSettings", null, null)) {
+                builder.WithSetting("MediaLibraryPickerFieldLocalizationSettings.TryToLocalizeMedia", model.TryToLocalizeMedia.ToString(CultureInfo.InvariantCulture));
+                builder.WithSetting("MediaLibraryPickerFieldLocalizationSettings.RemoveItemsWithoutLocalization", model.RemoveItemsWithoutLocalization.ToString(CultureInfo.InvariantCulture));
+                builder.WithSetting("MediaLibraryPickerFieldLocalizationSettings.RemoveItemsWithNoLocalizationPart", model.RemoveItemsWithNoLocalizationPart.ToString(CultureInfo.InvariantCulture));
+            }
+
+            yield return DefinitionTemplate(model);
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Settings/MediaLibraryPickerFieldLocalizationSettings.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Settings/MediaLibraryPickerFieldLocalizationSettings.cs
@@ -1,0 +1,17 @@
+﻿using Orchard.Environment.Extensions;
+
+namespace Orchard.MediaLibrary.Settings {
+    [OrchardFeature("Orchard.MediaLibrary.LocalizationExtensions")]
+    public class MediaLibraryPickerFieldLocalizationSettings {
+
+        public MediaLibraryPickerFieldLocalizationSettings() {
+            TryToLocalizeMedia = true;
+            RemoveItemsWithoutLocalization = false;
+            RemoveItemsWithNoLocalizationPart = false; 
+
+        }
+        public bool TryToLocalizeMedia { get; set; }
+        public bool RemoveItemsWithoutLocalization { get; set; }
+        public bool RemoveItemsWithNoLocalizationPart { get; set; }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Styles/media-library-picker-admin.css
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Styles/media-library-picker-admin.css
@@ -42,15 +42,19 @@
     text-align: right;
     font-size: 12px;
     opacity: 0.6;
+    height: 40px;
 }
 
 .overlay h3 {
     padding-right:5px;
     font-size: 12px;
-    height: 40px;
     overflow: hidden;
 }
 
+.overlay .pubblication-status {
+    padding-right:5px;
+    overflow: hidden;
+}
 .media-thumbnail {
     width: 120px;
     height: 120px;

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Admin/Index.cshtml
@@ -43,7 +43,7 @@
                         </div>
                         <div class="media-library-main-list-overlay">
                             <p class="title" data-bind="text: data.title, attr: { title: data.title }"></p>
-                            <p class="publication-status" data-bind="text: publicationStatus"></p>
+                            <p class="publication-status" data-bind="text: mediaInfos"></p>
                         </div>
                     </li>
                 </ul>
@@ -52,9 +52,12 @@
         <div id="media-library-main-editor">
             <div id="media-library-main-editor-focus" data-bind="with: focus">
                 <h1>@T("PROPERTIES")</h1>
-                <div class="summary" data-bind="html: summary">
-                    
-                </div>
+                <form>
+                    <div class="summary" data-bind="html: summary">
+
+                    </div>
+                    @Html.AntiForgeryTokenOrchard()
+                </form>
             </div>
             <article>
                 <header>
@@ -115,7 +118,7 @@ var mediaLibrarySettings = {
     <li>
         <div class="media-library-folder" data-bind="css: { 'in-progress': $root.pendingRequest() }">
             <div class="media-library-folder-title" data-bind="click: folderClicked, attr: { 'data-media-path': folderPath() }, css: {selected: isSelected()}">
-                <a href="#" class="media-library-navigation-folder-link"><i class="fa" data-bind="    css: {'fa-folder-open-o': isExpanded(), 'fa-folder-o': !isExpanded()}"></i><span data-bind="    text: name"></span></a>
+                <a href="#" class="media-library-navigation-folder-link"><i class="fa" data-bind="css: {'fa-folder-open-o': isExpanded(), 'fa-folder-o': !isExpanded()}"></i><span data-bind="text: name"></span></a>
             </div>
             <ul data-bind="template: { name: 'media-folder-template', foreach: childFolders, afterRender: afterRenderMediaFolderTemplate}, visible: isExpanded()">
             </ul>

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/DefinitionTemplates/MediaLibraryPickerFieldLocalizationSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/DefinitionTemplates/MediaLibraryPickerFieldLocalizationSettings.cshtml
@@ -1,0 +1,15 @@
+﻿@model Orchard.MediaLibrary.Settings.MediaLibraryPickerFieldLocalizationSettings
+
+<fieldset>
+    @Html.CheckBoxFor(m => m.TryToLocalizeMedia)
+    <label for="@Html.FieldIdFor(m => m.TryToLocalizeMedia)" class="forcheckbox">@T("Try to replace selected media items with their correct localization.")</label>
+    <span class="hint">@T("Check to attempt to replace media items selected in this field with their translation in the main ContentItem's culture. This only applies if the main ContentItem has a LocalizationPart.")</span>
+    <div data-controllerid="@Html.FieldIdFor(m => m.TryToLocalizeMedia)">
+        @Html.CheckBoxFor(m => m.RemoveItemsWithoutLocalization)
+        <label for="@Html.FieldIdFor(m => m.RemoveItemsWithoutLocalization)" class="forcheckbox">@T("Remove items that do not have the correct translation.")</label>
+        <span class="hint">@T("Check to remove media items from the MediaLibraryPickerField when the items selected do not have a version in the correct culture (they have a LocalizationPart, but not a translation in the main ContentItem's culture').")</span>
+        @Html.CheckBoxFor(m => m.RemoveItemsWithNoLocalizationPart)
+        <label for="@Html.FieldIdFor(m => m.RemoveItemsWithNoLocalizationPart)" class="forcheckbox">@T("Remove items that cannot be localized.")</label>
+        <span class="hint">@T("Check to remove media items from the MediaLibraryPickerField when the items selected cannot be localized (do not have a LocalizationPart).")</span>
+    </div>
+</fieldset>

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Localization.ContentTranslations.SummaryAdmin.ForMedia.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Localization.ContentTranslations.SummaryAdmin.ForMedia.cshtml
@@ -1,0 +1,22 @@
+﻿@using Orchard.Core.Contents;
+@using Orchard.Localization.Models;
+@if (AuthorizedFor(Permissions.PublishContent)) {
+    Style.Require("LocalizationAdmin");
+    IEnumerable<LocalizationPart> localizations  = Model.Localizations;
+    var localizationLinks = Html.UnorderedList(localizations, (c, i) => Html.ItemEditLink(c.Culture.Culture, c, new { ReturnUrl = Request.UrlReferrer }), "localizations");
+<div class="content-localization">
+    @if (Model.Culture != null) {
+    <div class="content-culture">@T("Culture: {0}", Model.Culture)</div>
+    } else {
+    <div class="content-culture">@T("Culture: {0}", T("Undefined"))</div>
+    }
+    @if (localizations.Count() > 0)
+    {
+    <div class="content-localizations"><h4>@T("Translations:")</h4>@localizationLinks</div>
+    }
+    @if (Model.Culture != null && !((IEnumerable<string>)Model.SiteCultures).All(c => c == Model.Culture || localizations.Any(l => c == l.Culture.Culture)))
+    {
+    <div class="add-localization">@Html.ActionLink(T("+ New translation").Text, "Translate", "Admin", new { area = "Orchard.Localization", id = Model.MasterId, ReturnUrl = Request.UrlReferrer }, new { itemprop = "UnsafeUrl" })</div>
+    }
+</div>
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/LocalizedMedia/MediaItems.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/LocalizedMedia/MediaItems.cshtml
@@ -1,6 +1,5 @@
 ﻿@using Orchard.Utility.Extensions
-@using Orchard.Localization.Models
-@using Orchard.ContentManagement
+
 @model Orchard.MediaLibrary.ViewModels.MediaManagerMediaItemsViewModel
 @{
     Response.ContentType = "text/json";

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/MediaLibraryPicker.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/MediaLibraryPicker.cshtml
@@ -1,4 +1,5 @@
 ﻿@using Orchard.ContentManagement
+@using Orchard.Localization.Models;
 @using Orchard.Utility.Extensions;
 
 @{
@@ -8,12 +9,12 @@
     Script.Require("jQueryColorBox").AtFoot();
     Script.Include("media-library-picker.js").AtFoot();
 
-    var fieldName = (string) Model.FieldName;
-    var displayName = (string) Model.DisplayName;
+    var fieldName = (string)Model.FieldName;
+    var displayName = (string)Model.DisplayName;
     var multiple = (bool)(Model.Multiple ?? false);
     var required = (bool)(Model.Required ?? false);
-    var hint = (string) Model.Hint;
-    var promptOnNavigate = (bool) (Model.PromptOnNavigate ?? true);
+    var hint = (string)Model.Hint;
+    var promptOnNavigate = (bool)(Model.PromptOnNavigate ?? true);
     var showSaveWarning = (bool)(Model.ShowSaveWarning);
     var contentItems = (IEnumerable<ContentItem>)Model.ContentItems ?? Enumerable.Empty<ContentItem>();
     var contentManager = WorkContext.Resolve<IContentManager>();
@@ -31,7 +32,7 @@
           data-return-url="@HttpUtility.JavaScriptStringEncode(Request.RawUrl)"
           data-prompt-on-navigate="@promptOnNavigate.ToString().ToLower()"
           data-show-save-warning="@showSaveWarning.ToString().ToLower()">
-    <label @if (required) { <text> class="required" </text>    }>@displayName</label>
+    <label @if (required) { <text> class="required" </text>       }>@displayName</label>
     <div class="message message-Warning media-library-picker-message">@T("You need to save your changes.")</div>
     <div class="items media-library-picker" summary="@displayName">
         <ul>
@@ -46,6 +47,15 @@
                             @Display(BuildDisplay(contentItem, "Thumbnail"))
                             <div class="overlay">
                                 <h3>@Html.ItemDisplayText(contentItem)</h3>
+                                <p class="publication-status" data-bind="text: mediaInfos">
+                                    @(contentItem.IsPublished() ? "" : T("Draft").Text)
+                                    @{
+                                        var localizationPart = contentItem.As<LocalizationPart>();
+                                        if (localizationPart != null && localizationPart.Culture != null) {
+                                            @(string.Format(" ({0})", localizationPart.Culture.Culture))
+                                        }
+                                    }
+                                </p>
                             </div>
                         </div>
                     </div>
@@ -58,7 +68,7 @@
                         </li>
                     </ul>
                 </li>
-            }
+                                        }
         </ul>
     </div>
     <div>

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-Audio.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-Audio.cshtml
@@ -1,0 +1,1 @@
+﻿@Display(New.Localization_ContentTranslations_SummaryAdmin_ForMedia(Localizations: Model.Localizations, Culture: Model.Culture,SiteCultures: Model.SiteCultures, MasterId:Model.MasterId))

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-Document.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-Document.cshtml
@@ -1,0 +1,1 @@
+﻿@Display(New.Localization_ContentTranslations_SummaryAdmin_ForMedia(Localizations: Model.Localizations, Culture: Model.Culture,SiteCultures: Model.SiteCultures, MasterId:Model.MasterId))

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-Image.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-Image.cshtml
@@ -1,0 +1,1 @@
+﻿@Display(New.Localization_ContentTranslations_SummaryAdmin_ForMedia(Localizations: Model.Localizations, Culture: Model.Culture,SiteCultures: Model.SiteCultures, MasterId:Model.MasterId))

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-OEmbed.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-OEmbed.cshtml
@@ -1,0 +1,1 @@
+﻿@Display(New.Localization_ContentTranslations_SummaryAdmin_ForMedia(Localizations: Model.Localizations, Culture: Model.Culture,SiteCultures: Model.SiteCultures, MasterId:Model.MasterId))

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-VectorImage.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-VectorImage.cshtml
@@ -1,0 +1,1 @@
+﻿@Display(New.Localization_ContentTranslations_SummaryAdmin_ForMedia(Localizations: Model.Localizations, Culture: Model.Culture,SiteCultures: Model.SiteCultures, MasterId:Model.MasterId))

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-Video.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/Localization.ContentTranslations.SummaryAdmin-Video.cshtml
@@ -1,0 +1,1 @@
+﻿@Display(New.Localization_ContentTranslations_SummaryAdmin_ForMedia(Localizations: Model.Localizations, Culture: Model.Culture,SiteCultures: Model.SiteCultures, MasterId:Model.MasterId))

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/MediaLibraryLocalization.Actions.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Parts/MediaLibraryLocalization.Actions.cshtml
@@ -1,0 +1,39 @@
+﻿
+<form style="display:inline" data-bind="submit: doCultureFilter">
+    <label for="filterLocalization">@T("Language")</label>
+    <select id="filterLocalization" name="FilterLocalization" data-bind="value: mediaCulture, event: { change: cultureFilterChanged }">
+        @Html.SelectOption("", true, T("Any (show all)").ToString())
+        @foreach (string culture in Model.Cultures) {
+            @Html.SelectOption(culture, false, culture)
+        }
+    </select>
+</form>
+
+@using (Script.Foot()) {
+<script type="text/javascript">
+    //<![CDATA[
+
+    var beforeCultureFilterVM = enhanceViewModel;
+    enhanceViewModel = function(viewModel) {
+        beforeCultureFilterVM(viewModel);
+        viewModel.mediaCulture = ko.observable();
+        viewModel.cultureFilterChanged = function (event) {
+            var culture = this.mediaCulture();
+            viewModel.doCultureFilter(culture);
+        }
+        viewModel.doCultureFilter = function (culture) {
+            var self = viewModel;
+
+            self.loadMediaItemsUrl = function (folderPath, skip, count, order, mediaType) {
+                var searchActionUrl = '@HttpUtility.JavaScriptStringEncode(Url.Action("MediaItems", "LocalizedMedia", new {area = "Orchard.MediaLibrary"}))';
+                return searchActionUrl + '?folderPath=' + folderPath + '&skip=' + skip + '&count=' + count + '&order=' + order + '&mediaType=' + mediaType + '&culture=' + culture;
+            };
+
+            self.getMediaItems(20);
+        };
+    };
+    
+    //]]>
+</script>
+
+}

--- a/src/Orchard.Web/Modules/Orchard.Search/Views/Media/MediaItems.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Search/Views/Media/MediaItems.cshtml
@@ -6,20 +6,21 @@
     new {
         mediaItemsCount = Model.MediaItemsCount,
         mediaItems = Model.MediaItems.Select(x => new {
-            id = x.MediaPart.Id, 
-            contentType = x.MediaPart.ContentItem.ContentType, 
-            contentTypeClass = x.MediaPart.ContentItem.ContentType.HtmlClassify(), 
-            title = x.MediaPart.Title, 
-            alternateText = x.MediaPart.AlternateText, 
-            caption = x.MediaPart.Caption, 
-            resource = x.MediaPart.MediaUrl, 
-            mimeType = x.MediaPart.MimeType, 
-            mimeTypeClass = x.MediaPart.MimeType.HtmlClassify(), 
+            id = x.MediaPart.Id,
+            contentType = x.MediaPart.ContentItem.ContentType,
+            contentTypeClass = x.MediaPart.ContentItem.ContentType.HtmlClassify(),
+            title = x.MediaPart.Title,
+            published = x.MediaPart.ContentItem.VersionRecord.Published,
+            alternateText = x.MediaPart.AlternateText,
+            caption = x.MediaPart.Caption,
+            resource = x.MediaPart.MediaUrl,
+            mimeType = x.MediaPart.MimeType,
+            mimeTypeClass = x.MediaPart.MimeType.HtmlClassify(),
             thumbnail = Display(x.Shape).ToString(),
-            editLink = Url.ItemEditUrl(x.MediaPart)
+            editLink = Url.ItemEditUrl(x.MediaPart),
+            localization = (((dynamic)x.MediaPart.ContentItem).LocalizationPart != null && ((dynamic)x.MediaPart.ContentItem).LocalizationPart.Culture != null) ? ((dynamic)x.MediaPart.ContentItem).LocalizationPart.CultureField.Value.Culture : ""
         }).ToArray(),
         folderPath = Model.FolderPath
     }))
 }
 
- 


### PR DESCRIPTION
Implements what opened with #7843 

"Orchard.MediaLibrary.LocalizationExtensions" feature:
- MediaLocalizationMigrations: Adds LocalizationPart to all Media stereotyped types
- MediaLibraryPickerFieldLocalizationExtensionHandler: Updates the media items within the field according to field settings
- Settings for translation behaviours for MediaLibraryPickerField
- Adds warning on localizing media items
- form filter media by culture

"MediaLibrary" feature:
- Implemented Cloning methods of all medias PartDrivers
- MediaPartHandler: Adds a check to prevent file system media deletion when the file is referenced by other medias
- ClientStorageController: Adds a check to prevent file system media deletion when the file is referenced by other medias

"Localization" feature:
- Adds a logic to propagate returnurl parameter to the redirection url
- ILocalizationService: Adds a new method to set the culture of a content and at the same time the master content of it
- Propagate returnurl parameter if necessary

"Search" feature:
- updated json of media items called via ajax