### PR TITLE
Fixed LayoutEditor race condition (#8250)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Layouts/Views/EditorTemplates/LayoutEditor.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Views/EditorTemplates/LayoutEditor.cshtml
@@ -40,7 +40,6 @@
                     }
                 });
 
-            angular.bootstrap($(".layout-editor-holder")[0], ["LayoutEditor"]);
 
             $(function () {
                 var editorConfig = JSON.parse(LayoutEditor.decode("@Html.Raw(Url.Encode(Model.ConfigurationData))"));
@@ -59,6 +58,8 @@
                         e.preventDefault();
                     });
                 });
+
+                angular.bootstrap($(".layout-editor-holder")[0], ["LayoutEditor"]);
             });
 
         </script>


### PR DESCRIPTION
Fixed a race condition in the Layout Editor by moving the call to bootstrapping angular inside the existing DOM ready block which fixes #8250 