### PR TITLE
Fixes Duplicated media items

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Scripts/media-library-picker.js
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Scripts/media-library-picker.js
@@ -103,7 +103,7 @@
                             .replace(/\{title\}/g, selectedData[i].title)
                             .replace(/\{editLink\}/g, selectedData[i].editLink);
                         var content = $(tmpl);
-                        element.find('.media-library-picker.items ul').append(content);
+                        element.find('.media-library-picker.items ul.media-items').append(content);
                     }
                     
                     refreshIds();

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/MediaLibraryPicker.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/MediaLibraryPicker.cshtml
@@ -34,7 +34,7 @@
     <label @if (required) { <text> class="required" </text>    }>@displayName</label>
     <div class="message message-Warning media-library-picker-message">@T("You need to save your changes.")</div>
     <div class="items media-library-picker" summary="@displayName">
-        <ul>
+        <ul class="media-items">
             @foreach (var contentItem in contentItems) {
                 var editRouteValues = contentManager.GetItemMetadata(contentItem).EditorRouteValues;
                 var editUrl = Url.Action(


### PR DESCRIPTION
When updating via js (pickAdnClose) the list of items in media library picker fields updates only the <ul> containing items (with the specific css-class "media-items") not the others <ul>
Fixes #7934 