### PR TITLE
Remove headers for information discovery

### DIFF
--- a/src/Orchard.Web/Global.asax.cs
+++ b/src/Orchard.Web/Global.asax.cs
@@ -20,6 +20,7 @@ namespace Orchard.Web {
         }
 
         protected void Application_Start() {
+            MvcHandler.DisableMvcResponseHeader = true; // remove X-AspNetMvc-Version header
             RegisterRoutes(RouteTable.Routes);
             _starter = new Starter<IOrchardHost>(HostInitialization, HostBeginRequest, HostEndRequest);
             _starter.OnApplicationStart(this);
@@ -31,6 +32,9 @@ namespace Orchard.Web {
 
         protected void Application_EndRequest() {
             _starter.OnEndRequest(this);
+        }
+        protected void Application_PreSendRequestHeaders() {
+            Response.Headers.Remove("Server"); // remove Server header
         }
 
         private static void HostBeginRequest(HttpApplication application, IOrchardHost host) {

--- a/src/Orchard.Web/Web.config
+++ b/src/Orchard.Web/Web.config
@@ -52,7 +52,7 @@
 
     <system.web>
         <!-- Accept file uploads up to 64 MB. -->
-        <httpRuntime targetFramework="4.5.2" requestValidationMode="2.0" maxRequestLength="65536" />
+        <httpRuntime targetFramework="4.5.2" requestValidationMode="2.0" maxRequestLength="65536" enableVersionHeader="false" />
         <compilation debug="true" targetFramework="4.5.2" batch="true" numRecompilesBeforeAppRestart="250" optimizeCompilations="true">
             <buildProviders>
                 <add extension=".csproj" type="Orchard.Environment.Extensions.Compilers.CSharpExtensionBuildProviderShim" />

--- a/src/Orchard/Owin/Startup.cs
+++ b/src/Orchard/Owin/Startup.cs
@@ -8,7 +8,7 @@ namespace Orchard.Owin {
     public class Startup {
         public void Configuration(IAppBuilder app) {
             app.Use((context, next) => {
-                context.Response.Headers.Append("X-Generator", "Orchard");
+                // context.Response.Headers.Append("X-Generator", "Orchard"); // commenting this removes the X-Generator header
                 return next();
             });
         }


### PR DESCRIPTION
Changes to remove the following headers being flagged as possible Information Discovery Issues:

Server, X-AspNet-Version, X-AspNetMvc-Version, X-Generator

This PR is related to #7989