### PR TITLE
AutoroutePartHandler using ILockingProvider

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using Orchard.Autoroute.Models;
 using Orchard.Autoroute.Services;
 using Orchard.ContentManagement;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Data;
 using Orchard.Localization;
+using Orchard.Locking;
 using Orchard.UI.Notify;
 
 namespace Orchard.Autoroute.Handlers {
@@ -13,6 +14,7 @@ namespace Orchard.Autoroute.Handlers {
         private readonly Lazy<IAutorouteService> _autorouteService;
         private readonly IOrchardServices _orchardServices;
         private readonly IHomeAliasService _homeAliasService;
+        private readonly ILockingProvider _lockingProvider;
 
         public Localizer T { get; set; }
 
@@ -20,12 +22,14 @@ namespace Orchard.Autoroute.Handlers {
             IRepository<AutoroutePartRecord> autoroutePartRepository,
             Lazy<IAutorouteService> autorouteService,
             IOrchardServices orchardServices, 
-            IHomeAliasService homeAliasService) {
+            IHomeAliasService homeAliasService,
+            ILockingProvider lockingProvider) {
 
             Filters.Add(StorageFilter.For(autoroutePartRepository));
             _autorouteService = autorouteService;
             _orchardServices = orchardServices;
             _homeAliasService = homeAliasService;
+            _lockingProvider = lockingProvider;
 
             OnUpdated<AutoroutePart>((ctx, part) => CreateAlias(part));
 
@@ -54,6 +58,15 @@ namespace Orchard.Autoroute.Handlers {
             ProcessAlias(part);
         }
 
+        private string LockString {
+            get {
+                return string.Join(".",
+                    _orchardServices.WorkContext?.CurrentSite?.BaseUrl ?? "",
+                    _orchardServices.WorkContext?.CurrentSite?.SiteName ?? "",
+                    "AutoroutePartHandler");
+            }
+        }
+
         private void PublishAlias(AutoroutePart part) {
             ProcessAlias(part);
 
@@ -74,34 +87,44 @@ namespace Orchard.Autoroute.Handlers {
                 // Update the home alias to point to this item being published.
                 _homeAliasService.PublishHomeAlias(part);
             }
+
+            _lockingProvider.Lock(LockString,
+                () => { _autorouteService.Value.PublishAlias(part); });
             
-            _autorouteService.Value.PublishAlias(part);
         }
 
         private void ProcessAlias(AutoroutePart part) {
-            if (!part.HasDraft())
-            {
-                // Generate an alias if one as not already been entered.
-                if (String.IsNullOrWhiteSpace(part.DisplayAlias))
-                {
-                    part.DisplayAlias = _autorouteService.Value.GenerateAlias(part);
-                }
 
-                // If the generated alias is empty, compute a new one.
-                if (String.IsNullOrWhiteSpace(part.DisplayAlias))
-                {
-                    _autorouteService.Value.ProcessPath(part);
-                    _orchardServices.Notifier.Warning(T("The permalink could not be generated, a new slug has been defined: \"{0}\"", part.Path));
-                    return;
-                }
+            LocalizedString message = null;
 
-                // Check for permalink conflict, unless we are trying to set the home page.
-                var previous = part.Path;
-                if (!_autorouteService.Value.ProcessPath(part))
-                    _orchardServices.Notifier.Warning(
-                        T("Permalinks in conflict. \"{0}\" is already set for a previously created {2} so now it has the slug \"{1}\"",
-                                                    previous, part.Path, part.ContentItem.ContentType));
+            // Generate an alias if one has not already been entered.
+            if (String.IsNullOrWhiteSpace(part.DisplayAlias)) {
+                part.DisplayAlias = _autorouteService.Value.GenerateAlias(part);
             }
+
+            _lockingProvider.Lock(LockString,
+                () => {
+                    // Lock this portion of the code to prevent race conditions where we are reading the aliases to compute
+                    // stuff for a content, while another content is publishing. 
+                    // If the generated alias is empty, compute a new one.
+                    if (String.IsNullOrWhiteSpace(part.DisplayAlias)) {
+                        _autorouteService.Value.ProcessPath(part);
+                        message = T("The permalink could not be generated, a new slug has been defined: \"{0}\"", part.Path);
+                        return;
+                    }
+
+                    // Check for permalink conflict, unless we are trying to set the home page.
+                    var previous = part.Path;
+                    if (!_autorouteService.Value.ProcessPath(part))
+                        message =
+                            T("Permalinks in conflict. \"{0}\" is already set for a previously created {2} so now it has the slug \"{1}\"",
+                                                        previous, part.Path, part.ContentItem.ContentType);
+                });
+
+            if (message != null) {
+                _orchardServices.Notifier.Warning(message);
+            }
+            
         }
 
         void RemoveAlias(AutoroutePart part) {
@@ -111,7 +134,9 @@ namespace Orchard.Autoroute.Handlers {
             if (part.ContentItem.Id == homePageId) {
                 _orchardServices.Notifier.Warning(T("You removed the content item that served as the site's home page. \nMost possibly this means that instead of the home page a \"404 Not Found\" page will be displayed. \n\nTo prevent this you can e.g. publish a content item that has the \"Set as home page\" checkbox ticked."));
             }
-            _autorouteService.Value.RemoveAliases(part);
+
+            _lockingProvider.Lock(LockString,
+                () => { _autorouteService.Value.RemoveAliases(part); });
         }
     }
 }


### PR DESCRIPTION
AutoroutePartHandler using ILockingProvider to reduce the chance of deadlock, while keeping DisplayAlias values unique for published content.
I figured I could do a PR to the branch the other PR is from, rather than just create a Gist for you to copy from.