### PR TITLE
fix #7699: normalize line endings on sln before injecting projects

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.CodeGeneration/Commands/CodeGenerationCommands.cs
+++ b/src/Orchard.Web/Modules/Orchard.CodeGeneration/Commands/CodeGenerationCommands.cs
@@ -436,6 +436,7 @@ namespace Orchard.CodeGeneration.Commands {
                     var projectReference = string.Format("EndProject\r\nProject(\"{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}\") = \"{0}\", \"Orchard.Web\\{2}\\{0}\\{0}.csproj\", \"{{{1}}}\"\r\n", projectName, projectGuid, containingFolder);
                     var projectConfiguationPlatforms = string.Format("\t{{{0}}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU\r\n\t\t{{{0}}}.Debug|Any CPU.Build.0 = Debug|Any CPU\r\n\t\t{{{0}}}.Release|Any CPU.ActiveCfg = Release|Any CPU\r\n\t\t{{{0}}}.Release|Any CPU.Build.0 = Release|Any CPU\r\n\t", projectGuid);
                     var solutionText = File.ReadAllText(solutionPath);
+                    solutionText = NormalizeLineEndings(solutionText);
                     solutionText = solutionText.Insert(solutionText.LastIndexOf("EndProject\r\n"), projectReference);
                     solutionText = AppendGlobalSection(solutionText, "ProjectConfigurationPlatforms", projectConfiguationPlatforms);
                     solutionText = AppendGlobalSection(solutionText, "NestedProjects", "\t{" + projectGuid + "} = {" + solutionFolderGuid + "}\r\n\t");
@@ -443,6 +444,10 @@ namespace Orchard.CodeGeneration.Commands {
                     TouchSolution(output);
                 }
             }
+        }
+
+        private string NormalizeLineEndings(string input) {
+            return input.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", "\r\n");
         }
 
         private string AppendGlobalSection(string solutionText, string sectionName, string content) {


### PR DESCRIPTION
CodeGeneration will fail when adding a new theme or module project to the solution if the solution file doesn't have `\r\n` line endings. This fix normalizes all line endings in the solution to `\r\n` before injecting the project reference.

- Replace all instances of `\r\n` to `\n`. File will now have `\r` or `\n` but not both together.
- Replace all remaining instances if `\r` to `\n`. File will now only have `\n`.
- Replace all instances of `\n` back to `\r\n`. File will now only have `\r\n`.

Fixes #7699