### PR TITLE
Fixed radio button bug in base.js

### DIFF
--- a/src/Orchard.Web/Core/Shapes/Scripts/base.js
+++ b/src/Orchard.Web/Core/Shapes/Scripts/base.js
@@ -175,7 +175,7 @@
             if (controller.is(":checkbox")) {
                 controller.click($(this).toggleWhatYouControl).each($(this).toggleWhatYouControl);
             } else if (controller.is(":radio")) {
-                $("[name='" + controller.attr("name") + "']").click(function () { $("[name='" + $(this).attr("name") + "']").each($(this).toggleWhatYouControl); });
+                $("[name='" + controller.attr("name") + "']").click(function () { $("[name='" + $(this).attr("name") + "']").each($(this).toggleWhatYouControl); }).each($(this).toggleWhatYouControl);
             }
             else if (controller.is("option")) {
                 controller.parent().change(function() {


### PR DESCRIPTION
Fixes #7833
If you wanted to hide and show text per radio button, it works by clicking on the radio button.
But at Page Load everything was shown.