### PR TITLE
Workaround for possible NRE while indexing ContentItemRecords. (#7937)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Indexing/Services/IndexingTaskExecutor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Indexing/Services/IndexingTaskExecutor.cs
@@ -160,6 +160,9 @@ namespace Orchard.Indexing.Services {
                         .OrderBy(versionRecord => versionRecord.Id)
                         .Take(ContentItemsPerLoop)
                         .ToList()
+                        // In some rare cases a ContentItemRecord without a ContentType can end up in the DB.
+                        // We need to filter out such records, otherwise they will crash the ContentManager.
+                        .Where(x => x.ContentItemRecord != null && x.ContentItemRecord.ContentType != null)
                         .Select(versionRecord => _contentManager.Get(versionRecord.ContentItemRecord.Id, VersionOptions.VersionRecord(versionRecord.Id)))
                         .Distinct()
                         .ToList();
@@ -220,6 +223,9 @@ namespace Orchard.Indexing.Services {
                         .OrderBy(x => x.Id)
                         .Take(ContentItemsPerLoop)
                         .ToList()
+                        // In some rare cases a ContentItemRecord without a ContentType can end up in the DB.
+                        // We need to filter out such records, otherwise they will crash the ContentManager.
+                        .Where(x => x.ContentItemRecord != null && x.ContentItemRecord.ContentType != null)
                         .GroupBy(x => x.ContentItemRecord.Id)
                     .Select(group => new { TaskId = group.Max(task => task.Id), Delete = group.Last().Action == IndexingTaskRecord.Delete, Id = group.Key, ContentItem = _contentManager.Get(group.Key, VersionOptions.Latest) })
                         .OrderBy(x => x.TaskId)


### PR DESCRIPTION
This is meant as a workaround for the possible `NullReferenceException` as described in issue #7937.
It prevents `Orchard.Indexing` from crashing on corrupted `ContentItemRecords` that have no `ContentType` set.
Previously, indices weren't updated anymore once a corrupted `ContentItemRecord` made it into the database.