### PR TITLE
Issue/8286 apply settings in taxonomy filed translation

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/LocalizedTaxonomyFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/LocalizedTaxonomyFieldDriver.cs
@@ -22,20 +22,22 @@ namespace Orchard.Taxonomies.Drivers {
             return ContentShape("Fields_TaxonomyFieldList_Edit", GetDifferentiator(field, part), () => {
                 var templateName = "Fields/TaxonomyFieldList";
                 var taxonomySettings= new TaxonomyFieldSettings();
-                  var contentDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
-                    if (contentDefinition != null) {
-                        var taxonomyField = contentDefinition.Parts.SelectMany(p => p.PartDefinition.Fields).Where(x => x.FieldDefinition.Name == "TaxonomyField" && x.Name == field.Name).FirstOrDefault();
-                         if (taxonomyField != null) {
-                             taxonomySettings = taxonomyField.Settings.GetModel<TaxonomyFieldSettings>();
+                var contentDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
+                if (contentDefinition != null) {
+                    var taxonomyField = contentDefinition.Parts.SelectMany(p => p.PartDefinition.Fields).Where(x => x.FieldDefinition.Name == "TaxonomyField" && x.Name == field.Name).FirstOrDefault();
+                        if (taxonomyField != null) {
+                            taxonomySettings = taxonomyField.Settings.GetModel<TaxonomyFieldSettings>();
 
-                        }
                     }
-               
+                }
+                var tryToTranslate = field.PartFieldDefinition.Settings.GetModel<TaxonomyFieldLocalizationSettings>().TryToLocalize;
+
                 var viewModel = new LocalizedTaxonomiesViewModel {
                     ContentType = part.ContentItem.ContentType,
                     FieldName = field.Name,
                     Id = part.ContentItem.Id,
-                    Setting = taxonomySettings
+                    Setting = taxonomySettings,
+                    TryTotranslate = tryToTranslate
                 };
                 return shapeHelper.EditorTemplate(TemplateName: templateName, Model: viewModel, Prefix: GetPrefix(field, part));
             });

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/LocalizedTaxonomyFieldHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/LocalizedTaxonomyFieldHandler.cs
@@ -94,6 +94,10 @@ namespace Orchard.Taxonomies.Handlers {
                     }
                     _taxonomyService.UpdateTerms(context.ContentItem, newTermParts, partFieldDefinition.Name);
                 }
+                else {
+                    // clear all terms
+                    _taxonomyService.UpdateTerms(context.ContentItem, new List<TermPart>(), partFieldDefinition.Name);
+                }
             }
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/LocalizedTaxonomySource.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/LocalizedTaxonomySource.cs
@@ -5,8 +5,9 @@ using Orchard.Core.Title.Models;
 using Orchard.Environment.Extensions;
 using Orchard.Localization.Models;
 using Orchard.Localization.Services;
+using Orchard.Taxonomies.Fields;
 using Orchard.Taxonomies.Models;
-
+using Orchard.Taxonomies.Settings;
 
 namespace Orchard.Taxonomies.Services {
     [OrchardFeature("Orchard.Taxonomies.LocalizationExtensions")]
@@ -37,11 +38,29 @@ namespace Orchard.Taxonomies.Services {
                 var masterCorrection = taxonomyPart.ContentItem.As<LocalizationPart>().MasterContentItem;
                 if (masterCorrection == null)
                     masterCorrection = taxonomyPart;
+
+                // update culture according to TryToLocalize settings
+                var fields = currentcontent.Parts.Where(x => x.Fields.Any(y => y.FieldDefinition.Name == "TaxonomyField")).Select(z => z.Fields.First(w => w.FieldDefinition.Name == "TaxonomyField"));
+                var taxoField = fields.First() as TaxonomyField;
+                if(taxoField != null) {
+                    var settings = taxoField.PartFieldDefinition.Settings.GetModel<TaxonomyFieldLocalizationSettings>();
+                    if(settings.TryToLocalize == false) {
+                        var termsField = taxoField.TermsField.Value.FirstOrDefault();
+                        if (termsField != null) {
+                            var taxoOriginalLocalization = termsField.ContentItem.As<LocalizationPart>();
+                            if(taxoOriginalLocalization != null && taxoOriginalLocalization.Culture != null) {
+                                culture = taxoOriginalLocalization.Culture.Culture;
+                            }
+                        }
+                    }
+                }
+
                 var localizedLocalizationPart = _localizationService.GetLocalizedContentItem(masterCorrection.ContentItem, culture);
                 if (localizedLocalizationPart == null)
                     return taxonomyPart;
-                else
+                else {
                     return localizedLocalizationPart.ContentItem.As<TaxonomyPart>();
+                }
             }
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/LocalizedTaxonomySource.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/LocalizedTaxonomySource.cs
@@ -40,15 +40,14 @@ namespace Orchard.Taxonomies.Services {
                     masterCorrection = taxonomyPart;
 
                 // update culture according to TryToLocalize settings
-                var fields = currentcontent.Parts.Where(x => x.Fields.Any(y => y.FieldDefinition.Name == "TaxonomyField")).Select(z => z.Fields.First(w => w.FieldDefinition.Name == "TaxonomyField"));
-                var taxoField = fields.First() as TaxonomyField;
-                if(taxoField != null) {
+                var fields = currentcontent.Parts.Where(x => x.Fields.Any(y => y.FieldDefinition.Name == "TaxonomyFielda")).Select(z => z.Fields.First(w => w.FieldDefinition.Name == "TaxonomyField"));
+                if (fields.FirstOrDefault() is TaxonomyField taxoField) {
                     var settings = taxoField.PartFieldDefinition.Settings.GetModel<TaxonomyFieldLocalizationSettings>();
-                    if(settings.TryToLocalize == false) {
+                    if (settings.TryToLocalize == false) {
                         var termsField = taxoField.TermsField.Value.FirstOrDefault();
                         if (termsField != null) {
                             var taxoOriginalLocalization = termsField.ContentItem.As<LocalizationPart>();
-                            if(taxoOriginalLocalization != null && taxoOriginalLocalization.Culture != null) {
+                            if (taxoOriginalLocalization != null && taxoOriginalLocalization.Culture != null) {
                                 culture = taxoOriginalLocalization.Culture.Culture;
                             }
                         }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/LocalizedTaxonomySource.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/LocalizedTaxonomySource.cs
@@ -40,7 +40,7 @@ namespace Orchard.Taxonomies.Services {
                     masterCorrection = taxonomyPart;
 
                 // update culture according to TryToLocalize settings
-                var fields = currentcontent.Parts.Where(x => x.Fields.Any(y => y.FieldDefinition.Name == "TaxonomyFielda")).Select(z => z.Fields.First(w => w.FieldDefinition.Name == "TaxonomyField"));
+                var fields = currentcontent.Parts.Where(x => x.Fields.Any(y => y.FieldDefinition.Name == "TaxonomyField")).Select(z => z.Fields.First(w => w.FieldDefinition.Name == "TaxonomyField"));
                 if (fields.FirstOrDefault() is TaxonomyField taxoField) {
                     var settings = taxoField.PartFieldDefinition.Settings.GetModel<TaxonomyFieldLocalizationSettings>();
                     if (settings.TryToLocalize == false) {

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/ViewModels/LocalizedTaxonomiesViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/ViewModels/LocalizedTaxonomiesViewModel.cs
@@ -8,5 +8,6 @@ namespace Orchard.Taxonomies.ViewModels {
         public string FieldName { get; set; }
         public int Id { get; set; }
         public TaxonomyFieldSettings Setting { get; set; }
+        public bool TryTotranslate { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
@@ -138,11 +138,7 @@
                 }
                 $("#Localization_SelectedCulture").on('change', function () {
                     var optionSelected = $("option:selected", this);
-                    @if(Model.TryTotranslate) {
-                        <text>
-                            filterTaxonomyCulture($("#Localization_SelectedCulture").val());
-                        </text>
-                    }
+                    filterTaxonomyCulture($("#Localization_SelectedCulture").val());
                 });
                 $("#Localization_SelectedCulture").trigger("change");
             });

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
@@ -138,7 +138,11 @@
                 }
                 $("#Localization_SelectedCulture").on('change', function () {
                     var optionSelected = $("option:selected", this);
-                    filterTaxonomyCulture($("#Localization_SelectedCulture").val());
+                    @if(Model.TryTotranslate) {
+                        <text>
+                            filterTaxonomyCulture($("#Localization_SelectedCulture").val());
+                        </text>
+                    }
                 });
                 $("#Localization_SelectedCulture").trigger("change");
             });


### PR DESCRIPTION
This is my proposal to fix issue #8286.
When the BuildEdito is first created just after cloning and TryToLocalize is false, I simply remove all terms associated with the taxonomy field.