### PR TITLE
Fixed null reference of MediaPart on Page content item creation

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Fields/MediaLibraryPickerField.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Fields/MediaLibraryPickerField.cs
@@ -18,7 +18,7 @@ namespace Orchard.MediaLibrary.Fields {
 
         public IEnumerable<MediaPart> MediaParts { 
             get {
-                return _contentItems != null ? _contentItems.Value : Enumerable.Empty<MediaPart>();
+                return _contentItems != null ? (_contentItems.Value ?? Enumerable.Empty<MediaPart>()) : Enumerable.Empty<MediaPart>();
             }
             set { _contentItems.Value = value; }
         }


### PR DESCRIPTION
I was working on customize content definition. I suddenly found some weird error following step below.

1. Add `MediaLibraryPickerField` in `MenuPart`.
2. Try to create new `Page` 

My debugger triggering while page loading. and complain about `MediaPart` is null on `MediaLibraryPicker.Summary` view. after Investigation i would say `MediaPart` might null when it on `Page` creation.
