### PR TITLE
Fixing that stylesheets are not found on Dashboard

### DIFF
--- a/src/Orchard/DisplayManagement/Descriptors/ResourceBindingStrategy/StylesheetBindingStrategy.cs
+++ b/src/Orchard/DisplayManagement/Descriptors/ResourceBindingStrategy/StylesheetBindingStrategy.cs
@@ -92,14 +92,27 @@ namespace Orchard.DisplayManagement.Descriptors.ResourceBindingStrategy {
                                 var shape = ((dynamic)displayContext.Value);
                                 var output = displayContext.ViewContext.Writer;
                                 ResourceDefinition resource = shape.Resource;
-                                string url = shape.Url;
+                                var url = GetResourceUrl(shape.Url, hit.fileVirtualPath);
                                 string condition = shape.Condition;
                                 Dictionary<string, string> attributes = shape.TagAttributes;
-                                ResourceManager.WriteResource(output, resource, url ?? hit.fileVirtualPath, condition, attributes);
+                                ResourceManager.WriteResource(output, resource, url, condition, attributes);
                                 return null;
                             });
                 }
             }
+        }
+
+        private string GetResourceUrl(string shapeUrl, string fileVirtualPath) {
+            if (string.IsNullOrEmpty(shapeUrl)) return fileVirtualPath;
+
+            return GetPathFromRelativeUrl(shapeUrl) == GetPathFromRelativeUrl(fileVirtualPath) ? shapeUrl : fileVirtualPath;
+        }
+
+        private string GetPathFromRelativeUrl(string url) {
+            var path = url.TrimStart('~');
+            var indexOfQueryString = path.IndexOf('?');
+
+            return indexOfQueryString >= 0 ? path.Substring(0, indexOfQueryString) : path;
         }
 
         private bool FeatureIsEnabled(FeatureDescriptor fd) {


### PR DESCRIPTION
Fixing #7932 and #7754 

Resource URLs are not replaced with file virtual path in StylesheetBindingStrategy leaving the URL pointing to TheAdmin theme folder instead of the related module path.

It was broken after merging https://github.com/OrchardCMS/Orchard/pull/7564 which fixed that the query strings are ignored. So this fix needs to keep that also fixed.