### PR TITLE
Placement's path condition now strips the Tenant/Site UrlPrefix

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentDisplayBase.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentDisplayBase.cs
@@ -19,29 +19,22 @@ namespace Orchard.Layouts.Services {
         private readonly RequestContext _requestContext;
         private readonly IVirtualPathProvider _virtualPathProvider;
         private readonly IWorkContextAccessor _workContextAccessor;
-        private readonly ShellSettings _shellSettings;
-        private readonly UrlPrefix _urlPrefix;
 
         protected ContentDisplayBase(
             IShapeFactory shapeFactory,
             Lazy<IShapeTableLocator> shapeTableLocator,
             RequestContext requestContext,
             IVirtualPathProvider virtualPathProvider,
-            IWorkContextAccessor workContextAccessor,
-            ShellSettings shellSettings) {
+            IWorkContextAccessor workContextAccessor) {
 
             _shapeFactory = shapeFactory;
             _shapeTableLocator = shapeTableLocator;
             _requestContext = requestContext;
             _virtualPathProvider = virtualPathProvider;
             _workContextAccessor = workContextAccessor;
-            _shellSettings = shellSettings;
-            if (!string.IsNullOrEmpty(_shellSettings.RequestUrlPrefix))
-                _urlPrefix = new UrlPrefix(_shellSettings.RequestUrlPrefix);
-
-
         }
 
+        public abstract UrlPrefix TenantUrlPrefix { get; }
         public abstract string DefaultStereotype { get; }
 
         public BuildDisplayContext BuildDisplayContext(IContent content, string displayType, string groupId) {
@@ -156,8 +149,8 @@ namespace Orchard.Layouts.Services {
         private string GetPath() {
             var appRelativePath = _virtualPathProvider.ToAppRelative(_requestContext.HttpContext.Request.Path);
             // If the tenant has a prefix, we strip the tenant prefix away.
-            if (_urlPrefix != null)
-                appRelativePath = _urlPrefix.RemoveLeadingSegments(appRelativePath);
+            if (TenantUrlPrefix != null)
+                appRelativePath = TenantUrlPrefix.RemoveLeadingSegments(appRelativePath);
 
             return VirtualPathUtility.AppendTrailingSlash(appRelativePath);
         }

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentFieldDisplay.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentFieldDisplay.cs
@@ -6,20 +6,23 @@ using Orchard.ContentManagement;
 using Orchard.ContentManagement.Drivers;
 using Orchard.DisplayManagement;
 using Orchard.DisplayManagement.Descriptors;
+using Orchard.Environment.Configuration;
 using Orchard.FileSystems.VirtualPath;
 
 namespace Orchard.Layouts.Services {
     public class ContentFieldDisplay : ContentDisplayBase, IContentFieldDisplay {
         private readonly IEnumerable<IContentFieldDriver> _contentFieldDrivers;
+        private readonly ShellSettings _shellSettings;
 
         public ContentFieldDisplay(
             IShapeFactory shapeFactory,
             Lazy<IShapeTableLocator> shapeTableLocator, 
             RequestContext requestContext,
             IVirtualPathProvider virtualPathProvider,
-            IWorkContextAccessor workContextAccessor, 
+            IWorkContextAccessor workContextAccessor,
+            ShellSettings shellSettings, 
             IEnumerable<IContentFieldDriver> contentFieldDrivers) 
-            : base(shapeFactory, shapeTableLocator, requestContext, virtualPathProvider, workContextAccessor) {
+            : base(shapeFactory, shapeTableLocator, requestContext, virtualPathProvider, workContextAccessor, shellSettings) {
 
             _contentFieldDrivers = contentFieldDrivers;
         }

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentFieldDisplay.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentFieldDisplay.cs
@@ -12,7 +12,6 @@ using Orchard.FileSystems.VirtualPath;
 namespace Orchard.Layouts.Services {
     public class ContentFieldDisplay : ContentDisplayBase, IContentFieldDisplay {
         private readonly IEnumerable<IContentFieldDriver> _contentFieldDrivers;
-        private readonly ShellSettings _shellSettings;
 
         public ContentFieldDisplay(
             IShapeFactory shapeFactory,

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentFieldDisplay.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentFieldDisplay.cs
@@ -8,23 +8,36 @@ using Orchard.DisplayManagement;
 using Orchard.DisplayManagement.Descriptors;
 using Orchard.Environment.Configuration;
 using Orchard.FileSystems.VirtualPath;
+using Orchard.Mvc.Routes;
 
 namespace Orchard.Layouts.Services {
     public class ContentFieldDisplay : ContentDisplayBase, IContentFieldDisplay {
         private readonly IEnumerable<IContentFieldDriver> _contentFieldDrivers;
-
+        private readonly ShellSettings _shellSettings;
         public ContentFieldDisplay(
             IShapeFactory shapeFactory,
-            Lazy<IShapeTableLocator> shapeTableLocator, 
+            Lazy<IShapeTableLocator> shapeTableLocator,
             RequestContext requestContext,
             IVirtualPathProvider virtualPathProvider,
             IWorkContextAccessor workContextAccessor,
-            ShellSettings shellSettings, 
-            IEnumerable<IContentFieldDriver> contentFieldDrivers) 
-            : base(shapeFactory, shapeTableLocator, requestContext, virtualPathProvider, workContextAccessor, shellSettings) {
-
+            ShellSettings shellSettings,
+            IEnumerable<IContentFieldDriver> contentFieldDrivers)
+            : base(shapeFactory, shapeTableLocator, requestContext, virtualPathProvider, workContextAccessor) {
+            _shellSettings = shellSettings;
             _contentFieldDrivers = contentFieldDrivers;
         }
+
+        public override UrlPrefix TenantUrlPrefix {
+            get {
+                if (!string.IsNullOrEmpty(_shellSettings.RequestUrlPrefix)) {
+                    return new UrlPrefix(_shellSettings.RequestUrlPrefix);
+                }
+                else {
+                    return null;
+                }
+            }
+        }
+
 
         public override string DefaultStereotype {
             get { return "ContentField"; }
@@ -65,7 +78,7 @@ namespace Orchard.Layouts.Services {
                 if (result != null)
                     result.Apply(context);
             }, Logger);
-            
+
             return context.Shape;
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentPartDisplay.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentPartDisplay.cs
@@ -8,10 +8,12 @@ using Orchard.DisplayManagement;
 using Orchard.DisplayManagement.Descriptors;
 using Orchard.Environment.Configuration;
 using Orchard.FileSystems.VirtualPath;
+using Orchard.Mvc.Routes;
 
 namespace Orchard.Layouts.Services {
     public class ContentPartDisplay : ContentDisplayBase, IContentPartDisplay {
         private readonly IEnumerable<IContentPartDriver> _contentPartDrivers;
+        private readonly ShellSettings _shellSettings;
 
 
         public ContentPartDisplay(
@@ -22,9 +24,19 @@ namespace Orchard.Layouts.Services {
             IWorkContextAccessor workContextAccessor,
             ShellSettings shellSettings, 
             IEnumerable<IContentPartDriver> contentPartDrivers) 
-            : base(shapeFactory, shapeTableLocator, requestContext, virtualPathProvider, workContextAccessor, shellSettings) {
-
+            : base(shapeFactory, shapeTableLocator, requestContext, virtualPathProvider, workContextAccessor) {
+            _shellSettings = shellSettings;
             _contentPartDrivers = contentPartDrivers;
+        }
+        public override UrlPrefix TenantUrlPrefix {
+            get {
+                if (!string.IsNullOrEmpty(_shellSettings.RequestUrlPrefix)) {
+                    return new UrlPrefix(_shellSettings.RequestUrlPrefix);
+                }
+                else {
+                    return null;
+                }
+            }
         }
 
         public override string DefaultStereotype {

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentPartDisplay.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentPartDisplay.cs
@@ -12,7 +12,6 @@ using Orchard.FileSystems.VirtualPath;
 namespace Orchard.Layouts.Services {
     public class ContentPartDisplay : ContentDisplayBase, IContentPartDisplay {
         private readonly IEnumerable<IContentPartDriver> _contentPartDrivers;
-        private readonly ShellSettings _shellSettings;
 
 
         public ContentPartDisplay(

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentPartDisplay.cs
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Services/ContentPartDisplay.cs
@@ -6,20 +6,24 @@ using Orchard.ContentManagement;
 using Orchard.ContentManagement.Drivers;
 using Orchard.DisplayManagement;
 using Orchard.DisplayManagement.Descriptors;
+using Orchard.Environment.Configuration;
 using Orchard.FileSystems.VirtualPath;
 
 namespace Orchard.Layouts.Services {
     public class ContentPartDisplay : ContentDisplayBase, IContentPartDisplay {
         private readonly IEnumerable<IContentPartDriver> _contentPartDrivers;
+        private readonly ShellSettings _shellSettings;
+
 
         public ContentPartDisplay(
             IShapeFactory shapeFactory,
             Lazy<IShapeTableLocator> shapeTableLocator, 
             RequestContext requestContext,
             IVirtualPathProvider virtualPathProvider,
-            IWorkContextAccessor workContextAccessor, 
+            IWorkContextAccessor workContextAccessor,
+            ShellSettings shellSettings, 
             IEnumerable<IContentPartDriver> contentPartDrivers) 
-            : base(shapeFactory, shapeTableLocator, requestContext, virtualPathProvider, workContextAccessor) {
+            : base(shapeFactory, shapeTableLocator, requestContext, virtualPathProvider, workContextAccessor, shellSettings) {
 
             _contentPartDrivers = contentPartDrivers;
         }

--- a/src/Orchard/ContentManagement/DefaultContentDisplay.cs
+++ b/src/Orchard/ContentManagement/DefaultContentDisplay.cs
@@ -5,8 +5,10 @@ using System.Web.Routing;
 using Orchard.ContentManagement.Handlers;
 using Orchard.DisplayManagement;
 using Orchard.DisplayManagement.Descriptors;
+using Orchard.Environment.Configuration;
 using Orchard.FileSystems.VirtualPath;
 using Orchard.Logging;
+using Orchard.Mvc.Routes;
 using Orchard.UI.Zones;
 
 namespace Orchard.ContentManagement {
@@ -18,6 +20,8 @@ namespace Orchard.ContentManagement {
         private readonly RequestContext _requestContext;
         private readonly IVirtualPathProvider _virtualPathProvider;
         private readonly IWorkContextAccessor _workContextAccessor;
+        private readonly ShellSettings _shellSettings;
+        private readonly UrlPrefix _urlPrefix;
 
         public DefaultContentDisplay(
             Lazy<IEnumerable<IContentHandler>> handlers,
@@ -25,15 +29,19 @@ namespace Orchard.ContentManagement {
             Lazy<IShapeTableLocator> shapeTableLocator,
             RequestContext requestContext,
             IVirtualPathProvider virtualPathProvider,
-            IWorkContextAccessor workContextAccessor) {
+            IWorkContextAccessor workContextAccessor,
+            ShellSettings shellSettings) {
             _handlers = handlers;
             _shapeFactory = shapeFactory;
             _shapeTableLocator = shapeTableLocator;
             _requestContext = requestContext;
             _virtualPathProvider = virtualPathProvider;
             _workContextAccessor = workContextAccessor;
-
+            _shellSettings = shellSettings;
+            if (!string.IsNullOrEmpty(_shellSettings.RequestUrlPrefix))
+                _urlPrefix = new UrlPrefix(_shellSettings.RequestUrlPrefix);
             Logger = NullLogger.Instance;
+
         }
 
         public ILogger Logger { get; set; }
@@ -158,7 +166,12 @@ namespace Orchard.ContentManagement {
         /// Gets the current app-relative path, i.e. ~/my-blog/foo.
         /// </summary>
         private string GetPath() {
-            return VirtualPathUtility.AppendTrailingSlash(_virtualPathProvider.ToAppRelative(_requestContext.HttpContext.Request.Path));
+            var appRelativePath = _virtualPathProvider.ToAppRelative(_requestContext.HttpContext.Request.Path);
+            // If the tenant has a prefix, we strip the tenant prefix away.
+            if (_urlPrefix != null)
+                appRelativePath = _urlPrefix.RemoveLeadingSegments(appRelativePath);
+
+            return VirtualPathUtility.AppendTrailingSlash(appRelativePath);
         }
     }
 }


### PR DESCRIPTION
fixes #6962

Making this PR I found that 
`\src\Orchard.Web\Modules\Orchard.Layouts\Services\ContentDisplayBase.cs` has a TODO
```
    // TODO: This class contains duplicated code from the DefaultContentDisplay class.
    // Consider combining this class with DefaultContentDisplay to reuse shared code, for example by inheriting from a common base class.
```
But to modify the ContentDisplayBase with the same code added to DefaultContentDisplay it breaks Orchard.Layouts because `ContentFieldDisplay : ContentDisplayBase` and `ContentPartDisplay : ContentDisplayBase`  **so this change is potentially breaking**