### PR TITLE
Adds RemovePartFromContentTypeStep for deltas

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Recipes/Orchard.Recipes.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Orchard.Recipes.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Providers\Executors\RemoveContentDefinitionStep.cs" />
     <Compile Include="Providers\Executors\RemoveContentStep.cs" />
     <Compile Include="Providers\Executors\RecipesStep.cs" />
+    <Compile Include="Providers\Executors\RemovePartFromContentTypeStep.cs" />
     <Compile Include="ViewModels\ContentExecutionStepViewModel.cs" />
     <Compile Include="Providers\Executors\ContentStep.cs" />
     <Compile Include="Providers\Executors\ContentDefinitionStep.cs" />

--- a/src/Orchard.Web/Modules/Orchard.Recipes/Providers/Executors/RemovePartFromContentTypeStep.cs
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Providers/Executors/RemovePartFromContentTypeStep.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Xml;
+using Orchard.ContentTypes.Services;
+using Orchard.Localization;
+using Orchard.Logging;
+using Orchard.Recipes.Models;
+using Orchard.Recipes.Services;
+
+namespace Orchard.Recipes.Providers.Executors {
+    public class RemovePartFromContentTypeStep : RecipeExecutionStep {
+        private readonly IContentDefinitionService _contentDefinitionService;
+
+        public RemovePartFromContentTypeStep(RecipeExecutionLogger logger, IContentDefinitionService contentDefinitionService) : base(logger) {
+            _contentDefinitionService = contentDefinitionService;
+        }
+
+        public override string Name {
+            get { return "RemovePartFromContentType"; }
+        }
+
+        public override LocalizedString DisplayName {
+            get { return T("Remove Part From Content Type"); }
+        }
+
+        public override LocalizedString Description {
+            get { return T("Removes a list of parts from a content type."); }
+        }
+
+        // <RemovePartFromContentType>
+        //   <Blog>
+        //     <Parts>
+        //     </Parts>
+        //   </Blog>
+        // </RemovePartFromContentType>
+        public override void Execute(RecipeExecutionContext context) {
+            foreach (var metadataElementType in context.RecipeStep.Step.Elements()) {
+                Logger.Debug("Processing element '{0}'.", metadataElementType.Name.LocalName);
+                var typeName = XmlConvert.DecodeName(metadataElementType.Name.LocalName);
+
+                foreach (var metadataElement in metadataElementType.Elements()) {
+                    switch (metadataElement.Name.LocalName) {
+                        case "Parts":
+                            foreach (var element in metadataElement.Elements()) {
+                                var partName = XmlConvert.DecodeName(element.Name.LocalName);
+
+                                Logger.Information("Removing content part '{0}' from content type '{1}'.", typeName, partName);
+                                try {
+                                    _contentDefinitionService.RemovePartFromType(partName, typeName);
+                                }
+                                catch (Exception ex) {
+                                    Logger.Error(ex, "Error while removing content part '{0}' from content type'{1}'.", typeName, partName);
+                                    throw;
+                                }
+                            }
+                            break;
+
+                        default:
+                            Logger.Warning("Unrecognized element '{0}' encountered; skipping",
+                                metadataElement.Name.LocalName);
+                            break;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add support for removal of content parts from content type definitions through recipes.

We hit a scenario where we needed to remove a part from a certain content type, we tried a content definition step with that part removed, however the part persisted.

This step makes it possible to remove individual parts from content type definitions