### PR TITLE
AuditTrail summary view error when title was empty.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Views/AuditTrailEvent-Content.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Views/AuditTrailEvent-Content.SummaryAdmin.cshtml
@@ -10,7 +10,11 @@
     var eventVersionNumber = eventData.Get<int>("VersionNumber");
     var isPublishedEvent = eventData.Get<bool>("Published");
     var itemDisplayText = contentItem != null ? Html.ItemDisplayText(contentItem) : default(IHtmlString);
-    var title = itemDisplayText != null ? itemDisplayText.ToString() : eventData.Get<string>("Title") ?? "[untitled]";
+    var title = itemDisplayText != null ? itemDisplayText.ToString() : eventData.Get<string>("Title");
+    if (string.IsNullOrEmpty(title))
+    {
+        title = "[untitled]";
+    }
 }
 <section class="audittrail-content-eventsummary">
     @if (contentItem != null) {


### PR DESCRIPTION
I was working on Audit Trail so far. And i found a error when no title defined on content item.

Current code is check for `null` but not for empty string. the error will occur at part of  code line here (Argument Exception)

```
Html.ItemEditLink(title, contentItemId), eventPastTense)
```

where title can not null and empty.

so i just add statement for make sure `title` can not empty