### PR TITLE
bugfix: Cannot insert duplicate key in object 'dbo.Settings_ShellFeatureStateRecord`

### DIFF
--- a/src/Orchard/Environment/Features/FeatureManager.cs
+++ b/src/Orchard/Environment/Features/FeatureManager.cs
@@ -79,7 +79,7 @@ namespace Orchard.Environment.Features {
 
             IDictionary<FeatureDescriptor, bool> availableFeatures = GetAvailableFeatures()
                 .ToDictionary(featureDescriptor => featureDescriptor,
-                                featureDescriptor => enabledFeatures.FirstOrDefault(shellFeature => shellFeature.Name == featureDescriptor.Id) != null);
+                                featureDescriptor => enabledFeatures.FirstOrDefault(shellFeature => shellFeature.Name.Equals(featureDescriptor.Id, StringComparison.OrdinalIgnoreCase)) != null);
 
             //Fix for https://github.com/OrchardCMS/Orchard/issues/6075 - added distinct to the end to ensure each feature is only listed once
             IEnumerable<string> featuresToEnable = featureIds
@@ -127,8 +127,8 @@ namespace Orchard.Environment.Features {
             if (featuresToDisable.Any()) {
                 foreach (string featureId in featuresToDisable) {
                     string id = featureId;
-
-                    enabledFeatures.RemoveAll(shellFeature => shellFeature.Name == id);
+                    
+                    enabledFeatures.RemoveAll(shellFeature => shellFeature.Name.Equals(id, StringComparison.OrdinalIgnoreCase)); 
                     Logger.Information("{0} was disabled", featureId);
                 }
 


### PR DESCRIPTION
The feature names are compared without ignoring the case in `EnableFeatures` (with 's')  and `DisabledFeatures` (with 's'). It causes "**Violation of UNIQUE KEY constraint 'UC_SFSR_SSRId_Name'. Cannot insert duplicate key in object 'dbo.Settings_ShellFeatureStateRecord**'" error when there is a module that has the same name but lower case in `Settings_ShellFeatureStateRecord` table and/or `Settings_ShellFeatureRecord`.

`featureState.Key.Id.Equals(fId, StringComparison.OrdinalIgnoreCase)` has been used in the `EnableFeature` (without 's') so I has used the same code for `EnableFeatures`  and `DisabledFeatures` .