### PR TITLE
8111: Updating QueryVersionScopeOptions and ProjectionManager to support Draft-only Queries

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/Filter/FilterContext.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/Filter/FilterContext.cs
@@ -14,7 +14,7 @@ namespace Orchard.Projections.Descriptors.Filter {
 
         public QueryPartRecord QueryPartRecord { get; set; }
         public string GetFilterColumnName() {
-            return QueryPartRecord != null && QueryPartRecord.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value";
+            return QueryPartRecord.GetVersionedFieldIndexColumnName();
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/SortCriterion/SortCriteriaContext.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Descriptors/SortCriterion/SortCriteriaContext.cs
@@ -14,7 +14,7 @@ namespace Orchard.Projections.Descriptors.SortCriterion {
 
         public QueryPartRecord QueryPartRecord { get; set; }
         public string GetSortColumnName() {
-            return QueryPartRecord != null && QueryPartRecord.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value";
+            return QueryPartRecord.GetVersionedFieldIndexColumnName();
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Drivers/QueryPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Drivers/QueryPartDriver.cs
@@ -44,6 +44,8 @@ namespace Orchard.Projections.Drivers {
 
             var element = context.Element(part.PartDefinition.Name);
 
+            element.SetAttributeValue("VersionScope", part.VersionScope);
+
             element.Add(
                 new XElement("FilterGroups",
                     part.FilterGroups.Select(filterGroup =>
@@ -120,6 +122,8 @@ namespace Orchard.Projections.Drivers {
             if (context.Data.Element(part.PartDefinition.Name) == null) {
                 return;
             }
+
+            context.ImportAttribute(part.PartDefinition.Name, "VersionScope", scope => part.VersionScope = (QueryVersionScopeOptions)Enum.Parse(typeof(QueryVersionScopeOptions), scope));
 
             var queryElement = context.Data.Element(part.PartDefinition.Name);
 

--- a/src/Orchard.Web/Modules/Orchard.Projections/Extensions/QueryPartRecordExtensions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Extensions/QueryPartRecordExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace Orchard.Projections.Models {
+    public static class QueryPartRecordExtensions {
+        public static string GetVersionedFieldIndexColumnName(this QueryPartRecord queryPartRecord) {
+            return queryPartRecord == null ?
+                QueryVersionScopeOptions.Published.ToVersionedFieldIndexColumnName() :
+                queryPartRecord.VersionScope.ToVersionedFieldIndexColumnName();
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Projections/Extensions/QueryVersionScopeOptionsExtensions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Extensions/QueryVersionScopeOptionsExtensions.cs
@@ -1,0 +1,26 @@
+﻿using Orchard.ContentManagement;
+
+namespace Orchard.Projections {
+    public static class QueryVersionScopeOptionsExtensions {
+        public static VersionOptions ToVersionOptions(this QueryVersionScopeOptions scope) {
+            switch (scope) {
+                case QueryVersionScopeOptions.Latest:
+                    return VersionOptions.Latest;
+                case QueryVersionScopeOptions.Draft:
+                    return VersionOptions.Draft;
+                default:
+                    return VersionOptions.Published;
+            }
+        }
+
+        public static string ToVersionedFieldIndexColumnName(this QueryVersionScopeOptions scope) {
+            switch (scope) {
+                case QueryVersionScopeOptions.Latest:
+                case QueryVersionScopeOptions.Draft:
+                    return "LatestValue";
+                default:
+                    return "Value";
+            }
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/BooleanFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/BooleanFieldTypeEditor.cs
@@ -25,7 +25,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return BooleanFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
+            return BooleanFilterForm.GetFilterPredicate(formState, ((QueryVersionScopeOptions)formState.VersionScope).ToVersionedFieldIndexColumnName());
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/DateTimeFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/DateTimeFieldTypeEditor.cs
@@ -29,7 +29,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return DateTimeFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value", _clock.UtcNow, true);
+            return DateTimeFilterForm.GetFilterPredicate(formState, ((QueryVersionScopeOptions)formState.VersionScope).ToVersionedFieldIndexColumnName(), _clock.UtcNow, true);
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/DecimalFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/DecimalFieldTypeEditor.cs
@@ -27,7 +27,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return NumericFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
+            return NumericFilterForm.GetFilterPredicate(formState, ((QueryVersionScopeOptions)formState.VersionScope).ToVersionedFieldIndexColumnName());
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/FloatFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/FloatFieldTypeEditor.cs
@@ -28,7 +28,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return NumericFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
+            return NumericFilterForm.GetFilterPredicate(formState, ((QueryVersionScopeOptions)formState.VersionScope).ToVersionedFieldIndexColumnName());
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/IntegerFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/IntegerFieldTypeEditor.cs
@@ -34,7 +34,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return NumericFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
+            return NumericFilterForm.GetFilterPredicate(formState, ((QueryVersionScopeOptions)formState.VersionScope).ToVersionedFieldIndexColumnName());
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/StringFieldTypeEditor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FieldTypeEditors/StringFieldTypeEditor.cs
@@ -25,7 +25,7 @@ namespace Orchard.Projections.FieldTypeEditors {
         }
 
         public Action<IHqlExpressionFactory> GetFilterPredicate(dynamic formState) {
-            return StringFilterForm.GetFilterPredicate(formState, formState.VersionScope == QueryVersionScopeOptions.Latest ? "LatestValue" : "Value");
+            return StringFilterForm.GetFilterPredicate(formState, ((QueryVersionScopeOptions)formState.VersionScope).ToVersionedFieldIndexColumnName());
         }
 
         public LocalizedString DisplayFilter(string fieldName, string storageName, dynamic formState) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/Models/FieldIndexRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Models/FieldIndexRecord.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace Orchard.Projections.Models {
+﻿namespace Orchard.Projections.Models {
     public abstract class FieldIndexRecord {
         public virtual int Id { get; set; }
         public virtual string PropertyName { get; set; }
@@ -25,5 +23,4 @@ namespace Orchard.Projections.Models {
         public virtual decimal? Value { get; set; }
         public virtual decimal? LatestValue { get; set; }
     }
-
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Models/QueryPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Models/QueryPart.cs
@@ -11,8 +11,8 @@ namespace Orchard.Projections.Models {
         }
 
         public QueryVersionScopeOptions VersionScope {
-            get { return this.Retrieve(x => x.VersionScope); }
-            set { this.Store(x => x.VersionScope, value); }
+            get { return Retrieve(x => x.VersionScope); }
+            set { Store(x => x.VersionScope, value); }
         }
         public IList<SortCriterionRecord> SortCriteria {
             get { return Record.SortCriteria; }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Models/QueryPartRecord.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Models/QueryPartRecord.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
-using Orchard.ContentManagement;
 using Orchard.ContentManagement.Records;
 using Orchard.Data.Conventions;
 
@@ -26,6 +25,5 @@ namespace Orchard.Projections.Models {
         [CascadeAllDeleteOrphan, Aggregate]
         [XmlArray("Layouts")]
         public virtual IList<LayoutRecord> Layouts { get; set; }
-
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
@@ -128,6 +128,8 @@
     <Content Include="Web.config" />
     <Content Include="Scripts\Web.config" />
     <Content Include="Styles\Web.config" />
+    <Compile Include="Extensions\QueryPartRecordExtensions.cs" />
+    <Compile Include="Extensions\QueryVersionScopeOptionsExtensions.cs" />
     <Compile Include="Permissions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Module.txt" />

--- a/src/Orchard.Web/Modules/Orchard.Projections/QueryVersionScopeOptions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/QueryVersionScopeOptions.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
-namespace Orchard.Projections {
-    public enum  QueryVersionScopeOptions {
+﻿namespace Orchard.Projections
+{
+    public enum QueryVersionScopeOptions
+    {
         Published,
-        Latest
+        Latest,
+        Draft
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Projections/QueryVersionScopeOptions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/QueryVersionScopeOptions.cs
@@ -1,7 +1,5 @@
-﻿namespace Orchard.Projections
-{
-    public enum QueryVersionScopeOptions
-    {
+﻿namespace Orchard.Projections {
+    public enum QueryVersionScopeOptions {
         Published,
         Latest,
         Draft

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -200,17 +200,23 @@ namespace Orchard.Projections.Services {
                 tokens = new Dictionary<string, object>();
             }
 
-            // pre-executing all groups 
             var versionScope = queryRecord.VersionScope;
-            foreach (var group in queryRecord.FilterGroups) {
+            VersionOptions version;
+            switch (versionScope) {
+                case QueryVersionScopeOptions.Latest:
+                    version = VersionOptions.Latest;
+                    break;
+                case QueryVersionScopeOptions.Draft:
+                    version = VersionOptions.Draft;
+                    break;
+                default:
+                    version = VersionOptions.Published;
+                    break;
+            }
 
-                IHqlQuery contentQuery;
-                if (versionScope == QueryVersionScopeOptions.Latest) {
-                    contentQuery = _contentManager.HqlQuery().ForVersion(VersionOptions.Latest);
-                }
-                else {
-                    contentQuery = _contentManager.HqlQuery().ForVersion(VersionOptions.Published);
-                }
+            // pre-executing all groups
+            foreach (var group in queryRecord.FilterGroups) {
+                var contentQuery = _contentManager.HqlQuery().ForVersion(version);
 
                 // iterate over each filter to apply the alterations to the query object
                 foreach (var filter in group.Filters) {

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using Orchard.ContentManagement;
 using Orchard.Data;
 using Orchard.Forms.Services;
-using Orchard.Projections.Descriptors;
 using Orchard.Localization;
-using Orchard.Projections.Descriptors.Property;
+using Orchard.Projections.Descriptors;
 using Orchard.Projections.Descriptors.Filter;
 using Orchard.Projections.Descriptors.Layout;
+using Orchard.Projections.Descriptors.Property;
 using Orchard.Projections.Descriptors.SortCriterion;
 using Orchard.Projections.Models;
 using Orchard.Tokens;
@@ -200,19 +200,7 @@ namespace Orchard.Projections.Services {
                 tokens = new Dictionary<string, object>();
             }
 
-            var versionScope = queryRecord.VersionScope;
-            VersionOptions version;
-            switch (versionScope) {
-                case QueryVersionScopeOptions.Latest:
-                    version = VersionOptions.Latest;
-                    break;
-                case QueryVersionScopeOptions.Draft:
-                    version = VersionOptions.Draft;
-                    break;
-                default:
-                    version = VersionOptions.Published;
-                    break;
-            }
+            var version = queryRecord.VersionScope.ToVersionOptions();
 
             // pre-executing all groups
             foreach (var group in queryRecord.FilterGroups) {
@@ -251,7 +239,7 @@ namespace Orchard.Projections.Services {
                     var sortCriterionContext = new SortCriterionContext {
                         Query = contentQuery,
                         State = FormParametersHelper.ToDynamic(sortCriterion.State),
-                        QueryPartRecord= queryRecord
+                        QueryPartRecord = queryRecord
                     };
 
                     string category = sortCriterion.Category;


### PR DESCRIPTION
Changes:

- Added extension methods
  - `QueryVersionScopeOptions.ToVersionOptions` (to convert a Query scope to a VersionOptions to be used in content queries)
  - `QueryVersionScopeOptions.ToVersionedFieldIndexColumnName` to determine which field index column should be used in a query based on the Query scope
  - `QueryPartRecord.GetVersionedFieldIndexColumnName` which is a wrapper above the previous one, uses the Published scope if not null.
- `FilterContext`, `SortCriteriaContext`, the `IFieldTypeEditor` implementations and `ProjectionManager` is updated to use these extension methods, so the core logic is defined in one place.
- Fixed that `QueryPart` didn't export/import the VersionScope property.

All 3 scopes re-tested with filters and sorting, unit tests still passing.