### PR TITLE
Fix error in ContainerSettings while editor validating

### DIFF
--- a/src/Orchard.Web/Core/Containers/Settings/ContainerSettings.cs
+++ b/src/Orchard.Web/Core/Containers/Settings/ContainerSettings.cs
@@ -118,7 +118,8 @@ namespace Orchard.Core.Containers.Settings {
                 yield break;
 
             var viewModel = new ContainerTypePartSettingsViewModel {
-                AvailableItemContentTypes = _containerService.GetContainableTypes().ToList()
+                AvailableItemContentTypes = _containerService.GetContainableTypes().ToList(),
+                ListViewProviders = _listViewService.Providers.ToList()
             };
             updateModel.TryUpdateModel(viewModel, "ContainerTypePartSettingsViewModel", null, new[] { "AvailableItemContentTypes" });
             builder.WithSetting("ContainerTypePartSettings.ItemsShownDefault", viewModel.ItemsShownDefault.ToString());


### PR DESCRIPTION
Hi Orchard Team

While i'm working on customize settings for content part / field

## Story 
so I'm attach `ContainerPart` in my content type  that have too many parts inside. one of part has settings with input validation.  when i tried to save with invalid value  then we trigger a bug: exception on ...! 

My investigation is because null value of `ListViewProviders` in `ContainerSettings.cs` that use in `ListViewPicker` view

## To Fix this

`ListViewProviders` in `TypePartEditorUpdate` method need initialize

Thanks.