### PR TITLE
DefaultContentManager performance upgrade

### DIFF
--- a/src/Orchard/ContentManagement/DefaultContentManager.cs
+++ b/src/Orchard/ContentManagement/DefaultContentManager.cs
@@ -282,6 +282,11 @@ namespace Orchard.ContentManagement {
         }
 
         public IEnumerable<T> GetMany<T>(IEnumerable<int> ids, VersionOptions options, QueryHints hints) where T : class, IContent {
+            if (!ids.Any()) {
+                // since there are no ids, I have to get no item, so it makes
+                // sense to not do anything at all
+                return Enumerable.Empty<T>();
+            }
             var contentItemVersionRecords = GetManyImplementation(hints, (contentItemCriteria, contentItemVersionCriteria) => {
                 contentItemCriteria.Add(Restrictions.In("Id", ids.ToArray()));
                 if (options.IsPublished) {
@@ -314,6 +319,11 @@ namespace Orchard.ContentManagement {
 
 
         public IEnumerable<ContentItem> GetManyByVersionId(IEnumerable<int> versionRecordIds, QueryHints hints) {
+            if (!versionRecordIds.Any()) {
+                // since there are no ids, I have to get no item, so it makes
+                // sense to not do anything at all
+                return Enumerable.Empty<ContentItem>();
+            }
             var contentItemVersionRecords = GetManyImplementation(hints, (contentItemCriteria, contentItemVersionCriteria) =>
                 contentItemVersionCriteria.Add(Restrictions.In("Id", versionRecordIds.ToArray())));
 


### PR DESCRIPTION
This is a performance/Quality of life change to `DefaultContentManager`.
Basically, whenever in a call to `GetMany` or `GetManyByVersionId` we know we will not be fetching anything, the method returns and empty enumerable without actually preparing/performing the query.
The performance impact will generally be minimal, but there are a few corner cases where this is useful (hence the reason why this is more of a quality of life change). An example we faced (and the reason why we are proposing this change) is a display view of a `ContentItem` with a `TaxonomyField` whose taxonomy has several hundred (more than 3000 in our case) terms: by activating the shapetracing feature to work on alternates, those calls are performed at least once for each term (even those that are not selected), slowing down page load considerably (up to several minutes on a dev laptop we tested this on).