### PR TITLE
Added NOLOCK to the IndexingTaskRecord table

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Indexing/Orchard.Indexing.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Indexing/Orchard.Indexing.csproj
@@ -109,6 +109,7 @@
     </Compile>
     <Compile Include="Services\CreateUpdateIndexTaskService.cs" />
     <Compile Include="Services\ICreateUpdateIndexTaskService.cs" />
+    <Compile Include="Services\IndexingNoLockTableProvider.cs" />
     <Compile Include="Services\UpdateIndexScheduler.cs" />
     <Compile Include="Services\IIndexingTaskExecutor.cs" />
     <Compile Include="Services\IUpdateIndexScheduler.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Indexing/Services/IndexingNoLockTableProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.Indexing/Services/IndexingNoLockTableProvider.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Orchard.Data.Providers;
+
+namespace Orchard.Indexing.Services {
+    public class IndexingNoLockTableProvider : INoLockTableProvider {
+        public IEnumerable<string> GetTableNames() {
+            return new string[] { "Orchard_Indexing_IndexingTaskRecord" };
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8082 #8073 
Added NOLOCK to the IndexingTaskRecord table to prevent locking everything while reading from it.
This directly solves #8082, and it seems to also fix #8073 on our end.