### PR TITLE
Fix misaligned checkboxes on workflow admin page

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Workflows/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Views/Admin/Index.cshtml
@@ -43,7 +43,7 @@
         <table class="items">
             <thead>
                 <tr>
-                    <th scope="col" class="checkbox"><input type="checkbox" class="check-all"/></th>
+                    <th scope="col"><input type="checkbox" class="check-all"/></th>
                     <th scope="col">@T("Name")</th>
                     <th scope="col">&nbsp;</th>
                     <th scope="col" class="actions">&nbsp;</th>


### PR DESCRIPTION
Remove unnecessary html class to fix misaligned check boxes on workflow admin page