### PR TITLE
Workaround for the Azure blob rename bug (Lombiq Technologies: ORCH-202), fixes #7741

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/AzureFileSystem.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/AzureFileSystem.cs
@@ -232,8 +232,8 @@ namespace Orchard.Azure.Services.FileSystems {
             path = ConvertToRelativeUriPath(path);
             newPath = ConvertToRelativeUriPath(newPath);
 
-            // Workaround for the bug where if the name differs only in casing the contained files will be broken.
-            // See: https://github.com/Azure/azure-storage-net/issues/892
+            // Workaround for https://github.com/Azure/azure-storage-net/issues/892
+            // Renaming a folder by only changing the casing corrupts all the files in the folder.
             if (path.Equals(newPath, StringComparison.OrdinalIgnoreCase)) {
                 var tempPath = Guid.NewGuid().ToString() + "/";
 

--- a/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/AzureFileSystem.cs
+++ b/src/Orchard.Web/Modules/Orchard.Azure/Services/FileSystems/AzureFileSystem.cs
@@ -232,6 +232,16 @@ namespace Orchard.Azure.Services.FileSystems {
             path = ConvertToRelativeUriPath(path);
             newPath = ConvertToRelativeUriPath(newPath);
 
+            // Workaround for the bug where if the name differs only in casing the contained files will be broken.
+            // See: https://github.com/Azure/azure-storage-net/issues/892
+            if (path.Equals(newPath, StringComparison.OrdinalIgnoreCase)) {
+                var tempPath = Guid.NewGuid().ToString() + "/";
+
+                RenameFolder(path, tempPath);
+
+                path = tempPath;
+            }
+
             if (!path.EndsWith("/"))
                 path += "/";
 


### PR DESCRIPTION
Fixes #7741 

This is a workaround only since the bug is in the AzureStorage SDK (see: https://github.com/Azure/azure-storage-net/issues/892 ). When you rename the folder and the name differs only in casing the file will break - except if you rename it to a temporary name and then rename it again to the target name.