### PR TITLE
Using Single fcnMode in Release builds #6942 (Lombiq Technologies: ORCH-207)

### DIFF
--- a/src/Orchard.Web/Web.Release.config
+++ b/src/Orchard.Web/Web.Release.config
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
-	<system.transactions>
-		<defaultSettings xdt:Transform="RemoveAttributes(timeout)" />
-	</system.transactions>
-	<system.web>
-		<compilation xdt:Transform="RemoveAttributes(debug)" />
-		<customErrors mode="RemoteOnly" xdt:Transform="SetAttributes(mode)" />
-		<machineKey validationKey="AutoGenerate" decryptionKey="AutoGenerate" xdt:Transform="SetAttributes(validationKey,decryptionKey)" />
-	</system.web>
+    <system.transactions>
+        <defaultSettings xdt:Transform="RemoveAttributes(timeout)" />
+    </system.transactions>
+    <system.web>
+        <compilation xdt:Transform="RemoveAttributes(debug)" />
+        <customErrors mode="RemoteOnly" xdt:Transform="SetAttributes(mode)" />
+        <machineKey validationKey="AutoGenerate" decryptionKey="AutoGenerate" xdt:Transform="SetAttributes(validationKey,decryptionKey)" />
+        <!--
+        Configures File Change Notifications to have a single monitor object unlike the default config which creates
+        one for each subdirectory. This is supposed to lower resources usage and work equally well unless the
+        application has too many folders (this may happen if you have a lot of tenants and Media folders for example).
+        "Disabled" can get rid of all file watching but may cause issues.
+        For more information see https://shazwazza.com/post/all-about-aspnet-file-change-notification-fcn/ and
+        https://github.com/OrchardCMS/Orchard/issues/6942.
+        -->
+        <httpRuntime fcnMode="Single" xdt:Transform="SetAttributes(fcnMode)" />
+    </system.web>
   
   <glimpse xdt:Transform="SetAttributes(defaultRuntimePolicy)" defaultRuntimePolicy="Off" />
 </configuration>


### PR DESCRIPTION
As discussed under https://github.com/OrchardCMS/Orchard/issues/6942 `fcnMode` is now set as `Single` as the Release default and there is some docs for people to understand what's it about.