### PR TITLE
Fix for issue #8286

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/LocalizedTaxonomyFieldHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/LocalizedTaxonomyFieldHandler.cs
@@ -94,6 +94,10 @@ namespace Orchard.Taxonomies.Handlers {
                     }
                     _taxonomyService.UpdateTerms(context.ContentItem, newTermParts, partFieldDefinition.Name);
                 }
+                else {
+                    // clear all terms
+                    _taxonomyService.UpdateTerms(context.ContentItem, new List<TermPart>(), partFieldDefinition.Name);
+                }
             }
         }
 


### PR DESCRIPTION
This is my proposal to fix issue #8286.
When the BuildEdito is first created just after cloning and TryToLocalize is false, I simply remove all terms associated with the taxonomy field.