### PR TITLE
Added interceptor to add "WITH (NOLOCK)" to specific tables

### DIFF
--- a/src/Orchard/Data/NoLockInterceptor.cs
+++ b/src/Orchard/Data/NoLockInterceptor.cs
@@ -17,7 +17,7 @@ namespace Orchard.Data {
 
             _shellSettings = shellSettings;
             // allow injecting through autofac config.
-            AllTableNames = "Orchard_Framework_ContentItemVersionRecord, Orchard_Framework_ContentItemRecord, Title_TitlePartRecord";
+            AllTableNames = "Orchard_Framework_ContentItemVersionRecord, Title_TitlePartRecord";
             // TODO: add providers that would inject tablenames and move the autofac injection to one of them
         }
 

--- a/src/Orchard/Data/NoLockInterceptor.cs
+++ b/src/Orchard/Data/NoLockInterceptor.cs
@@ -48,6 +48,8 @@ namespace Orchard.Data {
                     if (tableItem != null) {
                         // the table is involved in this statement
                         var tableIndex = parts.IndexOf(tableItem);
+                        // recompute whereIndex in case we added stuff to parts
+                        whereIndex = whereItem != null ? parts.IndexOf(whereItem) : parts.Count;
                         if (tableIndex > fromIndex && tableIndex < whereIndex) { // sanity check
                             // if before the table name we have "," or "FROM", this is not a join, but rather
                             // something like "FROM tableName alias ..."

--- a/src/Orchard/Data/NoLockInterceptor.cs
+++ b/src/Orchard/Data/NoLockInterceptor.cs
@@ -29,6 +29,7 @@ namespace Orchard.Data {
                     _tableNames = new List<string>(
                         _noLockTableProviders
                             .SelectMany(nltp => nltp.GetTableNames())
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
                             .Select(n => GetPrefixedTableName(n.Trim())));
                 }
                 return _tableNames;

--- a/src/Orchard/Data/NoLockInterceptor.cs
+++ b/src/Orchard/Data/NoLockInterceptor.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NHibernate;
+using NHibernate.SqlCommand;
+
+namespace Orchard.Data {
+    public class NoLockInterceptor : EmptyInterceptor, ISessionInterceptor {
+
+        public NoLockInterceptor() {
+            // allow injecting through autofac config.
+            AllTableNames = "Orchard_Framework_ContentItemVersionRecord, Orchard_Framework_ContentItemRecord, Title_TitlePartRecord";
+            // TODO: add providers that would inject tablenames and move the autofac injection to one of them
+        }
+
+        public List<string> TableNames {
+            get {
+                return AllTableNames
+                  .Split(new char[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                  .Select(s => s.Trim())
+                  .ToList();
+            }
+        }
+
+        public string AllTableNames { get; set; }
+
+        // based on https://stackoverflow.com/a/39518098/2669614
+        public override SqlString OnPrepareStatement(SqlString sql) {
+
+            // Modify the sql to add hints
+            if (sql.StartsWithCaseInsensitive("select")) {
+                var parts = sql.ToString().Split().ToList();
+                var fromItem = parts.FirstOrDefault(p => p.Trim().Equals("from", StringComparison.OrdinalIgnoreCase));
+                int fromIndex = fromItem != null ? parts.IndexOf(fromItem) : -1;
+                var whereItem = parts.FirstOrDefault(p => p.Trim().Equals("where", StringComparison.OrdinalIgnoreCase));
+                int whereIndex = whereItem != null ? parts.IndexOf(whereItem) : parts.Count;
+
+                if (fromIndex == -1)
+                    return sql;
+
+                foreach (var tableName in TableNames) {
+                    // set NOLOCK for each one of these tables
+                    var tableItem = parts
+                        .FirstOrDefault(p => p.Trim()
+                            .Equals(tableName, StringComparison.OrdinalIgnoreCase));
+                    if (tableItem != null) {
+                        // the table is involved in this statement
+                        var tableIndex = parts.IndexOf(tableItem);
+                        if (tableIndex > fromIndex && tableIndex < whereIndex) { // sanity check
+                            // if before the table name we have "," or "FROM", this is not a join, but rather
+                            // something like "FROM tableName alias ..."
+                            // we can insert "WITH (NOLOCK)" after that
+                            if (tableIndex == fromIndex + 1
+                                || parts[tableIndex - 1].Equals(",")) {
+
+                                parts.Insert(tableIndex + 2, "WITH (NOLOCK)");
+                            }
+                            else {
+                                // probably doing a join, so edit the next "on" and make it
+                                // "WITH (NOLOCK) on"
+                                for (int i = tableIndex + 1; i < whereIndex; i++) {
+                                    if (parts[i].Trim().Equals("on", StringComparison.OrdinalIgnoreCase)) {
+                                        parts[i] = "WITH (NOLOCK) on";
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                // MUST use SqlString.Parse() method instead of new SqlString()
+                sql = SqlString.Parse(string.Join(" ", parts));
+            }
+
+            return sql;
+        }
+    }
+}

--- a/src/Orchard/Data/Providers/DefaultNoLockTableProvider.cs
+++ b/src/Orchard/Data/Providers/DefaultNoLockTableProvider.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orchard.Data.Providers {
+    public class DefaultNoLockTableProvider : INoLockTableProvider {
+
+        public DefaultNoLockTableProvider() {
+
+            // We may use AutoFac to override the default tables:
+            /*
+             <component instance-scope="per-lifetime-scope"
+                       type="Orchard.Data.Providers.DefaultNoLockTableProvider, Orchard.Framework"
+                       service="Orchard..Data.Providers.INoLockTableProvider">
+                <properties>
+                    <property name="TableName" value="Table_Name_1, Table_Name_2" />
+                </properties>
+            </component>
+             */
+            TableNames = "Orchard_Framework_ContentItemVersionRecord, Title_TitlePartRecord";
+        }
+
+        public string TableNames { get; set; }
+
+        private IEnumerable<string> _tableNames;
+
+        public IEnumerable<string> GetTableNames() {
+            if (_tableNames == null) {
+                _tableNames = new List<string>(TableNames
+                    .Split(new char[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries));
+            }
+            return _tableNames;
+        }
+    }
+}

--- a/src/Orchard/Data/Providers/INoLockTableProvider.cs
+++ b/src/Orchard/Data/Providers/INoLockTableProvider.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orchard.Data.Providers {
+    public interface INoLockTableProvider : IDependency {
+        /// <summary>
+        /// Returns the names of the tables from which read operations should ignore shared locks.
+        /// </summary>
+        /// <returns>An IEnumerable<string> with the table names.</string></returns>
+        /// <remarks>Implementations of this should not have to worry about table prefixes used to 
+        /// discriminate between tenants sharing a db. That should be taken care of, if needed, where
+        /// the results of this method are used. Implementations of this should avoid returning null.</remarks>
+        IEnumerable<string> GetTableNames();
+    }
+}

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -175,6 +175,7 @@
     <Compile Include="ContentManagement\Extensions\DriverResultExtensions.cs" />
     <Compile Include="ContentManagement\Handlers\CloneContentContext.cs" />
     <Compile Include="Data\Migration\Interpreters\PostgreSqlCommandInterpreter.cs" />
+    <Compile Include="Data\NoLockInterceptor.cs" />
     <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\DefaultPlacementParseMatchProviders.cs" />
     <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\IPlacementParseMatchProvider.cs" />
     <Compile Include="Environment\Configuration\ExtensionLocations.cs" />

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -176,6 +176,8 @@
     <Compile Include="ContentManagement\Handlers\CloneContentContext.cs" />
     <Compile Include="Data\Migration\Interpreters\PostgreSqlCommandInterpreter.cs" />
     <Compile Include="Data\NoLockInterceptor.cs" />
+    <Compile Include="Data\Providers\DefaultNoLockTableProvider.cs" />
+    <Compile Include="Data\Providers\INoLockTableProvider.cs" />
     <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\DefaultPlacementParseMatchProviders.cs" />
     <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\IPlacementParseMatchProvider.cs" />
     <Compile Include="Environment\Configuration\ExtensionLocations.cs" />


### PR DESCRIPTION
See discussion in #8040

This seems to fix the concurrency issues on the query for GetMenus().
Might fix something else too, but I don't know what kind of issues it may introduce.

I based this off 1.10.x, out of habit, but it's trivial to cherry-pick the commit for dev. 