### PR TITLE
Fix Breadcrumb when ContentItem without TitlePart.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Lists/Views/Breadcrumbs.ContentItem.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Lists/Views/Breadcrumbs.ContentItem.cshtml
@@ -4,7 +4,7 @@
     var breadcrumbs = new List<dynamic>();
     var containerAccessor = (Func<IContent, IContent>) Model.ContainerAccessor;
     do {
-        var displayText = content.Id > 0 ? (Html.ItemDisplayText(content) != null) ? Html.ItemDisplayText(content).ToString() : T("{0}", content.ContentItem.TypeDefinition.DisplayName).ToString() : T("New {0}", content.ContentItem.TypeDefinition.DisplayName).ToString();
+        var displayText = content.Id > 0 ? (Html.ItemDisplayText(content) != null) ? Html.ItemDisplayText(content).ToString() : content.ContentItem.TypeDefinition.DisplayName : T("New {0}", content.ContentItem.TypeDefinition.DisplayName).ToString();
         var breadcrumb = New.BreadcrumbItem(Text: displayText, Url: Url.ItemAdminUrl(content));
         breadcrumbs.Insert(0, breadcrumb);
         content = containerAccessor(content);

--- a/src/Orchard.Web/Modules/Orchard.Lists/Views/Breadcrumbs.ContentItem.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Lists/Views/Breadcrumbs.ContentItem.cshtml
@@ -4,7 +4,7 @@
     var breadcrumbs = new List<dynamic>();
     var containerAccessor = (Func<IContent, IContent>) Model.ContainerAccessor;
     do {
-        var displayText = content.Id > 0 ? Html.ItemDisplayText(content).ToString() : T("New {0}", content.ContentItem.TypeDefinition.DisplayName).ToString();
+        var displayText = content.Id > 0 ? (Html.ItemDisplayText(content) != null) ? Html.ItemDisplayText(content).ToString() : T("{0}", content.ContentItem.TypeDefinition.DisplayName).ToString() : T("New {0}", content.ContentItem.TypeDefinition.DisplayName).ToString();
         var breadcrumb = New.BreadcrumbItem(Text: displayText, Url: Url.ItemAdminUrl(content));
         breadcrumbs.Insert(0, breadcrumb);
         content = containerAccessor(content);


### PR DESCRIPTION
When ContentItem using Orchard.Lists doesn't have TitlePart, Html.ItemDisplayText(content) return null and show error on website.
So, I using `ContentType` name instead title.