### PR TITLE
Fix taxonomy deletion

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -115,9 +115,9 @@ namespace Orchard.Taxonomies.Services {
 
         public void DeleteTaxonomy(TaxonomyPart taxonomy) {
             _contentManager.Remove(taxonomy.ContentItem);
-
+            List<TermPart> allTerms = GetRootTerms(taxonomy.Id).ToList();
             // Removing terms
-            foreach (var term in GetRootTerms(taxonomy.Id)) {
+            foreach (var term in allTerms) {
                 DeleteTerm(term);
             }
 


### PR DESCRIPTION
I working on taxonomy for while and i found an error when delete taxonomy (in SqlCE database). the error say.. 

```
System.Data.SqlServerCe.SqlCeLockTimeoutException: SQL Server Compact timeout waiting for a lock. The default lock time is 200ms.....
```
This error will occur while delete, select in same transaction.