### PR TITLE
fix: only creatable content types can be created

### DIFF
--- a/src/Orchard.Web/Core/Contents/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Core/Contents/Controllers/AdminController.cs
@@ -242,6 +242,9 @@ namespace Orchard.Core.Contents.Controllers {
             if (string.IsNullOrEmpty(id))
                 return CreatableTypeList(containerId);
 
+            if (contentItem.TypeDefinition.Settings.First(x => x.Key == "ContentTypeSettings.Creatable").Value.ToLower() == "false")
+                return new HttpUnauthorizedResult();
+
             if (_contentDefinitionManager.GetTypeDefinition(id) == null) {
                 return RedirectToAction("Create", new { id = "" });
             }
@@ -286,6 +289,9 @@ namespace Orchard.Core.Contents.Controllers {
 
         private ActionResult CreatePOST(string id, string returnUrl, Func<ContentItem, bool> conditionallyPublish) {
             var contentItem = _contentManager.New(id);
+
+            if (contentItem.TypeDefinition.Settings.First(x => x.Key == "ContentTypeSettings.Creatable").Value.ToLower() == "false")
+                return new HttpUnauthorizedResult();
 
             if (!Services.Authorizer.Authorize(Permissions.EditContent, contentItem, T("You do not have permission to edit content.")))
                 return new HttpUnauthorizedResult();


### PR DESCRIPTION
Before this change if I set a content type to uncreatable you could create it with the link.

So e.g. in Page content type creatable checkbox is unchecked, but you could create with link: `/Admin/Contents/Create/Page`.