### PR TITLE
fixed issue #8239

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/MediaLibraryService.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/MediaLibraryService.cs
@@ -94,7 +94,8 @@ namespace Orchard.MediaLibrary.Services {
 
             if (!String.IsNullOrEmpty(folderPath)) {
                 if (recursive) {
-                    query = query.Join<MediaPartRecord>().Where(m => m.FolderPath.StartsWith(folderPath));
+                    var subfolderSearch = folderPath.EndsWith(Path.DirectorySeparatorChar.ToString()) ? folderPath : folderPath + Path.DirectorySeparatorChar;
+                    query = query.Join<MediaPartRecord>().Where(m => (m.FolderPath == folderPath || m.FolderPath.StartsWith(subfolderSearch)));
                 }
                 else {
                     query = query.Join<MediaPartRecord>().Where(m => m.FolderPath == folderPath);


### PR DESCRIPTION
The use of StartsWith is limited to a path ending with directory separator ("\" on Windows systems) to avoid unwanted deletion/rename in neighbor folders.