### PR TITLE
Fix title encoding for edit content item, Fix encoding for Audittrail events

### DIFF
--- a/src/Orchard.Web/Core/Contents/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Core/Contents/Views/Admin/Edit.cshtml
@@ -2,7 +2,7 @@
     var typeDisplayName = Model.ContentItem.TypeDefinition.DisplayName;
     var pageTitle = T("Edit Content");
     if (!string.IsNullOrWhiteSpace(typeDisplayName)) {
-        pageTitle = T("Edit {0}", typeDisplayName);
+        pageTitle = T("Edit {0}", Html.Raw(typeDisplayName));
     }
 
     Layout.Title = pageTitle;

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Views/AuditTrailEvent-Content.SummaryAdmin.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Views/AuditTrailEvent-Content.SummaryAdmin.cshtml
@@ -1,20 +1,16 @@
-@using Orchard.AuditTrail.Helpers
+﻿@using Orchard.AuditTrail.Helpers
 @using Orchard.AuditTrail.Services.Models
 @using Orchard.ContentManagement
 @{
     var descriptor = (AuditTrailEventDescriptor)Model.Descriptor;
     var eventData = (IDictionary<string, object>) Model.EventData;
     var eventPastTense = descriptor.Name.Text.ToLower();
-    var contentItemId = (int?)Model.ContentItemId;
+    var contentItemId = (int)Model.ContentItemId;
     var contentItem = (ContentItem) Model.ContentItem;
     var eventVersionNumber = eventData.Get<int>("VersionNumber");
     var isPublishedEvent = eventData.Get<bool>("Published");
-    var itemDisplayText = contentItem != null ? Html.ItemDisplayText(contentItem) : default(IHtmlString);
-    var title = itemDisplayText != null ? itemDisplayText.ToString() : eventData.Get<string>("Title");
-    if (string.IsNullOrEmpty(title))
-    {
-        title = "[untitled]";
-    }
+    var itemDisplayText = contentItem != null ? Html.ItemDisplayText(contentItem, false) : default(IHtmlString);
+    var title = itemDisplayText != null ? itemDisplayText.ToString() : eventData.Get<string>("Title") ?? "[untitled]";
 }
 <section class="audittrail-content-eventsummary">
     @if (contentItem != null) {
@@ -22,13 +18,14 @@
         var isLatest = contentItem.VersionRecord.Number == eventVersionNumber;
         var isRemoved = !contentItem.VersionRecord.Latest && !contentItem.VersionRecord.Published;
         if (isPublishedEvent || isLatest) {
-            @T("{0} of the {1} {2} was {3}.", Html.ActionLink(T("Version {0}", eventVersionNumber).Text, "Detail", "Content", new { area = "Orchard.AuditTrail", id = contentItemId.Value, version = eventVersionNumber }, null), contentType.ToLower(), isRemoved ? Html.Raw("<strong>" + title + "</strong>") : Html.ItemEditLink(title, contentItemId.Value), eventPastTense)
+            @T("{0} of the {1} {2} was {3}.", Html.ActionLink(T("Version {0}", eventVersionNumber).Text, "Detail", "Content", new { area = "Orchard.AuditTrail", id = contentItemId, version = eventVersionNumber }, null), contentType.ToLower(), isRemoved ? Html.Raw("<strong>" + title + "</strong>") : Html.ItemEditLink(title, contentItemId), eventPastTense)
         }
         else if (isRemoved) {
             @T("The {0} <strong>{1}</strong> was {2}.", contentType.ToLower(), title, eventPastTense)
         }
         else {
-            @T("The {0} {1} was {2}.", contentType.ToLower(), Html.ItemEditLink(title, contentItemId.Value), eventPastTense)
+            @T("The {0} {1} was {2}.", contentType.ToLower(), Html.ItemEditLink(title, contentItemId), eventPastTense)
+
         }
     }
     else {


### PR DESCRIPTION
Edited content items have title with html entities for some chars, we use Html.Raw(typeDisplayName) for fix this issue.

Audittrail has bad encoding in Audittrail list for ContentItem name, fix this with add false params to: Html.ItemDisplayText(contentItem, false)