### PR TITLE
Fix Tab id in Tab_Galley view

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaPicker/Views/Admin/Tab_Gallery.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaPicker/Views/Admin/Tab_Gallery.cshtml
@@ -7,7 +7,7 @@
 @helper FolderLink(string folderName, string mediaPath) {
 	// querystring values need to persist after a new GET when clicking on the media browser's
 	// folders for navigation.
-    @Html.ActionLink(folderName, "Index", null, null, null, "tab=1", new {
+    @Html.ActionLink(folderName, "Index", null, null, null, "tab-gallery", new {
         callback = Request["callback"],
 		uploadpath = Request["uploadpath"],
 		editmode = Request["editmode"],


### PR DESCRIPTION
I found a bad tab id in `Tab_Galley` view. it was defined with `tab=1` in ActionLink but i should match with tab panel in `Index` view below

In Index view 
```
    <div id="tab-gallery">
@Html.Partial("Tab_Gallery", (object)Model)
    </div>
```

To get tab button active to tab panel correctly then action link must use same id instead of `tab=1`.