### PR TITLE
Fixes #8181: Prevent placement info loss

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Services/ContentTypePlacementStrategy.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Services/ContentTypePlacementStrategy.cs
@@ -63,8 +63,10 @@ namespace Orchard.ContentTypes.Services {
                                     if (!String.IsNullOrEmpty(customPlacement.Placement.Position)) {
                                         location = String.Concat(location, ":", customPlacement.Placement.Position);
                                     }
-
-                                    return new PlacementInfo { Location = location };
+                                    // keep the identified Placement.info and then overrides only the location in order to preserve other informations like Wrappers and Alternates
+                                    var placementInfo = placement(ctx);
+                                    placementInfo.Location = location;
+                                    return placementInfo;
                                 }
                             }
                         }

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Services/ContentTypePlacementStrategy.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Services/ContentTypePlacementStrategy.cs
@@ -63,10 +63,14 @@ namespace Orchard.ContentTypes.Services {
                                     if (!String.IsNullOrEmpty(customPlacement.Placement.Position)) {
                                         location = String.Concat(location, ":", customPlacement.Placement.Position);
                                     }
-                                    // keep the identified Placement.info and then overrides only the location in order to preserve other informations like Wrappers and Alternates
-                                    var placementInfo = placement(ctx);
-                                    placementInfo.Location = location;
-                                    return placementInfo;
+                                    // clone the identified Placement.info into a new one in order to keep original informations like Wrappers and Alternates
+                                    var originalPlacementInfo = placement(ctx);
+                                    return new PlacementInfo {
+                                        Location = location,
+                                        Alternates = originalPlacementInfo.Alternates,
+                                        ShapeType = originalPlacementInfo.ShapeType,
+                                        Wrappers = originalPlacementInfo.Wrappers
+                                    };
                                 }
                             }
                         }


### PR DESCRIPTION
Keep the identified Placement.info data and then overrides only the location in order to preserve other informations like Wrappers and Alternates