### PR TITLE
Added a filter for projections over StringFields

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Projections/FilterEditors/Forms/StringFilterForm.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FilterEditors/Forms/StringFilterForm.cs
@@ -94,7 +94,7 @@ namespace Orchard.Projections.FilterEditors.Forms {
                     return y => y.Not(x => x.Like(property, Convert.ToString(value), HqlMatchMode.Anywhere));
                 case StringOperator.ContainsAnyIfProvided:
                     if (string.IsNullOrWhiteSpace((string)value))
-                        return x => x.IsNotEmpty(property);
+                        return x => x.IsNotEmpty("Id"); // basically, return every possible ContentItem
                     var values3 = Convert.ToString(value)
                         .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                     var predicates3 = values3.Skip(1)

--- a/src/Orchard.Web/Modules/Orchard.Projections/FilterEditors/Forms/StringFilterForm.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/FilterEditors/Forms/StringFilterForm.cs
@@ -49,6 +49,10 @@ namespace Orchard.Projections.FilterEditors.Forms {
                     f._Operator.Add(new SelectListItem { Value = Convert.ToString(StringOperator.Ends), Text = T("Ends with").Text });
                     f._Operator.Add(new SelectListItem { Value = Convert.ToString(StringOperator.NotEnds), Text = T("Does not end with").Text });
                     f._Operator.Add(new SelectListItem { Value = Convert.ToString(StringOperator.NotContains), Text = T("Does not contain").Text });
+                    f._Operator.Add(new SelectListItem {
+                        Value = Convert.ToString(StringOperator.ContainsAnyIfProvided),
+                        Text = T("Contains any word (if any is provided)").Text
+                    });
 
                     return f;
                 };
@@ -88,6 +92,14 @@ namespace Orchard.Projections.FilterEditors.Forms {
                     return y => y.Not(x => x.Like(property, Convert.ToString(value), HqlMatchMode.End));
                 case StringOperator.NotContains:
                     return y => y.Not(x => x.Like(property, Convert.ToString(value), HqlMatchMode.Anywhere));
+                case StringOperator.ContainsAnyIfProvided:
+                    if (string.IsNullOrWhiteSpace((string)value))
+                        return x => x.IsNotEmpty(property);
+                    var values3 = Convert.ToString(value)
+                        .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    var predicates3 = values3.Skip(1)
+                        .Select<string, Action<IHqlExpressionFactory>>(x => y => y.Like(property, x, HqlMatchMode.Anywhere)).ToArray();
+                    return x => x.Disjunction(y => y.Like(property, values3[0], HqlMatchMode.Anywhere), predicates3);
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -118,6 +130,11 @@ namespace Orchard.Projections.FilterEditors.Forms {
                     return T("{0} does not end with '{1}'", fieldName, value);
                 case StringOperator.NotContains:
                     return T("{0} does not contain '{1}'", fieldName, value);
+                case StringOperator.ContainsAnyIfProvided:
+                    return T("{0} contains any of '{1}' (or '{1}' is empty)",
+                        fieldName,
+                        new LocalizedString(string.Join("', '",
+                            value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))));
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -135,5 +152,6 @@ namespace Orchard.Projections.FilterEditors.Forms {
         Ends,
         NotEnds,
         NotContains,
+        ContainsAnyIfProvided
     }
 }


### PR DESCRIPTION
Added a filter for projections over StringFields that allows returning all items when the provided value is empty.
The goal for this (base on an actual use case we have):
We want to do a "ContainsAny" query over the selected Ids on a ContentPickerField, and return all Items if no "filter" is selected.