### PR TITLE
Fix pager is not showing on taxonomies listing page.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/TermAdminController.cs
@@ -45,11 +45,14 @@ namespace Orchard.Taxonomies.Controllers {
             var pager = new Pager(_siteService.GetSiteSettings(), pagerParameters);
 
             var taxonomy = _taxonomyService.GetTaxonomy(taxonomyId);
-
+            
             var allTerms = _taxonomyService.GetTermsQuery(taxonomyId).OrderBy(x => x.FullWeight);
+
+            var totalItemCount = allTerms.Count();
+
             var termsPage = pager.PageSize > 0 ? allTerms.Slice(pager.GetStartIndex(), pager.PageSize) : allTerms.Slice(0, 0);
 
-            var pagerShape = Shape.Pager(pager).TotalItemCount(allTerms.Count());
+            var pagerShape = Shape.Pager(pager).TotalItemCount(totalItemCount);
 
             var entries = termsPage
                     .Select(term => term.CreateTermEntry())


### PR DESCRIPTION
I found `Pager` is not showing when I click link of website. 
(i.e. `~/Taxonomies/TermAdmin?taxonomyId=26&page=2`)

I tested in the first page is showing `Pager` but another page number is not show it. 
I check this code and when use `Slice()` then `allTerms.Count()` is zero and `Pager` is not show.