### PR TITLE
Throwing exception when an invalid XML character is being saved into Infoset (Lombiq Technologies: ORCH-208), fixes #7560

### DIFF
--- a/src/Orchard.Tests/ContentManagement/Drivers/FieldStorage/InfosetFieldStorageProviderTests.cs
+++ b/src/Orchard.Tests/ContentManagement/Drivers/FieldStorage/InfosetFieldStorageProviderTests.cs
@@ -130,7 +130,6 @@ namespace Orchard.Tests.ContentManagement.Drivers.FieldStorage {
             var storage = _provider.BindStorage(part, part.PartDefinition.Fields.Single());
 
             foreach (var character in InfosetHelper.InvalidXmlCharacters) {
-                System.IO.File.AppendAllText(@"d:\Users\Zoltán\Desktop\chars.txt", character.ToString());
                 Assert.Throws<ArgumentException>(() => storage.Set("alpha", character));
             }
         }

--- a/src/Orchard.Tests/ContentManagement/Drivers/FieldStorage/InfosetFieldStorageProviderTests.cs
+++ b/src/Orchard.Tests/ContentManagement/Drivers/FieldStorage/InfosetFieldStorageProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Autofac;
 using NUnit.Framework;
 using Orchard.ContentManagement;
@@ -121,6 +122,23 @@ namespace Orchard.Tests.ContentManagement.Drivers.FieldStorage {
         [Test, Ignore("implementation pending")]
         public void VersionedSettingOnInfosetField() {
             Assert.Fail("todo");
+        }
+
+        [Test]
+        public void ForbiddenXmlCharactersDontBreakInfoset() {
+            var part = CreateContentItemPart();
+            var storage = _provider.BindStorage(part, part.PartDefinition.Fields.Single());
+
+            var invalidXmlCharacters = Enumerable
+                .Range(0, 32).Except(new[] { 9, 10, 13 })
+                .Select(character => Char.ConvertFromUtf32(character));
+
+            foreach (var character in invalidXmlCharacters) {
+                storage.Set("alpha", character);
+
+                // It's always the retrieval that can fail with invalid characters.
+                Assert.That(part.ContentItem.VersionRecord.Data, Is.Not.Null); 
+            }
         }
     }
 }

--- a/src/Orchard.Tests/ContentManagement/Drivers/FieldStorage/InfosetFieldStorageProviderTests.cs
+++ b/src/Orchard.Tests/ContentManagement/Drivers/FieldStorage/InfosetFieldStorageProviderTests.cs
@@ -125,19 +125,13 @@ namespace Orchard.Tests.ContentManagement.Drivers.FieldStorage {
         }
 
         [Test]
-        public void ForbiddenXmlCharactersDontBreakInfoset() {
+        public void ForbiddenXmlCharactersCauseException() {
             var part = CreateContentItemPart();
             var storage = _provider.BindStorage(part, part.PartDefinition.Fields.Single());
 
-            var invalidXmlCharacters = Enumerable
-                .Range(0, 32).Except(new[] { 9, 10, 13 })
-                .Select(character => Char.ConvertFromUtf32(character));
-
-            foreach (var character in invalidXmlCharacters) {
-                storage.Set("alpha", character);
-
-                // It's always the retrieval that can fail with invalid characters.
-                Assert.That(part.ContentItem.VersionRecord.Data, Is.Not.Null); 
+            foreach (var character in InfosetHelper.InvalidXmlCharacters) {
+                System.IO.File.AppendAllText(@"d:\Users\Zoltán\Desktop\chars.txt", character.ToString());
+                Assert.Throws<ArgumentException>(() => storage.Set("alpha", character));
             }
         }
     }

--- a/src/Orchard/ContentManagement/FieldStorage/InfosetStorage/InfosetPart.cs
+++ b/src/Orchard/ContentManagement/FieldStorage/InfosetStorage/InfosetPart.cs
@@ -69,6 +69,7 @@ namespace Orchard.ContentManagement.FieldStorage.InfosetStorage {
         }
 
         public void Set(string partName, string fieldName, string valueName, string value, bool versionable = false) {
+            InfosetHelper.ThrowIfContainsInvalidXmlCharacter(value);
 
             var element = versionable ? VersionInfoset.Element : Infoset.Element;
 

--- a/src/Orchard/ContentManagement/FieldStorage/InfosetStorage/InfosetStorageProvider.cs
+++ b/src/Orchard/ContentManagement/FieldStorage/InfosetStorage/InfosetStorageProvider.cs
@@ -38,6 +38,8 @@ namespace Orchard.ContentManagement.FieldStorage.InfosetStorage {
         }
 
         private void Set(XElement element, string partName, string fieldName, string valueName, string value) {
+            InfosetHelper.ThrowIfContainsInvalidXmlCharacter(value);
+
             var partElement = element.Element(partName);
             if (partElement == null) {
                 partElement = new XElement(partName);

--- a/src/Orchard/ContentManagement/InfosetHelper.cs
+++ b/src/Orchard/ContentManagement/InfosetHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Xml.Linq;
 using Orchard.ContentManagement.FieldStorage.InfosetStorage;
@@ -7,6 +8,8 @@ using Orchard.Utility;
 
 namespace Orchard.ContentManagement {
     public static class InfosetHelper {
+        public static readonly char[] InvalidXmlCharacters =
+            Enumerable.Range(0, 32).Except(new[] { 9, 10, 13 }).Select(codePoint => Char.ConvertFromUtf32(codePoint)[0]).ToArray();
 
         public static TProperty Retrieve<TPart, TProperty>(this TPart contentPart,
             Expression<Func<TPart, TProperty>> targetExpression,
@@ -128,6 +131,24 @@ namespace Orchard.ContentManagement {
             var versioned = typeof(ContentPartVersionRecord).IsAssignableFrom(typeof(TRecord));
             propertyInfo.SetValue(contentPart.Record, value, null);
             contentPart.Store(name, value, versioned);
+        }
+
+        /// <summary>
+        /// Checks the given string and throws an <see cref="ArgumentException"/> if it contains characters that are
+        /// invalid in XML. Otherwise just returns the original string.
+        /// </summary>
+        /// <param name="value">The string to check for invalid XML characters.</param>
+        /// <exception cref="ArgumentException">Thrown if the string contains invalid characters.</exception>
+        /// <returns>The original string if no invalid characters were found.</returns>
+        public static string ThrowIfContainsInvalidXmlCharacter(string value) {
+            var invalidCharacters = value.Intersect(InvalidXmlCharacters);
+
+            if (!invalidCharacters.Any()) {
+                return value;
+            }
+
+            throw new ArgumentException(
+                $"The string contains the character(s) {string.Join(", ", invalidCharacters.Select(character => character.ToString()))} which are invalid in XML and should be removed.");
         }
     }
 }

--- a/src/Orchard/ContentManagement/InfosetHelper.cs
+++ b/src/Orchard/ContentManagement/InfosetHelper.cs
@@ -141,14 +141,12 @@ namespace Orchard.ContentManagement {
         /// <exception cref="ArgumentException">Thrown if the string contains invalid characters.</exception>
         /// <returns>The original string if no invalid characters were found.</returns>
         public static string ThrowIfContainsInvalidXmlCharacter(string value) {
-            var invalidCharacters = value.Intersect(InvalidXmlCharacters);
-
-            if (!invalidCharacters.Any()) {
+            if (!value.Any(character => InvalidXmlCharacters.Contains(character))) {
                 return value;
             }
 
             throw new ArgumentException(
-                $"The string contains the character(s) {string.Join(", ", invalidCharacters.Select(character => character.ToString()))} which are invalid in XML and should be removed.");
+                $"The string contains character(s) that are invalid in XML and which should be removed.");
         }
     }
 }

--- a/src/Orchard/ContentManagement/XmlHelper.cs
+++ b/src/Orchard/ContentManagement/XmlHelper.cs
@@ -52,7 +52,7 @@ namespace Orchard.ContentManagement {
         /// <param name="value">The value to set.</param>
         /// <returns>Itself</returns>
         public static XElement Attr<T>(this XElement el, string name, T value) {
-            el.SetAttributeValue(name, ToString(value));
+            el.SetAttributeValue(name, InfosetHelper.ThrowIfContainsInvalidXmlCharacter(ToString(value)));
             return el;
         }
 
@@ -141,7 +141,7 @@ namespace Orchard.ContentManagement {
         /// <param name="value">The value.</param>
         /// <returns>The element.</returns>
         public static XElement Val<TValue>(this XElement el, TValue value) {
-            el.SetValue(ToString(value));
+            el.SetValue(InfosetHelper.ThrowIfContainsInvalidXmlCharacter(ToString(value)));
             return el;
         }
 


### PR DESCRIPTION
Implements the fix discussed under https://github.com/OrchardCMS/Orchard/issues/7560.

This exception will be logged if you try to write to the Infoset (or Infoset-backed properties) directly from code, but if you're editing a content item you'll be greated with a validation error something like this:
![image](https://user-images.githubusercontent.com/1976647/58656786-3780f800-831d-11e9-97bf-612d56a819a5.png)

As you can see this is far from ideal since there is no error message in the validation error box. This is because exception arising during model property validation it seems are not displayed. I don't know a simple way to solve this (nor do I think just displaying exceptions would the be best solution). However, I think this right now is "good enough": you can't break your site at least.