### PR TITLE
fix #7931: remove duplicate json.net assembly binding

### DIFF
--- a/src/Orchard.Web/Web.config
+++ b/src/Orchard.Web/Web.config
@@ -215,10 +215,6 @@
         <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.0.2.0" newVersion="5.0.2.0" />
       </dependentAssembly>


### PR DESCRIPTION
The `Newtonsoft.json` binding redirect was listed twice in the `Orchard.Web` `web.config`. This PR removes the duplicate binding.

Fixes #7931 