### PR TITLE
Fix/failed tests

### DIFF
--- a/src/Orchard.Specs/Boolean.feature
+++ b/src/Orchard.Specs/Boolean.feature
@@ -48,7 +48,7 @@ Scenario: Creating and using Boolean fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                | value                        |
-            | Fields[0].BooleanFieldSettings.Hint | Check if the event is active |
+            | Fields[Active].BooleanFieldSettings.Hint | Check if the event is active |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Check if the event is active"
@@ -57,7 +57,7 @@ Scenario: Creating and using Boolean fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value |
-            | Fields[0].BooleanFieldSettings.DefaultValue | True  |
+            | Fields[Active].BooleanFieldSettings.DefaultValue | True  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "checked=\"checked\""
@@ -66,7 +66,7 @@ Scenario: Creating and using Boolean fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value |
-            | Fields[0].BooleanFieldSettings.Optional     | false |
+            | Fields[Active].BooleanFieldSettings.Optional     | false |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
         And I fill in 

--- a/src/Orchard.Specs/Boolean.feature.cs
+++ b/src/Orchard.Specs/Boolean.feature.cs
@@ -157,7 +157,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table4.AddRow(new string[] {
-                        "Fields[0].BooleanFieldSettings.Hint",
+                        "Fields[Active].BooleanFieldSettings.Hint",
                         "Check if the event is active"});
 #line 49
         testRunner.And("I fill in", ((string)(null)), table4, "And ");
@@ -174,7 +174,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table5.AddRow(new string[] {
-                        "Fields[0].BooleanFieldSettings.DefaultValue",
+                        "Fields[Active].BooleanFieldSettings.DefaultValue",
                         "True"});
 #line 58
         testRunner.And("I fill in", ((string)(null)), table5, "And ");
@@ -191,7 +191,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table6.AddRow(new string[] {
-                        "Fields[0].BooleanFieldSettings.Optional",
+                        "Fields[Active].BooleanFieldSettings.Optional",
                         "false"});
 #line 67
         testRunner.And("I fill in", ((string)(null)), table6, "And ");

--- a/src/Orchard.Specs/DateTime.feature
+++ b/src/Orchard.Specs/DateTime.feature
@@ -61,7 +61,7 @@ Scenario: Creating and using Date fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                 | value                       |
-            | Fields[0].DateTimeFieldSettings.Hint | Enter the date of the event |
+            | Fields[EventDate].DateTimeFieldSettings.Hint | Enter the date of the event |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Enter the date of the event"
@@ -70,7 +70,7 @@ Scenario: Creating and using Date fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                    | value    |
-            | Fields[0].DateTimeFieldSettings.Display | DateOnly |
+            | Fields[EventDate].DateTimeFieldSettings.Display | DateOnly |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Event.EventDate.Editor.Date"
@@ -80,7 +80,7 @@ Scenario: Creating and using Date fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                    | value    |
-            | Fields[0].DateTimeFieldSettings.Display | TimeOnly |
+            | Fields[EventDate].DateTimeFieldSettings.Display | TimeOnly |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Event.EventDate.Editor.Time"
@@ -90,8 +90,8 @@ Scenario: Creating and using Date fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                     | value       |
-            | Fields[0].DateTimeFieldSettings.Display  | DateAndTime |
-            | Fields[0].DateTimeFieldSettings.Required | true        |
+            | Fields[EventDate].DateTimeFieldSettings.Display  | DateAndTime |
+            | Fields[EventDate].DateTimeFieldSettings.Required | true        |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Event.EventDate.Editor.Date"
@@ -119,8 +119,8 @@ Scenario: Creating and using Date fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                     | value    |
-            | Fields[0].DateTimeFieldSettings.Display  | DateOnly |
-            | Fields[0].DateTimeFieldSettings.Required | true     |
+            | Fields[EventDate].DateTimeFieldSettings.Display  | DateOnly |
+            | Fields[EventDate].DateTimeFieldSettings.Required | true     |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Event.EventDate.Editor.Date"
@@ -131,8 +131,8 @@ Scenario: Creating and using Date fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                     | value    |
-            | Fields[0].DateTimeFieldSettings.Display  | TimeOnly |
-            | Fields[0].DateTimeFieldSettings.Required | true     |
+            | Fields[EventDate].DateTimeFieldSettings.Display  | TimeOnly |
+            | Fields[EventDate].DateTimeFieldSettings.Required | true     |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Event.EventDate.Editor.Date"
@@ -143,9 +143,9 @@ Scenario: Creating and using Date fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value       |
-            | Fields[0].DateTimeFieldSettings.Display     | DateAndTime |
-            | Fields[0].DateTimeFieldSettings.Editor.Date | 01/31/2016  |
-            | Fields[0].DateTimeFieldSettings.Editor.Time | 10:00 AM    |
+            | Fields[EventDate].DateTimeFieldSettings.Display     | DateAndTime |
+            | Fields[EventDate].DateTimeFieldSettings.Editor.Date | 01/31/2016  |
+            | Fields[EventDate].DateTimeFieldSettings.Editor.Time | 10:00 AM    |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Event.EventDate.Editor.Date"
@@ -190,8 +190,8 @@ Scenario: Creating and using date time fields in another culture
         And I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                     | value       |
-            | Fields[0].DateTimeFieldSettings.Display  | DateAndTime |
-            | Fields[0].DateTimeFieldSettings.Required | true        |
+            | Fields[EventDate].DateTimeFieldSettings.Display  | DateAndTime |
+            | Fields[EventDate].DateTimeFieldSettings.Required | true        |
         And I hit "Save"
     When I go to "Admin/Contents/Create/Event"
         And I fill in 

--- a/src/Orchard.Specs/DateTime.feature.cs
+++ b/src/Orchard.Specs/DateTime.feature.cs
@@ -186,7 +186,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table6.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Hint",
+                        "Fields[EventDate].DateTimeFieldSettings.Hint",
                         "Enter the date of the event"});
 #line 62
         testRunner.And("I fill in", ((string)(null)), table6, "And ");
@@ -203,7 +203,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table7.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Display",
+                        "Fields[EventDate].DateTimeFieldSettings.Display",
                         "DateOnly"});
 #line 71
         testRunner.And("I fill in", ((string)(null)), table7, "And ");
@@ -222,7 +222,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table8.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Display",
+                        "Fields[EventDate].DateTimeFieldSettings.Display",
                         "TimeOnly"});
 #line 81
         testRunner.And("I fill in", ((string)(null)), table8, "And ");
@@ -241,10 +241,10 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table9.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Display",
+                        "Fields[EventDate].DateTimeFieldSettings.Display",
                         "DateAndTime"});
             table9.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Required",
+                        "Fields[EventDate].DateTimeFieldSettings.Required",
                         "true"});
 #line 91
         testRunner.And("I fill in", ((string)(null)), table9, "And ");
@@ -309,10 +309,10 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table13.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Display",
+                        "Fields[EventDate].DateTimeFieldSettings.Display",
                         "DateOnly"});
             table13.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Required",
+                        "Fields[EventDate].DateTimeFieldSettings.Required",
                         "true"});
 #line 120
         testRunner.And("I fill in", ((string)(null)), table13, "And ");
@@ -333,10 +333,10 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table14.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Display",
+                        "Fields[EventDate].DateTimeFieldSettings.Display",
                         "TimeOnly"});
             table14.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Required",
+                        "Fields[EventDate].DateTimeFieldSettings.Required",
                         "true"});
 #line 132
         testRunner.And("I fill in", ((string)(null)), table14, "And ");
@@ -357,13 +357,13 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table15.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Display",
+                        "Fields[EventDate].DateTimeFieldSettings.Display",
                         "DateAndTime"});
             table15.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Editor.Date",
+                        "Fields[EventDate].DateTimeFieldSettings.Editor.Date",
                         "01/31/2016"});
             table15.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Editor.Time",
+                        "Fields[EventDate].DateTimeFieldSettings.Editor.Time",
                         "10:00 AM"});
 #line 144
         testRunner.And("I fill in", ((string)(null)), table15, "And ");
@@ -461,10 +461,10 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table18.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Display",
+                        "Fields[EventDate].DateTimeFieldSettings.Display",
                         "DateAndTime"});
             table18.AddRow(new string[] {
-                        "Fields[0].DateTimeFieldSettings.Required",
+                        "Fields[EventDate].DateTimeFieldSettings.Required",
                         "true"});
 #line 191
         testRunner.And("I fill in", ((string)(null)), table18, "And ");

--- a/src/Orchard.Specs/Enumeration.feature
+++ b/src/Orchard.Specs/Enumeration.feature
@@ -35,7 +35,7 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                       | value   |
-            | Fields[0].EnumerationFieldSettings.Options | Seattle |
+            | Fields[Location].EnumerationFieldSettings.Options | Seattle |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "<option>Seattle</option>"
@@ -57,7 +57,7 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                    | value                    |
-            | Fields[0].EnumerationFieldSettings.Hint | Please select a location |
+            | Fields[Location].EnumerationFieldSettings.Hint | Please select a location |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Please select a location"
@@ -66,7 +66,7 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value    |
-            | Fields[0].EnumerationFieldSettings.ListMode | Dropdown |
+            | Fields[Location].EnumerationFieldSettings.ListMode | Dropdown |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "select id=\"Event_Location_Value\" name=\"Event.Location.Value\""
@@ -75,7 +75,7 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value       |
-            | Fields[0].EnumerationFieldSettings.ListMode | Radiobutton |
+            | Fields[Location].EnumerationFieldSettings.ListMode | Radiobutton |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "input id=\"Event_Location_Value\" name=\"Event.Location.Value\" type=\"radio\""
@@ -84,7 +84,7 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value   |
-            | Fields[0].EnumerationFieldSettings.ListMode | Listbox |
+            | Fields[Location].EnumerationFieldSettings.ListMode | Listbox |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "select id=\"Event_Location_SelectedValues\" multiple=\"multiple\" name=\"Event.Location.SelectedValues\""
@@ -93,7 +93,7 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value    |
-            | Fields[0].EnumerationFieldSettings.ListMode | Checkbox |
+            | Fields[Location].EnumerationFieldSettings.ListMode | Checkbox |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "input type=\"checkbox\" name=\"Event.Location.SelectedValues\""
@@ -102,7 +102,7 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value |
-            | Fields[0].EnumerationFieldSettings.Required | true  |
+            | Fields[Location].EnumerationFieldSettings.Required | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
         And I hit "Save"
@@ -112,9 +112,9 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                            | value    |
-            | Fields[0].EnumerationFieldSettings.Options      | Seattle  |
-            | Fields[0].EnumerationFieldSettings.ListMode     | Dropdown |
-            | Fields[0].EnumerationFieldSettings.DefaultValue | Seattle  |
+            | Fields[Location].EnumerationFieldSettings.Options      | Seattle  |
+            | Fields[Location].EnumerationFieldSettings.ListMode     | Dropdown |
+            | Fields[Location].EnumerationFieldSettings.DefaultValue | Seattle  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "selected=\"selected">Seattle"
@@ -123,8 +123,8 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                            | value   |
-            | Fields[0].EnumerationFieldSettings.Required     | true    |
-            | Fields[0].EnumerationFieldSettings.ListMode     | Listbox |
+            | Fields[Location].EnumerationFieldSettings.Required     | true    |
+            | Fields[Location].EnumerationFieldSettings.ListMode     | Listbox |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "required=\"required\""
@@ -133,8 +133,8 @@ Scenario: Creating and using Enumeration fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                            | value   |
-            | Fields[0].EnumerationFieldSettings.Required     | false   |
-            | Fields[0].EnumerationFieldSettings.ListMode     | Listbox |
+            | Fields[Location].EnumerationFieldSettings.Required     | false   |
+            | Fields[Location].EnumerationFieldSettings.ListMode     | Listbox |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should not see "required=\"required\""

--- a/src/Orchard.Specs/Enumeration.feature.cs
+++ b/src/Orchard.Specs/Enumeration.feature.cs
@@ -132,7 +132,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table3.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.Options",
+                        "Fields[Location].EnumerationFieldSettings.Options",
                         "Seattle"});
 #line 36
         testRunner.And("I fill in", ((string)(null)), table3, "And ");
@@ -174,7 +174,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table5.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.Hint",
+                        "Fields[Location].EnumerationFieldSettings.Hint",
                         "Please select a location"});
 #line 58
         testRunner.And("I fill in", ((string)(null)), table5, "And ");
@@ -191,7 +191,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table6.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Fields[Location].EnumerationFieldSettings.ListMode",
                         "Dropdown"});
 #line 67
         testRunner.And("I fill in", ((string)(null)), table6, "And ");
@@ -208,7 +208,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table7.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Fields[Location].EnumerationFieldSettings.ListMode",
                         "Radiobutton"});
 #line 76
         testRunner.And("I fill in", ((string)(null)), table7, "And ");
@@ -226,7 +226,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table8.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Fields[Location].EnumerationFieldSettings.ListMode",
                         "Listbox"});
 #line 85
         testRunner.And("I fill in", ((string)(null)), table8, "And ");
@@ -244,7 +244,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table9.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Fields[Location].EnumerationFieldSettings.ListMode",
                         "Checkbox"});
 #line 94
         testRunner.And("I fill in", ((string)(null)), table9, "And ");
@@ -261,7 +261,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table10.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.Required",
+                        "Fields[Location].EnumerationFieldSettings.Required",
                         "true"});
 #line 103
         testRunner.And("I fill in", ((string)(null)), table10, "And ");
@@ -280,13 +280,13 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table11.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.Options",
+                        "Fields[Location].EnumerationFieldSettings.Options",
                         "Seattle"});
             table11.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Fields[Location].EnumerationFieldSettings.ListMode",
                         "Dropdown"});
             table11.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.DefaultValue",
+                        "Fields[Location].EnumerationFieldSettings.DefaultValue",
                         "Seattle"});
 #line 113
         testRunner.And("I fill in", ((string)(null)), table11, "And ");
@@ -303,10 +303,10 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table12.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.Required",
+                        "Fields[Location].EnumerationFieldSettings.Required",
                         "true"});
             table12.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Fields[Location].EnumerationFieldSettings.ListMode",
                         "Listbox"});
 #line 124
         testRunner.And("I fill in", ((string)(null)), table12, "And ");
@@ -323,10 +323,10 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table13.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.Required",
+                        "Fields[Location].EnumerationFieldSettings.Required",
                         "false"});
             table13.AddRow(new string[] {
-                        "Fields[0].EnumerationFieldSettings.ListMode",
+                        "Fields[Location].EnumerationFieldSettings.ListMode",
                         "Listbox"});
 #line 134
         testRunner.And("I fill in", ((string)(null)), table13, "And ");

--- a/src/Orchard.Specs/Input.feature
+++ b/src/Orchard.Specs/Input.feature
@@ -35,7 +35,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                              | value                           |
-            | Fields[0].InputFieldSettings.Hint | Enter the contact email address |
+            | Fields[Contact].InputFieldSettings.Hint | Enter the contact email address |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Enter the contact email address"
@@ -44,7 +44,7 @@ Scenario: Creating and using Input fields
     #When I go to "Admin/ContentTypes/Edit/Event"
     #	And I fill in 
     #        | name                                 | value       |
-    #        | Fields[0].InputFieldSettings.Pattern | [^@]*@[^@]* |
+    #        | Fields[Contact].InputFieldSettings.Pattern | [^@]*@[^@]* |
     #	And I hit "Save"
     #	And I go to "Admin/Contents/Create/Event"
     #Then I should see "pattern=\"[^@]*@[^@]*\""
@@ -53,7 +53,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                              | value   |
-            | Fields[0].InputFieldSettings.Type | Email   |
+            | Fields[Contact].InputFieldSettings.Type | Email   |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "type=\"email\""
@@ -62,7 +62,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                               | value                  |
-            | Fields[0].InputFieldSettings.Title | Enter an email address |
+            | Fields[Contact].InputFieldSettings.Title | Enter an email address |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "title=\"Enter an email address\""
@@ -71,7 +71,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                   | value |
-            | Fields[0].InputFieldSettings.AutoFocus | true  |
+            | Fields[Contact].InputFieldSettings.AutoFocus | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "autofocus=\"autofocus\""
@@ -80,7 +80,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                      | value |
-            | Fields[0].InputFieldSettings.AutoComplete | true  |
+            | Fields[Contact].InputFieldSettings.AutoComplete | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "autocomplete=\"on\""
@@ -89,7 +89,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                     | value            |
-            | Fields[0].InputFieldSettings.Placeholder | email@domain.com |
+            | Fields[Contact].InputFieldSettings.Placeholder | email@domain.com |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "placeholder=\"email@domain.com\""
@@ -98,7 +98,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                   | value |
-            | Fields[0].InputFieldSettings.MaxLength | 100   |
+            | Fields[Contact].InputFieldSettings.MaxLength | 100   |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "maxlength=\"100\""
@@ -107,7 +107,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                  | value |
-            | Fields[0].InputFieldSettings.Required | true  |
+            | Fields[Contact].InputFieldSettings.Required | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
         And I fill in 
@@ -133,7 +133,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                      | value                       |
-            | Fields[0].InputFieldSettings.DefaultValue | contact@orchardproject.net |
+            | Fields[Contact].InputFieldSettings.DefaultValue | contact@orchardproject.net |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "value=\"contact@orchardproject.net\""
@@ -142,7 +142,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                      | value |
-            | Fields[0].InputFieldSettings.Required     | true  |
+            | Fields[Contact].InputFieldSettings.Required     | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "required=\"required\""
@@ -151,7 +151,7 @@ Scenario: Creating and using Input fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                      | value |
-            | Fields[0].InputFieldSettings.Required     | false |
+            | Fields[Contact].InputFieldSettings.Required     | false |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should not see "required=\"required\""

--- a/src/Orchard.Specs/Input.feature.cs
+++ b/src/Orchard.Specs/Input.feature.cs
@@ -132,7 +132,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table3.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.Hint",
+                        "Fields[Contact].InputFieldSettings.Hint",
                         "Enter the contact email address"});
 #line 36
         testRunner.And("I fill in", ((string)(null)), table3, "And ");
@@ -149,7 +149,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table4.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.Type",
+                        "Fields[Contact].InputFieldSettings.Type",
                         "Email"});
 #line 54
         testRunner.And("I fill in", ((string)(null)), table4, "And ");
@@ -166,7 +166,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table5.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.Title",
+                        "Fields[Contact].InputFieldSettings.Title",
                         "Enter an email address"});
 #line 63
         testRunner.And("I fill in", ((string)(null)), table5, "And ");
@@ -183,7 +183,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table6.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.AutoFocus",
+                        "Fields[Contact].InputFieldSettings.AutoFocus",
                         "true"});
 #line 72
         testRunner.And("I fill in", ((string)(null)), table6, "And ");
@@ -200,7 +200,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table7.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.AutoComplete",
+                        "Fields[Contact].InputFieldSettings.AutoComplete",
                         "true"});
 #line 81
         testRunner.And("I fill in", ((string)(null)), table7, "And ");
@@ -217,7 +217,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table8.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.Placeholder",
+                        "Fields[Contact].InputFieldSettings.Placeholder",
                         "email@domain.com"});
 #line 90
         testRunner.And("I fill in", ((string)(null)), table8, "And ");
@@ -234,7 +234,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table9.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.MaxLength",
+                        "Fields[Contact].InputFieldSettings.MaxLength",
                         "100"});
 #line 99
         testRunner.And("I fill in", ((string)(null)), table9, "And ");
@@ -251,7 +251,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table10.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.Required",
+                        "Fields[Contact].InputFieldSettings.Required",
                         "true"});
 #line 108
         testRunner.And("I fill in", ((string)(null)), table10, "And ");
@@ -304,7 +304,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table13.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.DefaultValue",
+                        "Fields[Contact].InputFieldSettings.DefaultValue",
                         "contact@orchardproject.net"});
 #line 134
         testRunner.And("I fill in", ((string)(null)), table13, "And ");
@@ -321,7 +321,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table14.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.Required",
+                        "Fields[Contact].InputFieldSettings.Required",
                         "true"});
 #line 143
         testRunner.And("I fill in", ((string)(null)), table14, "And ");
@@ -338,7 +338,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table15.AddRow(new string[] {
-                        "Fields[0].InputFieldSettings.Required",
+                        "Fields[Contact].InputFieldSettings.Required",
                         "false"});
 #line 152
         testRunner.And("I fill in", ((string)(null)), table15, "And ");

--- a/src/Orchard.Specs/Link.feature
+++ b/src/Orchard.Specs/Link.feature
@@ -51,7 +51,7 @@ Scenario: Creating and using Link fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                             | value                         |
-            | Fields[0].LinkFieldSettings.Hint | Enter the url of the web site |
+            | Fields[SiteUrl].LinkFieldSettings.Hint | Enter the url of the web site |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Enter the url of the web site"
@@ -60,7 +60,7 @@ Scenario: Creating and using Link fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                 | value |
-            | Fields[0].LinkFieldSettings.Required | true |
+            | Fields[SiteUrl].LinkFieldSettings.Required | true |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
         And I fill in 
@@ -73,7 +73,7 @@ Scenario: Creating and using Link fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                     | value                         |
-            | Fields[0].LinkFieldSettings.DefaultValue | http://www.orchardproject.net |
+            | Fields[SiteUrl].LinkFieldSettings.DefaultValue | http://www.orchardproject.net |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "value=\"http://www.orchardproject.net\""
@@ -82,7 +82,7 @@ Scenario: Creating and using Link fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                     | value |
-            | Fields[0].LinkFieldSettings.Required     | true  |
+            | Fields[SiteUrl].LinkFieldSettings.Required     | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "required=\"required\""
@@ -91,7 +91,7 @@ Scenario: Creating and using Link fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                     | value |
-            | Fields[0].LinkFieldSettings.Required     | false |
+            | Fields[SiteUrl].LinkFieldSettings.Required     | false |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should not see "required=\"required\""

--- a/src/Orchard.Specs/Link.feature.cs
+++ b/src/Orchard.Specs/Link.feature.cs
@@ -166,7 +166,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table5.AddRow(new string[] {
-                        "Fields[0].LinkFieldSettings.Hint",
+                        "Fields[SiteUrl].LinkFieldSettings.Hint",
                         "Enter the url of the web site"});
 #line 52
         testRunner.And("I fill in", ((string)(null)), table5, "And ");
@@ -183,7 +183,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table6.AddRow(new string[] {
-                        "Fields[0].LinkFieldSettings.Required",
+                        "Fields[SiteUrl].LinkFieldSettings.Required",
                         "true"});
 #line 61
         testRunner.And("I fill in", ((string)(null)), table6, "And ");
@@ -211,7 +211,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table8.AddRow(new string[] {
-                        "Fields[0].LinkFieldSettings.DefaultValue",
+                        "Fields[SiteUrl].LinkFieldSettings.DefaultValue",
                         "http://www.orchardproject.net"});
 #line 74
         testRunner.And("I fill in", ((string)(null)), table8, "And ");
@@ -228,7 +228,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table9.AddRow(new string[] {
-                        "Fields[0].LinkFieldSettings.Required",
+                        "Fields[SiteUrl].LinkFieldSettings.Required",
                         "true"});
 #line 83
         testRunner.And("I fill in", ((string)(null)), table9, "And ");
@@ -245,7 +245,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table10.AddRow(new string[] {
-                        "Fields[0].LinkFieldSettings.Required",
+                        "Fields[SiteUrl].LinkFieldSettings.Required",
                         "false"});
 #line 92
         testRunner.And("I fill in", ((string)(null)), table10, "And ");

--- a/src/Orchard.Specs/MediaPicker.feature
+++ b/src/Orchard.Specs/MediaPicker.feature
@@ -47,7 +47,7 @@ Scenario: Creating and using media fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                    | value                |
-            | Fields[0].MediaPickerFieldSettings.Hint | Please select a file |
+            | Fields[File].MediaPickerFieldSettings.Hint | Please select a file |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Please select a file"
@@ -56,7 +56,7 @@ Scenario: Creating and using media fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value |
-            | Fields[0].MediaPickerFieldSettings.Required | true  |
+            | Fields[File].MediaPickerFieldSettings.Required | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
         And I fill in 
@@ -70,7 +70,7 @@ Scenario: Creating and using media fields
         And I fill in 
             | name                                                 | value |
             | ext-Fields[0].MediaPickerFieldSettings               | true  |
-            | Fields[0].MediaPickerFieldSettings.AllowedExtensions | jpg   |
+            | Fields[File].MediaPickerFieldSettings.AllowedExtensions | jpg   |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     And I fill in 

--- a/src/Orchard.Specs/MediaPicker.feature
+++ b/src/Orchard.Specs/MediaPicker.feature
@@ -69,7 +69,7 @@ Scenario: Creating and using media fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                                 | value |
-            | ext-Fields[0].MediaPickerFieldSettings               | true  |
+            | ext-Fields[File].MediaPickerFieldSettings               | true  |
             | Fields[File].MediaPickerFieldSettings.AllowedExtensions | jpg   |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"

--- a/src/Orchard.Specs/MediaPicker.feature.cs
+++ b/src/Orchard.Specs/MediaPicker.feature.cs
@@ -153,7 +153,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table4.AddRow(new string[] {
-                        "Fields[0].MediaPickerFieldSettings.Hint",
+                        "Fields[File].MediaPickerFieldSettings.Hint",
                         "Please select a file"});
 #line 48
         testRunner.And("I fill in", ((string)(null)), table4, "And ");
@@ -170,7 +170,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table5.AddRow(new string[] {
-                        "Fields[0].MediaPickerFieldSettings.Required",
+                        "Fields[File].MediaPickerFieldSettings.Required",
                         "true"});
 #line 57
         testRunner.And("I fill in", ((string)(null)), table5, "And ");
@@ -201,7 +201,7 @@ this.ScenarioSetup(scenarioInfo);
                         "ext-Fields[0].MediaPickerFieldSettings",
                         "true"});
             table7.AddRow(new string[] {
-                        "Fields[0].MediaPickerFieldSettings.AllowedExtensions",
+                        "Fields[File].MediaPickerFieldSettings.AllowedExtensions",
                         "jpg"});
 #line 70
         testRunner.And("I fill in", ((string)(null)), table7, "And ");

--- a/src/Orchard.Specs/MediaPicker.feature.cs
+++ b/src/Orchard.Specs/MediaPicker.feature.cs
@@ -198,7 +198,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table7.AddRow(new string[] {
-                        "ext-Fields[0].MediaPickerFieldSettings",
+                        "ext-Fields[File].MediaPickerFieldSettings",
                         "true"});
             table7.AddRow(new string[] {
                         "Fields[File].MediaPickerFieldSettings.AllowedExtensions",

--- a/src/Orchard.Specs/Numeric.feature
+++ b/src/Orchard.Specs/Numeric.feature
@@ -48,7 +48,7 @@ Scenario: Creating and using numeric fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                | value                 |
-            | Fields[0].NumericFieldSettings.Hint | Please enter a number |
+            | Fields[Guests].NumericFieldSettings.Hint | Please enter a number |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Please enter a number"
@@ -57,7 +57,7 @@ Scenario: Creating and using numeric fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                    | value |
-            | Fields[0].NumericFieldSettings.Required | true  |
+            | Fields[Guests].NumericFieldSettings.Required | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
         And I fill in 
@@ -70,8 +70,8 @@ Scenario: Creating and using numeric fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                   | value |
-            | Fields[0].NumericFieldSettings.Minimum | -10   |
-            | Fields[0].NumericFieldSettings.Maximum | 100   |
+            | Fields[Guests].NumericFieldSettings.Minimum | -10   |
+            | Fields[Guests].NumericFieldSettings.Maximum | 100   |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "min=\"-10\"" 
@@ -92,8 +92,8 @@ Scenario: Creating and using numeric fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                   | value |
-            | Fields[0].NumericFieldSettings.Minimum | a     |
-            | Fields[0].NumericFieldSettings.Maximum | b     |
+            | Fields[Guests].NumericFieldSettings.Minimum | a     |
+            | Fields[Guests].NumericFieldSettings.Maximum | b     |
         And I hit "Save"
     Then I should see "The value &#39;a&#39; is not valid for Minimum."
         And I should see "The value &#39;b&#39; is not valid for Maximum."
@@ -110,7 +110,7 @@ Scenario: Creating and using numeric fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value |
-            | Fields[0].NumericFieldSettings.DefaultValue | 1234  |
+            | Fields[Guests].NumericFieldSettings.DefaultValue | 1234  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "value=\"1234\""
@@ -119,7 +119,7 @@ Scenario: Creating and using numeric fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value |
-            | Fields[0].NumericFieldSettings.Required     | true  |
+            | Fields[Guests].NumericFieldSettings.Required     | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "required=\"required\""
@@ -128,7 +128,7 @@ Scenario: Creating and using numeric fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                        | value |
-            | Fields[0].NumericFieldSettings.Required     | false |
+            | Fields[Guests].NumericFieldSettings.Required     | false |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should not see "required=\"required\""

--- a/src/Orchard.Specs/Numeric.feature.cs
+++ b/src/Orchard.Specs/Numeric.feature.cs
@@ -157,7 +157,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table4.AddRow(new string[] {
-                        "Fields[0].NumericFieldSettings.Hint",
+                        "Fields[Guests].NumericFieldSettings.Hint",
                         "Please enter a number"});
 #line 49
         testRunner.And("I fill in", ((string)(null)), table4, "And ");
@@ -174,7 +174,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table5.AddRow(new string[] {
-                        "Fields[0].NumericFieldSettings.Required",
+                        "Fields[Guests].NumericFieldSettings.Required",
                         "true"});
 #line 58
         testRunner.And("I fill in", ((string)(null)), table5, "And ");
@@ -202,10 +202,10 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table7.AddRow(new string[] {
-                        "Fields[0].NumericFieldSettings.Minimum",
+                        "Fields[Guests].NumericFieldSettings.Minimum",
                         "-10"});
             table7.AddRow(new string[] {
-                        "Fields[0].NumericFieldSettings.Maximum",
+                        "Fields[Guests].NumericFieldSettings.Maximum",
                         "100"});
 #line 71
         testRunner.And("I fill in", ((string)(null)), table7, "And ");
@@ -252,10 +252,10 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table10.AddRow(new string[] {
-                        "Fields[0].NumericFieldSettings.Minimum",
+                        "Fields[Guests].NumericFieldSettings.Minimum",
                         "a"});
             table10.AddRow(new string[] {
-                        "Fields[0].NumericFieldSettings.Maximum",
+                        "Fields[Guests].NumericFieldSettings.Maximum",
                         "b"});
 #line 93
         testRunner.And("I fill in", ((string)(null)), table10, "And ");
@@ -287,7 +287,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table12.AddRow(new string[] {
-                        "Fields[0].NumericFieldSettings.DefaultValue",
+                        "Fields[Guests].NumericFieldSettings.DefaultValue",
                         "1234"});
 #line 111
         testRunner.And("I fill in", ((string)(null)), table12, "And ");
@@ -304,7 +304,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table13.AddRow(new string[] {
-                        "Fields[0].NumericFieldSettings.Required",
+                        "Fields[Guests].NumericFieldSettings.Required",
                         "true"});
 #line 120
         testRunner.And("I fill in", ((string)(null)), table13, "And ");
@@ -321,7 +321,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table14.AddRow(new string[] {
-                        "Fields[0].NumericFieldSettings.Required",
+                        "Fields[Guests].NumericFieldSettings.Required",
                         "false"});
 #line 129
         testRunner.And("I fill in", ((string)(null)), table14, "And ");

--- a/src/Orchard.Specs/Text.feature
+++ b/src/Orchard.Specs/Text.feature
@@ -35,7 +35,7 @@ Scenario: Creating and using Text fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                                       | value |
-            | Fields[0].TextFieldSettingsEventsViewModel.Settings.Flavor | Large |
+            | Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Flavor | Large |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "class=\"text large\""
@@ -44,7 +44,7 @@ Scenario: Creating and using Text fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                                         | value |
-            | Fields[0].TextFieldSettingsEventsViewModel.Settings.Required | true  |
+            | Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Required | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
         And I fill in 
@@ -57,7 +57,7 @@ Scenario: Creating and using Text fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                                     | value                |
-            | Fields[0].TextFieldSettingsEventsViewModel.Settings.Hint | Subject of the event |
+            | Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Hint | Subject of the event |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "Subject of the event"
@@ -77,7 +77,7 @@ Scenario: Creating and using Text fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                                             | value                |
-            | Fields[0].TextFieldSettingsEventsViewModel.Settings.DefaultValue | Orchard Harvest 2016 |
+            | Fields[Subject].TextFieldSettingsEventsViewModel.Settings.DefaultValue | Orchard Harvest 2016 |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "value=\"Orchard Harvest 2016\""
@@ -86,7 +86,7 @@ Scenario: Creating and using Text fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                                             | value |
-            | Fields[0].TextFieldSettingsEventsViewModel.Settings.Required     | true  |
+            | Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Required     | true  |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should see "required=\"required\""
@@ -95,7 +95,7 @@ Scenario: Creating and using Text fields
     When I go to "Admin/ContentTypes/Edit/Event"
         And I fill in 
             | name                                                             | value |
-            | Fields[0].TextFieldSettingsEventsViewModel.Settings.Required     | false |
+            | Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Required     | false |
         And I hit "Save"
         And I go to "Admin/Contents/Create/Event"
     Then I should not see "required=\"required\""

--- a/src/Orchard.Specs/Text.feature.cs
+++ b/src/Orchard.Specs/Text.feature.cs
@@ -132,7 +132,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table3.AddRow(new string[] {
-                        "Fields[0].TextFieldSettingsEventsViewModel.Settings.Flavor",
+                        "Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Flavor",
                         "Large"});
 #line 36
         testRunner.And("I fill in", ((string)(null)), table3, "And ");
@@ -149,7 +149,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table4.AddRow(new string[] {
-                        "Fields[0].TextFieldSettingsEventsViewModel.Settings.Required",
+                        "Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Required",
                         "true"});
 #line 45
         testRunner.And("I fill in", ((string)(null)), table4, "And ");
@@ -177,7 +177,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table6.AddRow(new string[] {
-                        "Fields[0].TextFieldSettingsEventsViewModel.Settings.Hint",
+                        "Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Hint",
                         "Subject of the event"});
 #line 58
         testRunner.And("I fill in", ((string)(null)), table6, "And ");
@@ -215,7 +215,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table8.AddRow(new string[] {
-                        "Fields[0].TextFieldSettingsEventsViewModel.Settings.DefaultValue",
+                        "Fields[Subject].TextFieldSettingsEventsViewModel.Settings.DefaultValue",
                         "Orchard Harvest 2016"});
 #line 78
         testRunner.And("I fill in", ((string)(null)), table8, "And ");
@@ -232,7 +232,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table9.AddRow(new string[] {
-                        "Fields[0].TextFieldSettingsEventsViewModel.Settings.Required",
+                        "Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Required",
                         "true"});
 #line 87
         testRunner.And("I fill in", ((string)(null)), table9, "And ");
@@ -249,7 +249,7 @@ this.ScenarioSetup(scenarioInfo);
                         "name",
                         "value"});
             table10.AddRow(new string[] {
-                        "Fields[0].TextFieldSettingsEventsViewModel.Settings.Required",
+                        "Fields[Subject].TextFieldSettingsEventsViewModel.Settings.Required",
                         "false"});
 #line 96
         testRunner.And("I fill in", ((string)(null)), table10, "And ");

--- a/src/Orchard.Web/Modules/Orchard.Projections/Tests/Services/FieldIndexServiceTests.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Tests/Services/FieldIndexServiceTests.cs
@@ -33,6 +33,7 @@ namespace Orchard.Projections.Tests.Services {
             builder.RegisterType<FieldIndexPartHandler>().As<IContentHandler>();
             builder.RegisterType<OrchardServices>().As<IOrchardServices>();
             builder.RegisterType<DefaultContentManager>().As<IContentManager>();
+            builder.RegisterType<DraftFieldIndexService>().As<IDraftFieldIndexService>();
             builder.RegisterType<FieldIndexService>().As<IFieldIndexService>();
 
             builder.RegisterType<ThingHandler>().As<IContentHandler>();

--- a/src/Orchard.Web/Modules/Orchard.Projections/Tests/Services/FieldIndexStorageTests.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Tests/Services/FieldIndexStorageTests.cs
@@ -41,6 +41,7 @@ namespace Orchard.Projections.Tests.Services {
             builder.RegisterType<FieldIndexPartHandler>().As<IContentHandler>();
             builder.RegisterType<OrchardServices>().As<IOrchardServices>();
             builder.RegisterType<DefaultContentManager>().As<IContentManager>();
+            builder.RegisterType<DraftFieldIndexService>().As<IDraftFieldIndexService>();
             builder.RegisterType<FieldIndexService>().As<IFieldIndexService>();
 
             builder.RegisterType<ThingHandler>().As<IContentHandler>();


### PR DESCRIPTION
related to #7991 
The code here fixes a bunch of the failing tests. Some are still left to fix:

Some tests that are related to parsing of DateTime from DefaultDateFormatterTests.
These require more fiddling because they may be failing just because my machine has the it-IT culture set as default. I actually checked and the failing test cases are those for the it-IT culture itself, but if I try to run the very same code in the tests form the C# interactive window I get the expected results. I'll have to double check those.

Then in FileSystemStorageProviderTests two tests fail throwing an UnauthorizedAccessException on setup or teardown.