### PR TITLE
fix #8066: update validation RegEx for email to latest spec

### DIFF
--- a/src/Orchard.Tests.Modules/DynamicForms/ValidationRules/EmailValidationTests.cs
+++ b/src/Orchard.Tests.Modules/DynamicForms/ValidationRules/EmailValidationTests.cs
@@ -1,0 +1,99 @@
+﻿using System.Web.Mvc;
+using NUnit.Framework;
+using Orchard.DynamicForms.Services.Models;
+using Orchard.DynamicForms.ValidationRules;
+
+namespace Orchard.Tests.Modules.DynamicForms.ValidationRules {
+    [TestFixture]
+    public class EmailValidationTests {
+        [SetUp]
+        public void Init() {
+            _context = new ValidateInputContext {ModelState = new ModelStateDictionary(), FieldName = "Email Address"};
+            _validator = new EmailAddress();
+        }
+
+        private ValidateInputContext _context;
+        private EmailAddress _validator;
+
+        [Test]
+        public void InvalidateDoubleDotDomain() {
+            _context.AttemptedValue = "x@example..com";
+
+            _validator.Validate(_context);
+
+            Assert.That(_context.ModelState.IsValid, Is.False);
+        }
+
+        [Test]
+        public void InvalidateMissingAt() {
+            _context.AttemptedValue = "x.example.com";
+
+            _validator.Validate(_context);
+
+            Assert.That(_context.ModelState.IsValid, Is.False);
+        }
+
+        [Test]
+        public void InvalidateMissingDomain() {
+            _context.AttemptedValue = "x@";
+
+            _validator.Validate(_context);
+
+            Assert.That(_context.ModelState.IsValid, Is.False);
+        }
+
+        [Test]
+        public void InvalidateMissingLocalPart() {
+            _context.AttemptedValue = "@example.com";
+
+            _validator.Validate(_context);
+
+            Assert.That(_context.ModelState.IsValid, Is.False);
+        }
+
+        [Test]
+        public void ValidateMissingTLD() {
+            _context.AttemptedValue = "something@localhost";
+
+            _validator.Validate(_context);
+
+            Assert.That(_context.ModelState.IsValid, Is.True);
+        }
+
+        [Test]
+        public void ValidateOneLetterTLD() {
+            _context.AttemptedValue = "something@example.x";
+
+            _validator.Validate(_context);
+
+            Assert.That(_context.ModelState.IsValid, Is.True);
+        }
+
+        [Test]
+        public void ValidateTenLetterTLD() {
+            _context.AttemptedValue = "something@example.accountant";
+
+            _validator.Validate(_context);
+
+            Assert.That(_context.ModelState.IsValid, Is.True);
+        }
+
+        [Test]
+        public void ValidateThreeLetterTLD() {
+            _context.AttemptedValue = "something@example.com";
+
+            _validator.Validate(_context);
+
+            Assert.That(_context.ModelState.IsValid, Is.True);
+        }
+
+        [Test]
+        public void ValidateTwoLetterTLD() {
+            _context.AttemptedValue = "something@example.io";
+
+            _validator.Validate(_context);
+
+            Assert.That(_context.ModelState.IsValid, Is.True);
+        }
+    }
+}

--- a/src/Orchard.Tests.Modules/Orchard.Tests.Modules.csproj
+++ b/src/Orchard.Tests.Modules/Orchard.Tests.Modules.csproj
@@ -199,6 +199,7 @@
     <Compile Include="CodeGeneration\Commands\CodeGenerationCommandsTests.cs" />
     <Compile Include="Comments\Services\CommentServiceTests.cs" />
     <Compile Include="DesignerTools\Services\ObjectDumperTests.cs" />
+    <Compile Include="DynamicForms\ValidationRules\EmailValidationTests.cs" />
     <Compile Include="Email\EmailChannelTests.cs" />
     <Compile Include="ImageProcessing\ImageProcessingTests.cs" />
     <Compile Include="ImportExport\Services\ImportExportServiceTests.cs" />
@@ -283,6 +284,10 @@
     <ProjectReference Include="..\Orchard.Web\Modules\Orchard.DesignerTools\Orchard.DesignerTools.csproj">
       <Project>{4A4595EF-6C37-4F99-96ED-4AE0B9E438D3}</Project>
       <Name>Orchard.DesignerTools</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Orchard.Web\Modules\Orchard.DynamicForms\Orchard.DynamicForms.csproj">
+      <Project>{82190f52-2901-46d6-8a4c-34649959483f}</Project>
+      <Name>Orchard.DynamicForms</Name>
     </ProjectReference>
     <ProjectReference Include="..\Orchard.Web\Modules\Orchard.Email\Orchard.Email.csproj">
       <Project>{05660f47-d649-48bd-9ded-df4e01e7cff9}</Project>

--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/ValidationRules/EmailAddress.cs
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/ValidationRules/EmailAddress.cs
@@ -9,7 +9,9 @@ namespace Orchard.DynamicForms.ValidationRules {
     public class EmailAddress : ValidationRule {
         public EmailAddress() {
             RegexOptions = RegexOptions.Singleline | RegexOptions.IgnoreCase;
-            Pattern = @"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$";
+            // From https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
+            // Retrieved 2018-07-28
+            Pattern = @"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
         }
 
         public string Pattern { get; set; }


### PR DESCRIPTION
Update the regex used for validating email addresses to the latest at [WHATWG](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address-list), aligning Dynamic Forms with the same validation rules used in HTML5 `<input type="email" required />`
Corrects validation allowing valid addresses with a longer TLD, such as `x@xxx.accountants`.
Corrects validation allowing valid addresses without a TLD, such as `x@localhost`.

Fixes #8066