### PR TITLE
fix List.cshtml

### DIFF
--- a/src/Orchard.Web/Core/Contents/Views/Admin/List.cshtml
+++ b/src/Orchard.Web/Core/Contents/Views/Admin/List.cshtml
@@ -6,16 +6,19 @@
     var typeDisplayName = Model.TypeDisplayName;
     var pageTitle = T("Manage Content");
     var createLinkText = T("Create New Content");
-    var userCanCreateContent = false;
+    // if no specific type is selected, we assume we should show the "Create" button
+    var showCreateContentButton = string.IsNullOrWhiteSpace(typeDisplayName); 
     IAuthorizationService _authorizationService;
     WorkContext.TryResolve<IAuthorizationService>(out _authorizationService);
 
-    if (!string.IsNullOrWhiteSpace(typeDisplayName)) {
+    if (!showCreateContentButton) {
+        // being here it means there is a specific type we are considering
         pageTitle = T("Manage {0} Content", Html.Raw(typeDisplayName));
         createLinkText = T("Create New {0}", Html.Raw(typeDisplayName));
-        var permission = DynamicPermissions.CreateDynamicPermission(DynamicPermissions.PermissionTemplates[Permissions.CreateContent.Name], Model.ContentType);
+        var permission = DynamicPermissions
+            .CreateDynamicPermission(DynamicPermissions.PermissionTemplates[Permissions.CreateContent.Name], Model.ContentType);
         if (_authorizationService.TryCheckAccess(permission, WorkContext.CurrentUser, null)) {
-            userCanCreateContent = true;
+            showCreateContentButton = true;
         }
     }
 
@@ -23,7 +26,7 @@
 
     Layout.Title = pageTitle.Text;
 }
-@if (userCanCreateContent) { 
+@if (showCreateContentButton) { 
 <div class="manage">
     @Html.ActionLink(createLinkText.Text, "Create", new { Area = "Contents", Id = (string)Model.Options.SelectedFilter }, new { @class = "button primaryAction" })
 </div>


### PR DESCRIPTION
with the latest changes, the "Create Contnte" button would not show when no contenttype was pre-selected.
This fixes that, while keeping the checks that allow not displaying the button when the user cannot create the specific content type