### PR TITLE
Issue/8284

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Handlers/SslSettingsPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Handlers/SslSettingsPartHandler.cs
@@ -3,12 +3,24 @@ using Orchard.Data;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Localization;
 using Orchard.SecureSocketsLayer.Models;
+using Orchard.Caching;
 
 namespace Orchard.SecureSocketsLayer.Handlers {
     public class SslSettingsPartHandler : ContentHandler {
-        public SslSettingsPartHandler() {
+        private readonly ISignals _signals;
+
+        public SslSettingsPartHandler(ISignals signals) {
+
+            _signals = signals;
+
             T = NullLocalizer.Instance;
+
             Filters.Add(new ActivatingFilter<SslSettingsPart>("Site"));
+
+            // Evict cached content when updated, removed or destroyed.
+            OnPublished<SslSettingsPart>((context, part) => Invalidate(part));
+            OnRemoved<SslSettingsPart>((context, part) => Invalidate(part));
+            OnDestroyed<SslSettingsPart>((context, part) => Invalidate(part));
         }
 
         public Localizer T { get; set; }
@@ -21,6 +33,11 @@ namespace Orchard.SecureSocketsLayer.Handlers {
                 Id = "Ssl",
                 Position = "2"
             });
+        }
+
+        private void Invalidate(SslSettingsPart content) {
+            _signals.Trigger($"SslSettingsPart_{content.Id}");
+            _signals.Trigger("SslSettingsPart_EvictAll");
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Services/StrictTransportSecurityMiddlewareProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Services/StrictTransportSecurityMiddlewareProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Orchard.Caching;
 using Orchard.ContentManagement;
 using Orchard.Logging;
 using Orchard.Owin;
@@ -8,11 +9,19 @@ using Owin;
 namespace Orchard.SecureSocketsLayer.Services {
     public class StrictTransportSecurityMiddlewareProvider : IOwinMiddlewareProvider {
         private readonly IWorkContextAccessor _wca;
+        private readonly ICacheManager _cacheManager;
+        private readonly ISignals _signals;
 
         public ILogger Logger { get; set; }
 
-        public StrictTransportSecurityMiddlewareProvider(IWorkContextAccessor wca) {
+        public StrictTransportSecurityMiddlewareProvider(
+            IWorkContextAccessor wca,
+            ICacheManager cacheManager,
+            ISignals signals) {
+
             _wca = wca;
+            _cacheManager = cacheManager;
+            _signals = signals;
 
             Logger = NullLogger.Instance;
         }
@@ -22,7 +31,13 @@ namespace Orchard.SecureSocketsLayer.Services {
                 new OwinMiddlewareRegistration {
                     Configure = app =>
                         app.Use(async (context, next) => {
-                            var sslSettings = _wca.GetContext().CurrentSite.As<SslSettingsPart>();
+                            var cacheKey = "Orchard.SecureSocketsLayer.Services.StrictTransportSecurityMiddlewareProvider.GetOwinMiddlewares";
+                            var sslSettings = _cacheManager.Get(cacheKey, true, ctx =>{
+                                // check whether the cache should be invalidated
+                                ctx.Monitor(_signals.When("SslSettingsPart_EvictAll"));
+                                // cache this and save recomputing it each call
+                                return _wca.GetContext().CurrentSite.As<SslSettingsPart>();
+                            });
 
                             if (sslSettings.SendStrictTransportSecurityHeaders) {
                                 string responseValue = "max-age=" + sslSettings.StrictTransportSecurityMaxAge;

--- a/src/Orchard/Localization/Services/SiteCultureSelector.cs
+++ b/src/Orchard/Localization/Services/SiteCultureSelector.cs
@@ -1,22 +1,36 @@
 ﻿using System;
 using System.Web;
+using Orchard.Caching;
 
 namespace Orchard.Localization.Services {
     public class SiteCultureSelector : ICultureSelector {
         private readonly IWorkContextAccessor _workContextAccessor;
+        private readonly ICacheManager _cacheManager;
+        private readonly ISignals _signals;
 
-        public SiteCultureSelector(IWorkContextAccessor workContextAccessor) {
+        public SiteCultureSelector(
+            IWorkContextAccessor workContextAccessor,
+            ICacheManager cacheManager,
+            ISignals signals) {
+
             _workContextAccessor = workContextAccessor;
+            _cacheManager = cacheManager;
+            _signals = signals;
         }
 
         public CultureSelectorResult GetCulture(HttpContextBase context) {
-            string currentCultureName = _workContextAccessor.GetContext().CurrentSite.SiteCulture;
+            var cacheKey = "Orchard.Localization.Services.SiteCultureSelector.GetCulture";
+            return _cacheManager.Get(cacheKey, true, ctx => {
+                // this is the same signal used in Orchard.Framework.DefaultCultureManager
+                ctx.Monitor(_signals.When("culturesChanged"));
 
-            if (String.IsNullOrEmpty(currentCultureName)) {
-                return null;
-            }
-
-            return new CultureSelectorResult { Priority = -5, CultureName = currentCultureName };
+                string currentCultureName = _workContextAccessor.GetContext().CurrentSite.SiteCulture;
+                if (String.IsNullOrEmpty(currentCultureName)) {
+                    return null;
+                }
+                return new CultureSelectorResult { Priority = -5, CultureName = currentCultureName };
+            });
+            
         }
     }
 }


### PR DESCRIPTION
Fixes #8284

Tested locally Starting off Orchard 1.10.x as well as on our custom configuration.

The changes to `NavigationManager` improve performances on menu-heavy frontends, as well as a little bit on the backoffice (because they also cache some of the operations that are done for the admin menu there)

The other changes can really only be measured when serving cached content, as those operations are not that relevant compared to those required to generate frontend views. When serving stuff out of cache however those changes combined gave around 30% quicker responses on my a couple different test configurations.