### PR TITLE
Update ClientStorageController.cs

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/ClientStorageController.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/ClientStorageController.cs
@@ -194,7 +194,7 @@ namespace Orchard.MediaLibrary.Controllers {
                         // it changes the media file name
                         replaceMedia.FileName = filename;
                     }
-                    _mediaLibraryService.UploadMediaFile(replaceMedia.FolderPath, filename, file.InputStream);
+                    _mediaLibraryService.UploadMediaFile(replaceMedia.FolderPath, replaceMedia.FileName, file.InputStream);
                     replaceMedia.MimeType = mimeType;
 
                     _handlers.Invoke(x => x.Updated(new UpdateContentContext(replaceMedia.ContentItem)), Logger);


### PR DESCRIPTION
Fixes an issue caused by replacing a media file by another file with a different fileName that resulted in a wrong filename for the new file.