### PR TITLE
Concurrency fixes

### DIFF
--- a/src/Orchard.Tests.Modules/Tags/Services/TagsServiceTests.cs
+++ b/src/Orchard.Tests.Modules/Tags/Services/TagsServiceTests.cs
@@ -11,6 +11,7 @@ using Orchard.ContentManagement.Handlers;
 using Orchard.ContentManagement.Records;
 using Orchard.Data;
 using Orchard.Environment;
+using Orchard.Locking;
 using Orchard.Security;
 using Orchard.Tags.Handlers;
 using Orchard.Tags.Models;
@@ -40,6 +41,7 @@ namespace Orchard.Tests.Modules.Tags.Services {
             builder.RegisterType<DefaultContentManager>().As<IContentManager>();
             builder.RegisterType<StubCacheManager>().As<ICacheManager>();
             builder.RegisterType<Signals>().As<ISignals>();
+            builder.RegisterType<LockingProvider>().As<ILockingProvider>();
             builder.RegisterGeneric(typeof(Repository<>)).As(typeof(IRepository<>));
         }
 

--- a/src/Orchard.Tests/Stubs/StubWorkContextAccessor.cs
+++ b/src/Orchard.Tests/Stubs/StubWorkContextAccessor.cs
@@ -45,7 +45,7 @@ namespace Orchard.Tests.Stubs {
                 }
 
                 public string SiteName {
-                    get { throw new NotImplementedException(); }
+                    get { return "TestSite"; }
                 }
 
                 public string SiteSalt {

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -5,6 +5,7 @@ using Orchard.ContentManagement;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Data;
 using Orchard.Localization;
+using Orchard.Locking;
 using Orchard.UI.Notify;
 
 namespace Orchard.Autoroute.Handlers {
@@ -13,19 +14,22 @@ namespace Orchard.Autoroute.Handlers {
         private readonly Lazy<IAutorouteService> _autorouteService;
         private readonly IOrchardServices _orchardServices;
         private readonly IHomeAliasService _homeAliasService;
+        private readonly ILockingProvider _lockingProvider;
 
         public Localizer T { get; set; }
 
         public AutoroutePartHandler(
             IRepository<AutoroutePartRecord> autoroutePartRepository,
             Lazy<IAutorouteService> autorouteService,
-            IOrchardServices orchardServices, 
-            IHomeAliasService homeAliasService) {
+            IOrchardServices orchardServices,
+            IHomeAliasService homeAliasService,
+            ILockingProvider lockingProvider) {
 
             Filters.Add(StorageFilter.For(autoroutePartRepository));
             _autorouteService = autorouteService;
             _orchardServices = orchardServices;
             _homeAliasService = homeAliasService;
+            _lockingProvider = lockingProvider;
 
             OnUpdated<AutoroutePart>((ctx, part) => CreateAlias(part));
 
@@ -50,53 +54,74 @@ namespace Orchard.Autoroute.Handlers {
             });
         }
 
+        private string _lockString = "";
+        private string LockString {
+            get {
+                if (string.IsNullOrWhiteSpace(_lockString)) {
+                    _lockString = string.Join(
+                        _orchardServices.WorkContext?.CurrentSite?.BaseUrl ?? "",
+                        _orchardServices.WorkContext?.CurrentSite?.SiteName ?? "",
+                        "Orchard.Autoroute.Handlers.AutoroutePartHandler");
+                }
+
+                return _lockString;
+            }
+        }
+
         private void CreateAlias(AutoroutePart part) {
             ProcessAlias(part);
         }
 
         private void PublishAlias(AutoroutePart part) {
-            ProcessAlias(part);
+            _lockingProvider.Lock(LockString, () => {
+                ProcessAlias(part);
 
-            // Should it become the home page?
-            if (part.PromoteToHomePage) {
-                // Get the current homepage an unmark it as the homepage.
-                var currentHomePage = _homeAliasService.GetHomePage(VersionOptions.Latest);
-                if(currentHomePage != null && currentHomePage.Id != part.Id) {
-                    var autoroutePart = currentHomePage.As<AutoroutePart>();
+                // Should it become the home page?
+                if (part.PromoteToHomePage) {
+                    // Get the current homepage an unmark it as the homepage.
+                    var currentHomePage = _homeAliasService.GetHomePage(VersionOptions.Latest);
+                    if (currentHomePage != null && currentHomePage.Id != part.Id) {
+                        var autoroutePart = currentHomePage.As<AutoroutePart>();
 
-                    if (autoroutePart != null) {
-                        autoroutePart.PromoteToHomePage = false;
-                        if(autoroutePart.IsPublished())
-                            _orchardServices.ContentManager.Publish(autoroutePart.ContentItem);
+                        if (autoroutePart != null) {
+                            autoroutePart.PromoteToHomePage = false;
+                            if (autoroutePart.IsPublished())
+                                _orchardServices.ContentManager.Publish(autoroutePart.ContentItem);
+                        }
                     }
+
+                    // Update the home alias to point to this item being published.
+                    _homeAliasService.PublishHomeAlias(part);
                 }
 
-                // Update the home alias to point to this item being published.
-                _homeAliasService.PublishHomeAlias(part);
-            }
-            
-            _autorouteService.Value.PublishAlias(part);
+                _autorouteService.Value.PublishAlias(part);
+            });
         }
 
         private void ProcessAlias(AutoroutePart part) {
+            LocalizedString message = null;
             // Generate an alias if one as not already been entered.
             if (String.IsNullOrWhiteSpace(part.DisplayAlias)) {
                 part.DisplayAlias = _autorouteService.Value.GenerateAlias(part);
             }
 
-            // If the generated alias is empty, compute a new one.
             if (String.IsNullOrWhiteSpace(part.DisplayAlias)) {
                 _autorouteService.Value.ProcessPath(part);
-                _orchardServices.Notifier.Warning(T("The permalink could not be generated, a new slug has been defined: \"{0}\"", part.Path));
+                message = T("The permalink could not be generated, a new slug has been defined: \"{0}\"", part.Path);
                 return;
             }
 
             // Check for permalink conflict, unless we are trying to set the home page.
             var previous = part.Path;
-            if (!_autorouteService.Value.ProcessPath(part))
-                _orchardServices.Notifier.Warning(
-                    T("Permalinks in conflict. \"{0}\" is already set for a previously created {2} so now it has the slug \"{1}\"", 
-                                                previous, part.Path, part.ContentItem.ContentType));
+            if (!_autorouteService.Value.ProcessPath(part)) {
+                message =
+                    T("Permalinks in conflict. \"{0}\" is already set for a previously created {2} so now it has the slug \"{1}\"",
+                                                previous, part.Path, part.ContentItem.ContentType);
+            }
+
+            if (message != null) {
+                _orchardServices.Notifier.Warning(message);
+            }
         }
 
         void RemoveAlias(AutoroutePart part) {
@@ -106,7 +131,10 @@ namespace Orchard.Autoroute.Handlers {
             if (part.ContentItem.Id == homePageId) {
                 _orchardServices.Notifier.Warning(T("You removed the content item that served as the site's home page. \nMost possibly this means that instead of the home page a \"404 Not Found\" page will be displayed. \n\nTo prevent this you can e.g. publish a content item that has the \"Set as home page\" checkbox ticked."));
             }
-            _autorouteService.Value.RemoveAliases(part);
+
+            _lockingProvider.Lock(LockString, () => {
+                _autorouteService.Value.RemoveAliases(part);
+            });
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Orchard.Autoroute.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Orchard.Autoroute.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Recipes\Executors\HomeAliasStep.cs" />
     <Compile Include="ResourceManifest.cs" />
     <Compile Include="Services\AliasResolverSelector.cs" />
+    <Compile Include="Services\AutorouteNoLockTableProvider.cs" />
     <Compile Include="Services\HomeAliasService.cs" />
     <Compile Include="Services\IHomeAliasService.cs" />
     <Compile Include="Services\PathResolutionService.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Services/AutorouteNoLockTableProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Services/AutorouteNoLockTableProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Orchard.Data.Providers;
+
+namespace Orchard.Autoroute.Services {
+    public class AutorouteNoLockTableProvider : INoLockTableProvider {
+        public IEnumerable<string> GetTableNames() {
+            return new string[] { "Orchard_Autoroute_AutoroutePartRecord" };
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Services/AutorouteService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Services/AutorouteService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -6,13 +7,13 @@ using Orchard.Alias;
 using Orchard.Autoroute.Models;
 using Orchard.Autoroute.Settings;
 using Orchard.ContentManagement;
+using Orchard.ContentManagement.Aspects;
 using Orchard.ContentManagement.MetaData;
 using Orchard.ContentManagement.MetaData.Models;
-using Orchard.Tokens;
 using Orchard.Localization.Services;
+using Orchard.Locking;
 using Orchard.Mvc;
-using System.Web;
-using Orchard.ContentManagement.Aspects;
+using Orchard.Tokens;
 
 namespace Orchard.Autoroute.Services {
     public class AutorouteService : Component, IAutorouteService {
@@ -24,7 +25,12 @@ namespace Orchard.Autoroute.Services {
         private readonly IRouteEvents _routeEvents;
         private readonly ICultureManager _cultureManager;
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ILockingProvider _lockingProvider;
         private const string AliasSource = "Autoroute:View";
+
+        //This object is used to synchronize concurrent calls in the ProcessPath method
+        private static readonly ConcurrentDictionary<string, List<int>> _displayAliasVersions = 
+            new ConcurrentDictionary<string, List<int>>();
 
         public AutorouteService(
             IAliasService aliasService,
@@ -33,7 +39,8 @@ namespace Orchard.Autoroute.Services {
             IContentManager contentManager,
             IRouteEvents routeEvents,
             ICultureManager cultureManager,
-            IHttpContextAccessor httpContextAccessor) {
+            IHttpContextAccessor httpContextAccessor,
+            ILockingProvider lockingProvider) {
 
             _aliasService = aliasService;
             _tokenizer = tokenizer;
@@ -42,6 +49,7 @@ namespace Orchard.Autoroute.Services {
             _routeEvents = routeEvents;
             _cultureManager = cultureManager;
             _httpContextAccessor = httpContextAccessor;
+            _lockingProvider = lockingProvider;
         }
 
         public string GenerateAlias(AutoroutePart part) {
@@ -206,22 +214,45 @@ namespace Orchard.Autoroute.Services {
         }
 
         public bool ProcessPath(AutoroutePart part) {
-            var pathsLikeThis = GetSimilarPaths(part.Path).ToArray();
+            var returnValue = true;
 
-            // Don't include *this* part in the list
-            // of slugs to consider for conflict detection.
-            pathsLikeThis = pathsLikeThis.Where(p => p.ContentItem.Id != part.ContentItem.Id).ToArray();
+            var baseAlias = GenerateAlias(part);
 
-            if (pathsLikeThis.Any()) {
-                var originalPath = part.Path;
-                var newPath = GenerateUniqueSlug(part, pathsLikeThis.Select(p => p.Path));
-                part.DisplayAlias = newPath;
+            _lockingProvider.Lock(_displayAliasVersions,
+                () => {
+                    if (_displayAliasVersions.TryAdd(baseAlias, new List<int>())) {
+                        // We had not queryed for this path yet, so we now get the versions out 
+                        // of the db
+                        _displayAliasVersions[baseAlias].AddRange(
+                                GetSimilarPaths(baseAlias)
+                                    .Select(ap => new Tuple<int, int?>(ap.ContentItem.Id, GetSlugVersion(baseAlias, ap.Path)))
+                                    .Where(tup => tup.Item2.HasValue)
+                                    .OrderBy(tup => tup.Item2) // ascending
+                                    .Select(tup => tup.Item1) // get the Ids
+                            );
+                    }
+                });
 
-                if (originalPath != newPath)
-                    return false;
-            }
+            _lockingProvider.Lock(_displayAliasVersions[baseAlias],
+                () => {
+                    if (!_displayAliasVersions[baseAlias].Any()) {
+                        // We are processing the first ever part with this alias
+                        _displayAliasVersions[baseAlias].Add(part.ContentItem.Id);
+                        returnValue = true;
+                    }
+                    else if (_displayAliasVersions[baseAlias].Contains(part.ContentItem.Id)) {
+                        // This part has already been processed
+                        returnValue = true;
+                    }
+                    else {
+                        // Some parts have this alias already
+                        _displayAliasVersions[baseAlias].Add(part.ContentItem.Id);
+                        part.DisplayAlias = string.Format("{0}-{1}", baseAlias, _displayAliasVersions[baseAlias].Count);
+                        returnValue = false;
+                    }
+                });
 
-            return true;
+            return returnValue;
         }
 
         private SettingsDictionary GetTypePartSettings(string contentType) {

--- a/src/Orchard.Web/Modules/Orchard.Tags/Services/TagService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Tags/Services/TagService.cs
@@ -9,6 +9,7 @@ using Orchard.ContentManagement;
 using Orchard.Security;
 using Orchard.Tags.Models;
 using Orchard.UI.Notify;
+using Orchard.Locking;
 
 namespace Orchard.Tags.Services {
     public class TagService : ITagService {
@@ -18,19 +19,24 @@ namespace Orchard.Tags.Services {
         private readonly IAuthorizationService _authorizationService;
         private readonly IOrchardServices _orchardServices;
         private readonly ISessionFactoryHolder _sessionFactoryHolder;
+        private readonly ILockingProvider _lockingProvider;
 
         public TagService(IRepository<TagRecord> tagRepository,
                           IRepository<ContentTagRecord> contentTagRepository,
                           INotifier notifier,
                           IAuthorizationService authorizationService,
                           IOrchardServices orchardServices,
-                          ISessionFactoryHolder sessionFactoryHolder) {
+                          ISessionFactoryHolder sessionFactoryHolder,
+                          ILockingProvider lockingProvider) {
+
             _tagRepository = tagRepository;
             _contentTagRepository = contentTagRepository;
             _notifier = notifier;
             _authorizationService = authorizationService;
             _orchardServices = orchardServices;
             _sessionFactoryHolder = sessionFactoryHolder;
+            _lockingProvider = lockingProvider;
+
             Logger = NullLogger.Instance;
             T = NullLocalizer.Instance;
         }
@@ -56,11 +62,23 @@ namespace Orchard.Tags.Services {
         }
 
         public TagRecord CreateTag(string tagName) {
-            var result = _tagRepository.Get(x => x.TagName == tagName);
-            if (result == null) {
-                result = new TagRecord { TagName = tagName };
-                _tagRepository.Create(result);
-            }
+            TagRecord result = null;
+
+            var lockString = string.Join(".",
+                _orchardServices.WorkContext?.CurrentSite?.BaseUrl ?? "",
+                _orchardServices.WorkContext?.CurrentSite?.SiteName ?? "",
+                "TagService.CreateTag",
+                tagName);
+
+            _lockingProvider.Lock(lockString,
+                () => {
+                    result = _tagRepository.Get(x => x.TagName == tagName);
+                    if (result == null) {
+                        result = new TagRecord { TagName = tagName };
+                        _tagRepository.Create(result);
+                    }
+                });
+
             return result;
         }
 

--- a/src/Orchard/Data/NoLockInterceptor.cs
+++ b/src/Orchard/Data/NoLockInterceptor.cs
@@ -17,7 +17,7 @@ namespace Orchard.Data {
 
             _shellSettings = shellSettings;
             // allow injecting through autofac config.
-            AllTableNames = "Orchard_Framework_ContentItemVersionRecord, Orchard_Framework_ContentItemRecord, Title_TitlePartRecord";
+            AllTableNames = "Orchard_Framework_ContentItemVersionRecord, Title_TitlePartRecord";
             // TODO: add providers that would inject tablenames and move the autofac injection to one of them
         }
 

--- a/src/Orchard/Data/NoLockInterceptor.cs
+++ b/src/Orchard/Data/NoLockInterceptor.cs
@@ -48,6 +48,8 @@ namespace Orchard.Data {
                     if (tableItem != null) {
                         // the table is involved in this statement
                         var tableIndex = parts.IndexOf(tableItem);
+                        // recompute whereIndex in case we added stuff to parts
+                        whereIndex = whereItem != null ? parts.IndexOf(whereItem) : parts.Count;
                         if (tableIndex > fromIndex && tableIndex < whereIndex) { // sanity check
                             // if before the table name we have "," or "FROM", this is not a join, but rather
                             // something like "FROM tableName alias ..."

--- a/src/Orchard/Data/NoLockInterceptor.cs
+++ b/src/Orchard/Data/NoLockInterceptor.cs
@@ -29,6 +29,7 @@ namespace Orchard.Data {
                     _tableNames = new List<string>(
                         _noLockTableProviders
                             .SelectMany(nltp => nltp.GetTableNames())
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
                             .Select(n => GetPrefixedTableName(n.Trim())));
                 }
                 return _tableNames;

--- a/src/Orchard/Data/NoLockInterceptor.cs
+++ b/src/Orchard/Data/NoLockInterceptor.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NHibernate;
+using NHibernate.SqlCommand;
+
+namespace Orchard.Data {
+    public class NoLockInterceptor : EmptyInterceptor, ISessionInterceptor {
+
+        public NoLockInterceptor() {
+            // allow injecting through autofac config.
+            AllTableNames = "Orchard_Framework_ContentItemVersionRecord, Orchard_Framework_ContentItemRecord, Title_TitlePartRecord";
+            // TODO: add providers that would inject tablenames and move the autofac injection to one of them
+        }
+
+        public List<string> TableNames {
+            get {
+                return AllTableNames
+                  .Split(new char[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                  .Select(s => s.Trim())
+                  .ToList();
+            }
+        }
+
+        public string AllTableNames { get; set; }
+
+        // based on https://stackoverflow.com/a/39518098/2669614
+        public override SqlString OnPrepareStatement(SqlString sql) {
+
+            // Modify the sql to add hints
+            if (sql.StartsWithCaseInsensitive("select")) {
+                var parts = sql.ToString().Split().ToList();
+                var fromItem = parts.FirstOrDefault(p => p.Trim().Equals("from", StringComparison.OrdinalIgnoreCase));
+                int fromIndex = fromItem != null ? parts.IndexOf(fromItem) : -1;
+                var whereItem = parts.FirstOrDefault(p => p.Trim().Equals("where", StringComparison.OrdinalIgnoreCase));
+                int whereIndex = whereItem != null ? parts.IndexOf(whereItem) : parts.Count;
+
+                if (fromIndex == -1)
+                    return sql;
+
+                foreach (var tableName in TableNames) {
+                    // set NOLOCK for each one of these tables
+                    var tableItem = parts
+                        .FirstOrDefault(p => p.Trim()
+                            .Equals(tableName, StringComparison.OrdinalIgnoreCase));
+                    if (tableItem != null) {
+                        // the table is involved in this statement
+                        var tableIndex = parts.IndexOf(tableItem);
+                        if (tableIndex > fromIndex && tableIndex < whereIndex) { // sanity check
+                            // if before the table name we have "," or "FROM", this is not a join, but rather
+                            // something like "FROM tableName alias ..."
+                            // we can insert "WITH (NOLOCK)" after that
+                            if (tableIndex == fromIndex + 1
+                                || parts[tableIndex - 1].Equals(",")) {
+
+                                parts.Insert(tableIndex + 2, "WITH (NOLOCK)");
+                            }
+                            else {
+                                // probably doing a join, so edit the next "on" and make it
+                                // "WITH (NOLOCK) on"
+                                for (int i = tableIndex + 1; i < whereIndex; i++) {
+                                    if (parts[i].Trim().Equals("on", StringComparison.OrdinalIgnoreCase)) {
+                                        parts[i] = "WITH (NOLOCK) on";
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                // MUST use SqlString.Parse() method instead of new SqlString()
+                sql = SqlString.Parse(string.Join(" ", parts));
+            }
+
+            return sql;
+        }
+    }
+}

--- a/src/Orchard/Data/Providers/DefaultNoLockTableProvider.cs
+++ b/src/Orchard/Data/Providers/DefaultNoLockTableProvider.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orchard.Data.Providers {
+    public class DefaultNoLockTableProvider : INoLockTableProvider {
+
+        public DefaultNoLockTableProvider() {
+
+            // We may use AutoFac to override the default tables:
+            /*
+             <component instance-scope="per-lifetime-scope"
+                       type="Orchard.Data.Providers.DefaultNoLockTableProvider, Orchard.Framework"
+                       service="Orchard..Data.Providers.INoLockTableProvider">
+                <properties>
+                    <property name="TableName" value="Table_Name_1, Table_Name_2" />
+                </properties>
+            </component>
+             */
+            TableNames = "Orchard_Framework_ContentItemVersionRecord, Title_TitlePartRecord";
+        }
+
+        public string TableNames { get; set; }
+
+        private IEnumerable<string> _tableNames;
+
+        public IEnumerable<string> GetTableNames() {
+            if (_tableNames == null) {
+                _tableNames = new List<string>(TableNames
+                    .Split(new char[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries));
+            }
+            return _tableNames;
+        }
+    }
+}

--- a/src/Orchard/Data/Providers/DefaultNoLockTableProvider.cs
+++ b/src/Orchard/Data/Providers/DefaultNoLockTableProvider.cs
@@ -19,7 +19,7 @@ namespace Orchard.Data.Providers {
                 </properties>
             </component>
              */
-            TableNames = "Orchard_Framework_ContentItemVersionRecord, Title_TitlePartRecord";
+            TableNames = "Orchard_Framework_ContentItemVersionRecord, Title_TitlePartRecord, Orchard_Framework_ContentItemRecord";
         }
 
         public string TableNames { get; set; }

--- a/src/Orchard/Data/Providers/INoLockTableProvider.cs
+++ b/src/Orchard/Data/Providers/INoLockTableProvider.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orchard.Data.Providers {
+    public interface INoLockTableProvider : IDependency {
+        /// <summary>
+        /// Returns the names of the tables from which read operations should ignore shared locks.
+        /// </summary>
+        /// <returns>An IEnumerable<string> with the table names.</string></returns>
+        /// <remarks>Implementations of this should not have to worry about table prefixes used to 
+        /// discriminate between tenants sharing a db. That should be taken care of, if needed, where
+        /// the results of this method are used. Implementations of this should avoid returning null.</remarks>
+        IEnumerable<string> GetTableNames();
+    }
+}

--- a/src/Orchard/Locking/ILockingProvider.cs
+++ b/src/Orchard/Locking/ILockingProvider.cs
@@ -19,8 +19,10 @@ namespace Orchard.Locking {
         /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
         /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
         /// if both the Actions to handle exceptions are null, this method is the same as calling 
-        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
-        /// and will not even bubble them outward.</remarks>
+        /// lock(obj){criticalCode();}, meaning that it will bubble out the exception while holding the lock, and
+        /// only release it afterwards. If an innerHandler is provided, but outerHandler is null, an exception will
+        /// bubble out after the lock is released. To prevent exceptions from being thrown, both innerHandler and
+        /// outerHandler should be provided.</remarks>
         void Lock(
             object lockOn,
             Action criticalCode,
@@ -42,8 +44,10 @@ namespace Orchard.Locking {
         /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
         /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
         /// if both the Actions to handle exceptions are null, this method is the same as calling 
-        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
-        /// and will not even bubble them outward.</remarks>
+        /// lock(obj){criticalCode();}, meaning that it will bubble out the exception while holding the lock, and
+        /// only release it afterwards. If an innerHandler is provided, but outerHandler is null, an exception will
+        /// bubble out after the lock is released. To prevent exceptions from being thrown, both innerHandler and
+        /// outerHandler should be provided.</remarks>
         void Lock(
             string lockOn,
             Action criticalCode,
@@ -67,8 +71,10 @@ namespace Orchard.Locking {
         /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
         /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
         /// if both the Actions to handle exceptions are null, this method is the same as calling 
-        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
-        /// and will not even bubble them outward.</remarks>
+        /// lock(obj){criticalCode();}, meaning that it will bubble out the exception while holding the lock, and
+        /// only release it afterwards. If an innerHandler is provided, but outerHandler is null, an exception will
+        /// bubble out after the lock is released. To prevent exceptions from being thrown, both innerHandler and
+        /// outerHandler should be provided.</remarks>
         bool TryLock(
             object lockOn,
             Action criticalCode,
@@ -91,8 +97,10 @@ namespace Orchard.Locking {
         /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
         /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
         /// if both the Actions to handle exceptions are null, this method is the same as calling 
-        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
-        /// and will not even bubble them outward.</remarks>
+        /// lock(obj){criticalCode();}, meaning that it will bubble out the exception while holding the lock, and
+        /// only release it afterwards. If an innerHandler is provided, but outerHandler is null, an exception will
+        /// bubble out after the lock is released. To prevent exceptions from being thrown, both innerHandler and
+        /// outerHandler should be provided.</remarks>
         bool TryLock(
             string lockOn,
             Action criticalCode,
@@ -120,8 +128,10 @@ namespace Orchard.Locking {
         /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
         /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
         /// if both the Actions to handle exceptions are null, this method is the same as calling 
-        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
-        /// and will not even bubble them outward.</remarks>
+        /// lock(obj){criticalCode();}, meaning that it will bubble out the exception while holding the lock, and
+        /// only release it afterwards. If an innerHandler is provided, but outerHandler is null, an exception will
+        /// bubble out after the lock is released. To prevent exceptions from being thrown, both innerHandler and
+        /// outerHandler should be provided.</remarks>
         bool TryLock(
            object lockOn,
            TimeSpan timeout,
@@ -150,8 +160,10 @@ namespace Orchard.Locking {
         /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
         /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
         /// if both the Actions to handle exceptions are null, this method is the same as calling 
-        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
-        /// and will not even bubble them outward.</remarks>
+        /// lock(obj){criticalCode();}, meaning that it will bubble out the exception while holding the lock, and
+        /// only release it afterwards. If an innerHandler is provided, but outerHandler is null, an exception will
+        /// bubble out after the lock is released. To prevent exceptions from being thrown, both innerHandler and
+        /// outerHandler should be provided.</remarks>
         bool TryLock(
             string lockOn,
             TimeSpan timeout,
@@ -179,8 +191,10 @@ namespace Orchard.Locking {
         /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
         /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
         /// if both the Actions to handle exceptions are null, this method is the same as calling 
-        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
-        /// and will not even bubble them outward.</remarks>
+        /// lock(obj){criticalCode();}, meaning that it will bubble out the exception while holding the lock, and
+        /// only release it afterwards. If an innerHandler is provided, but outerHandler is null, an exception will
+        /// bubble out after the lock is released. To prevent exceptions from being thrown, both innerHandler and
+        /// outerHandler should be provided.</remarks>
         bool TryLock(
             object lockOn,
             int millisecondsTimeout,
@@ -208,8 +222,10 @@ namespace Orchard.Locking {
         /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
         /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
         /// if both the Actions to handle exceptions are null, this method is the same as calling 
-        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
-        /// and will not even bubble them outward.</remarks>
+        /// lock(obj){criticalCode();}, meaning that it will bubble out the exception while holding the lock, and
+        /// only release it afterwards. If an innerHandler is provided, but outerHandler is null, an exception will
+        /// bubble out after the lock is released. To prevent exceptions from being thrown, both innerHandler and
+        /// outerHandler should be provided.</remarks>
         bool TryLock(
             string lockOn,
             int millisecondsTimeout,

--- a/src/Orchard/Locking/ILockingProvider.cs
+++ b/src/Orchard/Locking/ILockingProvider.cs
@@ -1,0 +1,221 @@
+﻿using System;
+
+namespace Orchard.Locking {
+    public interface ILockingProvider : IDependency {
+
+        /// <summary>
+        /// Handles locking on a given object to execute the desired critical code. Optionally, it is possible
+        /// to tell how to manage exceptions, e.g. in a case where some cleanup may be required when the 
+        /// critical code fails after having been partially executed.
+        /// </summary>
+        /// <param name="lockOn">The object upon which the lock will be created.</param>
+        /// <param name="criticalCode">The critical code to be executed while holding the lock.</param>
+        /// <param name="innerHandler">The (optional) action to be executed to handle exceptions while still
+        /// holding the lock.</param>
+        /// <param name="outerHandler">The (optional) action to be executed to handle exceptions after the 
+        /// lock has been released.</param>
+        /// <exception cref="ArgumentNullException">Throws an ArgumentNullException the lockOn parameter is null.</exception>
+        /// <remarks>Internally, this method uses System.Threading.Monitor to delimit the execution of the
+        /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
+        /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
+        /// if both the Actions to handle exceptions are null, this method is the same as calling 
+        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
+        /// and will not even bubble them outward.</remarks>
+        void Lock(
+            object lockOn,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null);
+
+        /// <summary>
+        /// Handles locking on a given string to execute the desired critical code. Optionally, it is possible
+        /// to tell how to manage exceptions, e.g. in a case where some cleanup may be required when the 
+        /// critical code fails after having been partially executed.
+        /// </summary>
+        /// <param name="lockOn">The string upon which the lock will be created.</param>
+        /// <param name="criticalCode">The critical code to be executed while holding the lock.</param>
+        /// <param name="innerHandler">The (optional) action to be executed to handle exceptions while still
+        /// holding the lock.</param>
+        /// <param name="outerHandler">The (optional) action to be executed to handle exceptions after the 
+        /// lock has been released.</param>
+        /// <remarks>Internally, this method uses System.Threading.Monitor to delimit the execution of the
+        /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
+        /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
+        /// if both the Actions to handle exceptions are null, this method is the same as calling 
+        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
+        /// and will not even bubble them outward.</remarks>
+        void Lock(
+            string lockOn,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null);
+
+        /// <summary>
+        /// Handles locking on a given object to execute the desired critical code. Optionally, it is possible
+        /// to tell how to manage exceptions, e.g. in a case where some cleanup may be required when the 
+        /// critical code fails after having been partially executed.
+        /// </summary>
+        /// <param name="lockOn">The object upon which the lock will be created.</param>
+        /// <param name="criticalCode">The critical code to be executed while holding the lock.</param>
+        /// <param name="innerHandler">The (optional) action to be executed to handle exceptions while still
+        /// holding the lock.</param>
+        /// <param name="outerHandler">The (optional) action to be executed to handle exceptions after the 
+        /// lock has been released.</param>
+        /// <returns>true if the current thread acquires the lock; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Throws an ArgumentNullException the lockOn parameter is null.</exception>
+        /// <remarks>Internally, this method uses System.Threading.Monitor to delimit the execution of the
+        /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
+        /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
+        /// if both the Actions to handle exceptions are null, this method is the same as calling 
+        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
+        /// and will not even bubble them outward.</remarks>
+        bool TryLock(
+            object lockOn,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null);
+
+        /// <summary>
+        /// Handles locking on a given string to execute the desired critical code. Optionally, it is possible
+        /// to tell how to manage exceptions, e.g. in a case where some cleanup may be required when the 
+        /// critical code fails after having been partially executed.
+        /// </summary>
+        /// <param name="lockOn">The string upon which the lock will be created.</param>
+        /// <param name="criticalCode">The critical code to be executed while holding the lock.</param>
+        /// <param name="innerHandler">The (optional) action to be executed to handle exceptions while still
+        /// holding the lock.</param>
+        /// <param name="outerHandler">The (optional) action to be executed to handle exceptions after the 
+        /// lock has been released.</param>
+        /// <returns>true if the current thread acquires the lock; otherwise, false.</returns>
+        /// <remarks>Internally, this method uses System.Threading.Monitor to delimit the execution of the
+        /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
+        /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
+        /// if both the Actions to handle exceptions are null, this method is the same as calling 
+        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
+        /// and will not even bubble them outward.</remarks>
+        bool TryLock(
+            string lockOn,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null);
+
+        /// <summary>
+        /// Handles locking on a given object to execute the desired critical code. Optionally, it is possible
+        /// to tell how to manage exceptions, e.g. in a case where some cleanup may be required when the 
+        /// critical code fails after having been partially executed.
+        /// </summary>
+        /// <param name="lockOn">The object upon which the lock will be created.</param>
+        /// <param name="timeout">A TimeSpan representing the amount of time to wait for the lock. A value 
+        /// of –1 millisecond specifies an infinite wait.</param>
+        /// <param name="criticalCode">The critical code to be executed while holding the lock.</param>
+        /// <param name="innerHandler">The (optional) action to be executed to handle exceptions while still
+        /// holding the lock.</param>
+        /// <param name="outerHandler">The (optional) action to be executed to handle exceptions after the 
+        /// lock has been released.</param>
+        /// <returns>true if the current thread acquires the lock; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Throws an ArgumentNullException the lockOn parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Throws an ArgumentOutOfRangeException if the value of timeout
+        /// in milliseconds is negative and is not equal to Infinite (-1 millisecond), or is greater than MaxValue.</exception>
+        /// <remarks>Internally, this method uses System.Threading.Monitor to delimit the execution of the
+        /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
+        /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
+        /// if both the Actions to handle exceptions are null, this method is the same as calling 
+        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
+        /// and will not even bubble them outward.</remarks>
+        bool TryLock(
+           object lockOn,
+           TimeSpan timeout,
+           Action criticalCode,
+           Action<Exception> innerHandler = null,
+           Action<Exception> outerHandler = null);
+
+        /// <summary>
+        /// Handles locking on a given string to execute the desired critical code. Optionally, it is possible
+        /// to tell how to manage exceptions, e.g. in a case where some cleanup may be required when the 
+        /// critical code fails after having been partially executed.
+        /// </summary>
+        /// <param name="lockOn">The string upon which the lock will be created.</param>
+        /// <param name="timeout">A TimeSpan representing the amount of time to wait for the lock. A value 
+        /// of –1 millisecond specifies an infinite wait.</param>
+        /// <param name="criticalCode">The critical code to be executed while holding the lock.</param>
+        /// <param name="innerHandler">The (optional) action to be executed to handle exceptions while still
+        /// holding the lock.</param>
+        /// <param name="outerHandler">The (optional) action to be executed to handle exceptions after the 
+        /// lock has been released.</param>
+        /// <returns>true if the current thread acquires the lock; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Throws an ArgumentNullException the lockOn parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Throws an ArgumentOutOfRangeException if the value of timeout
+        /// in milliseconds is negative and is not equal to Infinite (-1 millisecond), or is greater than MaxValue.</exception>
+        /// <remarks>Internally, this method uses System.Threading.Monitor to delimit the execution of the
+        /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
+        /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
+        /// if both the Actions to handle exceptions are null, this method is the same as calling 
+        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
+        /// and will not even bubble them outward.</remarks>
+        bool TryLock(
+            string lockOn,
+            TimeSpan timeout,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null);
+
+        /// <summary>
+        /// Handles locking on a given object to execute the desired critical code. Optionally, it is possible
+        /// to tell how to manage exceptions, e.g. in a case where some cleanup may be required when the 
+        /// critical code fails after having been partially executed.
+        /// </summary>
+        /// <param name="lockOn">The object upon which the lock will be created.</param>
+        /// <param name="millisecondsTimeout">The number of milliseconds to wait for the lock..</param>
+        /// <param name="criticalCode">The critical code to be executed while holding the lock.</param>
+        /// <param name="innerHandler">The (optional) action to be executed to handle exceptions while still
+        /// holding the lock.</param>
+        /// <param name="outerHandler">The (optional) action to be executed to handle exceptions after the 
+        /// lock has been released.</param>
+        /// <returns>true if the current thread acquires the lock; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Throws an ArgumentNullException the lockOn parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Throws an ArgumentOutOfRangeException if the value 
+        /// of millisecondsTimeout is negative, and not equal to Infinite.</exception>
+        /// <remarks>Internally, this method uses System.Threading.Monitor to delimit the execution of the
+        /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
+        /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
+        /// if both the Actions to handle exceptions are null, this method is the same as calling 
+        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
+        /// and will not even bubble them outward.</remarks>
+        bool TryLock(
+            object lockOn,
+            int millisecondsTimeout,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null);
+
+        /// <summary>
+        /// Handles locking on a given string to execute the desired critical code. Optionally, it is possible
+        /// to tell how to manage exceptions, e.g. in a case where some cleanup may be required when the 
+        /// critical code fails after having been partially executed.
+        /// </summary>
+        /// <param name="lockOn">The string upon which the lock will be created.</param>
+        /// <param name="millisecondsTimeout">The number of milliseconds to wait for the lock..</param>
+        /// <param name="criticalCode">The critical code to be executed while holding the lock.</param>
+        /// <param name="innerHandler">The (optional) action to be executed to handle exceptions while still
+        /// holding the lock.</param>
+        /// <param name="outerHandler">The (optional) action to be executed to handle exceptions after the 
+        /// lock has been released.</param>
+        /// <returns>true if the current thread acquires the lock; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Throws an ArgumentNullException the lockOn parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Throws an ArgumentOutOfRangeException if the value 
+        /// of millisecondsTimeout is negative, and not equal to Infinite.</exception>
+        /// <remarks>Internally, this method uses System.Threading.Monitor to delimit the execution of the
+        /// critical code. Unlike the implementation of lock(obj){}, this implementation allows handling of
+        /// exceptions both while holding and after releasing the lock on the object. The default behaviour 
+        /// if both the Actions to handle exceptions are null, this method is the same as calling 
+        /// lock(obj){criticalCode();}. This is because by default the method will do nothing with the exceptions,
+        /// and will not even bubble them outward.</remarks>
+        bool TryLock(
+            string lockOn,
+            int millisecondsTimeout,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null);
+
+    }
+}

--- a/src/Orchard/Locking/LockingProvider.cs
+++ b/src/Orchard/Locking/LockingProvider.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Threading;
+
+namespace Orchard.Locking {
+    public class LockingProvider : ILockingProvider {
+
+        public void Lock(
+            object lockOn,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+
+            LockInternal(lockOn, criticalCode, innerHandler, outerHandler);
+        }
+
+        public void Lock(
+            string lockOn,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+
+            LockInternal(String.Intern(lockOn), criticalCode, innerHandler, outerHandler);
+        }
+
+        public bool TryLock(
+            object lockOn,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+
+            return TryLockInternal(lockOn, TimeSpan.Zero, criticalCode, innerHandler, outerHandler);
+        }
+
+        public bool TryLock(
+            string lockOn,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+
+            return TryLockInternal(String.Intern(lockOn), TimeSpan.Zero, criticalCode, innerHandler, outerHandler);
+        }
+
+        public bool TryLock(
+           object lockOn,
+           TimeSpan timeout,
+           Action criticalCode,
+           Action<Exception> innerHandler = null,
+           Action<Exception> outerHandler = null) {
+
+            return TryLockInternal(lockOn, timeout, criticalCode, innerHandler, outerHandler);
+        }
+
+        public bool TryLock(
+            string lockOn,
+            TimeSpan timeout,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+
+            return TryLockInternal(String.Intern(lockOn), timeout, criticalCode, innerHandler, outerHandler);
+        }
+
+        public bool TryLock(
+            object lockOn,
+            int millisecondsTimeout,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+            
+            return TryLockInternal(lockOn, millisecondsTimeout, criticalCode, innerHandler, outerHandler);
+        }
+
+        public bool TryLock(
+            string lockOn,
+            int millisecondsTimeout,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+            
+            return TryLockInternal(String.Intern(lockOn), millisecondsTimeout, criticalCode, innerHandler, outerHandler);
+        }
+
+        private void LockInternal(
+            object lockOn,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+
+            bool taken = false;
+            var tmp = lockOn;
+            Exception outerException = null;
+            try {
+                Monitor.Enter(tmp, ref taken);
+                criticalCode?.Invoke();
+            }
+            catch (Exception ex) {
+                outerException = ex;
+                innerHandler?.Invoke(ex);
+            }
+            finally {
+                if (taken) {
+                    Monitor.Exit(tmp);
+                }
+            }
+
+            if (outerException != null) {
+                outerHandler?.Invoke(outerException);
+            }
+        }
+
+        private bool TryLockInternal(
+            object lockOn,
+            TimeSpan timeout,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+
+            var tmp = lockOn;
+            Exception outerException = null;
+
+            if (Monitor.TryEnter(tmp, timeout)) {
+                try {
+                    criticalCode?.Invoke();
+                }
+                catch (Exception ex) {
+                    outerException = ex;
+                    innerHandler?.Invoke(ex);
+                }
+                finally {
+                    Monitor.Exit(tmp);
+                }
+
+                if (outerException != null) {
+                    outerHandler?.Invoke(outerException);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryLockInternal(
+            object lockOn,
+            int millisecondsTimeout,
+            Action criticalCode,
+            Action<Exception> innerHandler = null,
+            Action<Exception> outerHandler = null) {
+
+            var tmp = lockOn;
+            Exception outerException = null;
+
+            if (Monitor.TryEnter(tmp, millisecondsTimeout)) {
+                try {
+                    criticalCode?.Invoke();
+                }
+                catch (Exception ex) {
+                    outerException = ex;
+                    innerHandler?.Invoke(ex);
+                }
+                finally {
+                    Monitor.Exit(tmp);
+                }
+
+                if (outerException != null) {
+                    outerHandler?.Invoke(outerException);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+
+    }
+}

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -176,6 +176,7 @@
     <Compile Include="ContentManagement\Extensions\DriverResultExtensions.cs" />
     <Compile Include="ContentManagement\Handlers\CloneContentContext.cs" />
     <Compile Include="ContentManagement\IGlobalCriteriaProvider.cs" />
+    <Compile Include="Data\NoLockInterceptor.cs" />
     <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\DefaultPlacementParseMatchProviders.cs" />
     <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\IPlacementParseMatchProvider.cs" />
     <Compile Include="Environment\Configuration\ExtensionLocations.cs" />

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -188,6 +188,8 @@
     <Compile Include="Data\Migration\Schema\DropUniqueConstraintCommand.cs" />
     <Compile Include="Environment\Extensions\Models\LifecycleStatus.cs" />
     <Compile Include="Environment\ShellBuilders\ICompositionStrategy.cs" />
+    <Compile Include="Locking\ILockingProvider.cs" />
+    <Compile Include="Locking\LockingProvider.cs" />
     <Compile Include="Mvc\Updater.cs" />
     <Compile Include="Recipes\Models\ConfigurationContext.cs" />
     <Compile Include="Recipes\Models\RecipeBuilderStepConfigurationContext.cs" />

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -177,6 +177,8 @@
     <Compile Include="ContentManagement\Handlers\CloneContentContext.cs" />
     <Compile Include="ContentManagement\IGlobalCriteriaProvider.cs" />
     <Compile Include="Data\NoLockInterceptor.cs" />
+    <Compile Include="Data\Providers\DefaultNoLockTableProvider.cs" />
+    <Compile Include="Data\Providers\INoLockTableProvider.cs" />
     <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\DefaultPlacementParseMatchProviders.cs" />
     <Compile Include="DisplayManagement\Descriptors\ShapePlacementStrategy\IPlacementParseMatchProvider.cs" />
     <Compile Include="Environment\Configuration\ExtensionLocations.cs" />


### PR DESCRIPTION
@Skrypt @sebastienros 
Just to summarize things as I put together all our fixes:

 - With the NOLOCK, without changing anything in the Autouroute Module, we see deadlocks.
 - Adding an `INoLockTableProvider` that adds "Orchard_Autoroute_AutoroutePartRecord" I see deadlocks on "Orchard_Framework_ContentItemRecord". These generally require more than 2 concurrent creations to pop up (usually 3 are enough, so it's not a massive improvement)
 - Adding "Orchard_Framework_ContentItemRecord" to the tables (in `DefaultNoLockTableProvider`), I see no more deadlocks (I tried up to 20 concurrent creations). However there are duplicate aliases, so it's time to pull in the solutions @skrypt has been developing here with the LockingProvider.
 - I inserted the LockingProvider in `AutoroutePartHandler` as was initially done in #8025 . That seems to fix the issue with duplicate aliases.

To find what the deadlocks are on, I use the sp_BlitzLock procedure from the links @sebastienros gave us.
All the tests were done with Page contents, on a fresh tenant, after removing LayoutPart.

This is a synthesis of the stuff from the following:
#7720 
#8019 
#7708
#8025 
#8028 
#8040 
#8052 
(I am sure I am forgetting something)

As it is, by my tests, it fixes the concurrency issues we were seeing on MenuPart, TagsPart, AutoroutePart.
It does not fix the issue for LayoutPart: that is likely to be in `DefaultContentQuery.GetContentTypeRecordId` and I did not want to introduce an `ILockingProvider` there yet.
