### PR TITLE
Upgrade to net 461

### DIFF
--- a/src/Orchard.Azure.Tests/Orchard.Azure.Tests.csproj
+++ b/src/Orchard.Azure.Tests/Orchard.Azure.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Azure.Tests</RootNamespace>
     <AssemblyName>Orchard.Azure.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Core.Tests/Orchard.Core.Tests.csproj
+++ b/src/Orchard.Core.Tests/Orchard.Core.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Core.Tests</RootNamespace>
     <AssemblyName>Orchard.Core.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Profile/Orchard.Profile.csproj
+++ b/src/Orchard.Profile/Orchard.Profile.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Profile</RootNamespace>
     <AssemblyName>Orchard.Profile</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Specs/Orchard.Specs.csproj
+++ b/src/Orchard.Specs/Orchard.Specs.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Specs</RootNamespace>
     <AssemblyName>Orchard.Specs</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Tests.Modules/Orchard.Tests.Modules.csproj
+++ b/src/Orchard.Tests.Modules/Orchard.Tests.Modules.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Tests.Modules</RootNamespace>
     <AssemblyName>Orchard.Tests.Modules</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Tests/Orchard.Framework.Tests.csproj
+++ b/src/Orchard.Tests/Orchard.Framework.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Tests</RootNamespace>
     <AssemblyName>Orchard.Framework.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.WarmupStarter/Orchard.WarmupStarter.csproj
+++ b/src/Orchard.WarmupStarter/Orchard.WarmupStarter.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.WarmupStarter</RootNamespace>
     <AssemblyName>Orchard.WarmupStarter</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Orchard.Web.Tests/Orchard.Web.Tests.csproj
+++ b/src/Orchard.Web.Tests/Orchard.Web.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Web.Tests</RootNamespace>
     <AssemblyName>Orchard.Web.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Core/Orchard.Core.csproj
+++ b/src/Orchard.Web/Core/Orchard.Core.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Core</RootNamespace>
     <AssemblyName>Orchard.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Lucene/Lucene.csproj
+++ b/src/Orchard.Web/Modules/Lucene/Lucene.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Lucene</RootNamespace>
     <AssemblyName>Lucene</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Markdown/Markdown.csproj
+++ b/src/Orchard.Web/Modules/Markdown/Markdown.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Markdown</RootNamespace>
     <AssemblyName>Markdown</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Alias/Orchard.Alias.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Alias/Orchard.Alias.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Alias</RootNamespace>
     <AssemblyName>Orchard.Alias</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.AntiSpam/Orchard.AntiSpam.csproj
+++ b/src/Orchard.Web/Modules/Orchard.AntiSpam/Orchard.AntiSpam.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.AntiSpam</RootNamespace>
     <AssemblyName>Orchard.AntiSpam</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.ArchiveLater/Orchard.ArchiveLater.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ArchiveLater/Orchard.ArchiveLater.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.ArchiveLater</RootNamespace>
     <AssemblyName>Orchard.ArchiveLater</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Orchard.AuditTrail.csproj
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Orchard.AuditTrail.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.AuditTrail</RootNamespace>
     <AssemblyName>Orchard.AuditTrail</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Orchard.Autoroute.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Orchard.Autoroute.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Autoroute</RootNamespace>
     <AssemblyName>Orchard.Autoroute</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Orchard.Azure.MediaServices.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Orchard.Azure.MediaServices.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Azure.MediaServices</RootNamespace>
     <AssemblyName>Orchard.Azure.MediaServices</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Tests/Microsoft.CloudMedia.Tests/Microsoft.CloudMedia.Tests.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Tests/Microsoft.CloudMedia.Tests/Microsoft.CloudMedia.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.CloudMedia.Tests</RootNamespace>
     <AssemblyName>Microsoft.CloudMedia.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Azure/Orchard.Azure.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Azure/Orchard.Azure.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Azure</RootNamespace>
     <AssemblyName>Orchard.Azure</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Orchard.Blogs.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Orchard.Blogs.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Blogs</RootNamespace>
     <AssemblyName>Orchard.Blogs</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Caching/Orchard.Caching.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Caching/Orchard.Caching.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Caching</RootNamespace>
     <AssemblyName>Orchard.Caching</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.CodeGeneration/Orchard.CodeGeneration.csproj
+++ b/src/Orchard.Web/Modules/Orchard.CodeGeneration/Orchard.CodeGeneration.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.CodeGeneration</RootNamespace>
     <AssemblyName>Orchard.CodeGeneration</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Comments/Orchard.Comments.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Orchard.Comments.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Comments</RootNamespace>
     <AssemblyName>Orchard.Comments</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Conditions/Orchard.Conditions.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Conditions/Orchard.Conditions.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Conditions</RootNamespace>
     <AssemblyName>Orchard.Conditions</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.ContentPermissions/Orchard.ContentPermissions.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ContentPermissions/Orchard.ContentPermissions.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.ContentPermissions</RootNamespace>
     <AssemblyName>Orchard.ContentPermissions</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.ContentPicker</RootNamespace>
     <AssemblyName>Orchard.ContentPicker</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.ContentPreview/Orchard.ContentPreview.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ContentPreview/Orchard.ContentPreview.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.ContentPreview</RootNamespace>
     <AssemblyName>Orchard.ContentPreview</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Orchard.ContentTypes.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Orchard.ContentTypes.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.ContentTypes</RootNamespace>
     <AssemblyName>Orchard.ContentTypes</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Orchard.CustomForms.csproj
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Orchard.CustomForms.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.CustomForms</RootNamespace>
     <AssemblyName>Orchard.CustomForms</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Dashboards/Orchard.Dashboards.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Dashboards/Orchard.Dashboards.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Dashboards</RootNamespace>
     <AssemblyName>Orchard.Dashboards</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.DesignerTools/Orchard.DesignerTools.csproj
+++ b/src/Orchard.Web/Modules/Orchard.DesignerTools/Orchard.DesignerTools.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.DesignerTools</RootNamespace>
     <AssemblyName>Orchard.DesignerTools</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Orchard.DynamicForms.csproj
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Orchard.DynamicForms.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.DynamicForms</RootNamespace>
     <AssemblyName>Orchard.DynamicForms</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Email/Orchard.Email.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Email/Orchard.Email.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Email</RootNamespace>
     <AssemblyName>Orchard.Email</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Fields/Orchard.Fields.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Orchard.Fields.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Fields</RootNamespace>
     <AssemblyName>Orchard.Fields</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Forms/Orchard.Forms.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Forms/Orchard.Forms.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Forms</RootNamespace>
     <AssemblyName>Orchard.Forms</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Glimpse/Orchard.Glimpse.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Glimpse/Orchard.Glimpse.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Glimpse</RootNamespace>
     <AssemblyName>Orchard.Glimpse</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.ImageEditor/Orchard.ImageEditor.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ImageEditor/Orchard.ImageEditor.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.ImageEditor</RootNamespace>
     <AssemblyName>Orchard.ImageEditor</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Orchard.ImportExport.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Orchard.ImportExport.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.ImportExport</RootNamespace>
     <AssemblyName>Orchard.ImportExport</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Indexing/Orchard.Indexing.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Indexing/Orchard.Indexing.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Indexing</RootNamespace>
     <AssemblyName>Orchard.Indexing</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/src/Orchard.Web/Modules/Orchard.JobsQueue/Orchard.JobsQueue.csproj
+++ b/src/Orchard.Web/Modules/Orchard.JobsQueue/Orchard.JobsQueue.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.JobsQueue</RootNamespace>
     <AssemblyName>Orchard.JobsQueue</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/src/Orchard.Web/Modules/Orchard.JobsQueue/Tests/Orchard.Messaging.Tests.csproj
+++ b/src/Orchard.Web/Modules/Orchard.JobsQueue/Tests/Orchard.Messaging.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Messaging.Tests</RootNamespace>
     <AssemblyName>Orchard.Messaging.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Orchard.Layouts.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Orchard.Layouts.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Layouts</RootNamespace>
     <AssemblyName>Orchard.Layouts</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Lists/Orchard.Lists.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Lists/Orchard.Lists.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Lists</RootNamespace>
     <AssemblyName>Orchard.Lists</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Localization/Orchard.Localization.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Orchard.Localization.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Localization</RootNamespace>
     <AssemblyName>Orchard.Localization</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Media/Orchard.Media.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Media/Orchard.Media.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Media</RootNamespace>
     <AssemblyName>Orchard.Media</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary.WebSearch/Orchard.MediaLibrary.WebSearch.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary.WebSearch/Orchard.MediaLibrary.WebSearch.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.MediaLibrary.WebSearch</RootNamespace>
     <AssemblyName>Orchard.MediaLibrary.WebSearch</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.MediaLibrary</RootNamespace>
     <AssemblyName>Orchard.MediaLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.MediaPicker/Orchard.MediaPicker.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaPicker/Orchard.MediaPicker.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.MediaPicker</RootNamespace>
     <AssemblyName>Orchard.MediaPicker</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Orchard.MediaProcessing.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Orchard.MediaProcessing.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.MediaProcessing</RootNamespace>
     <AssemblyName>Orchard.MediaProcessing</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.MessageBus/Orchard.MessageBus.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MessageBus/Orchard.MessageBus.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.MessageBus</RootNamespace>
     <AssemblyName>Orchard.MessageBus</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Migrations/Orchard.Migrations.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Migrations/Orchard.Migrations.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Migrations</RootNamespace>
     <AssemblyName>Orchard.Migrations</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Modules/Orchard.Modules.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Modules/Orchard.Modules.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Modules</RootNamespace>
     <AssemblyName>Orchard.Modules</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.MultiTenancy/Orchard.MultiTenancy.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MultiTenancy/Orchard.MultiTenancy.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.MultiTenancy</RootNamespace>
     <AssemblyName>Orchard.MultiTenancy</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.OpenId/Orchard.OpenId.csproj
+++ b/src/Orchard.Web/Modules/Orchard.OpenId/Orchard.OpenId.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.OpenId</RootNamespace>
     <AssemblyName>Orchard.OpenId</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Orchard.OutputCache.csproj
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Orchard.OutputCache.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.OutputCache</RootNamespace>
     <AssemblyName>Orchard.OutputCache</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Packaging/Orchard.Packaging.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Packaging/Orchard.Packaging.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Packaging</RootNamespace>
     <AssemblyName>Orchard.Packaging</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Pages/Orchard.Pages.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Pages/Orchard.Pages.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Pages</RootNamespace>
     <AssemblyName>Orchard.Pages</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Projections</RootNamespace>
     <AssemblyName>Orchard.Projections</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Projections/Tests/Orchard.Projections.Tests.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Tests/Orchard.Projections.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Projections.Tests</RootNamespace>
     <AssemblyName>Orchard.Projections.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Orchard.Web/Modules/Orchard.PublishLater/Orchard.PublishLater.csproj
+++ b/src/Orchard.Web/Modules/Orchard.PublishLater/Orchard.PublishLater.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.PublishLater</RootNamespace>
     <AssemblyName>Orchard.PublishLater</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Recipes/Orchard.Recipes.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Orchard.Recipes.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Recipes</RootNamespace>
     <AssemblyName>Orchard.Recipes</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Redis/Orchard.Redis.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Redis/Orchard.Redis.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Redis</RootNamespace>
     <AssemblyName>Orchard.Redis</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Resources/Orchard.Resources.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Resources/Orchard.Resources.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Resources</RootNamespace>
     <AssemblyName>Orchard.Resources</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Roles/Orchard.Roles.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Orchard.Roles.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Roles</RootNamespace>
     <AssemblyName>Orchard.Roles</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Rules/Orchard.Rules.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Rules/Orchard.Rules.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Rules</RootNamespace>
     <AssemblyName>Orchard.Rules</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Scripting.CSharp/Orchard.Scripting.CSharp.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Scripting.CSharp/Orchard.Scripting.CSharp.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Scripting.CSharp</RootNamespace>
     <AssemblyName>Orchard.Scripting.CSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Scripting.Dlr/Orchard.Scripting.Dlr.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Scripting.Dlr/Orchard.Scripting.Dlr.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Scripting.Dlr</RootNamespace>
     <AssemblyName>Orchard.Scripting.Dlr</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Scripting/Orchard.Scripting.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Scripting/Orchard.Scripting.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Scripting</RootNamespace>
     <AssemblyName>Orchard.Scripting</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Search/Orchard.Search.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Search/Orchard.Search.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Search</RootNamespace>
     <AssemblyName>Orchard.Search</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Orchard.SecureSocketsLayer.csproj
+++ b/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Orchard.SecureSocketsLayer.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.SecureSocketsLayer</RootNamespace>
     <AssemblyName>Orchard.SecureSocketsLayer</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Setup/Orchard.Setup.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Setup/Orchard.Setup.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Setup</RootNamespace>
     <AssemblyName>Orchard.Setup</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Tags/Orchard.Tags.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Tags/Orchard.Tags.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Tags</RootNamespace>
     <AssemblyName>Orchard.Tags</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.TaskLease/Orchard.TaskLease.csproj
+++ b/src/Orchard.Web/Modules/Orchard.TaskLease/Orchard.TaskLease.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.TaskLease</RootNamespace>
     <AssemblyName>Orchard.TaskLease</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.TaskLease/Tests/Orchard.TaskLease.Tests/Orchard.TaskLease.Tests.csproj
+++ b/src/Orchard.Web/Modules/Orchard.TaskLease/Tests/Orchard.TaskLease.Tests/Orchard.TaskLease.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.TaskLease.Tests</RootNamespace>
     <AssemblyName>Orchard.TaskLease.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Orchard.Taxonomies.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Orchard.Taxonomies.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Taxonomies</RootNamespace>
     <AssemblyName>Orchard.Taxonomies</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Templates/Orchard.Templates.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Templates/Orchard.Templates.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Templates</RootNamespace>
     <AssemblyName>Orchard.Templates</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Themes/Orchard.Themes.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Themes/Orchard.Themes.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Themes</RootNamespace>
     <AssemblyName>Orchard.Themes</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Tokens/Orchard.Tokens.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Tokens/Orchard.Tokens.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Tokens</RootNamespace>
     <AssemblyName>Orchard.Tokens</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Tokens/Tests/Orchard.Tokens.Tests.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Tokens/Tests/Orchard.Tokens.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Tokens.Tests</RootNamespace>
     <AssemblyName>Orchard.Tokens.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Orchard.Web/Modules/Orchard.Users/Orchard.Users.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Users/Orchard.Users.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Users</RootNamespace>
     <AssemblyName>Orchard.Users</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Warmup/Orchard.Warmup.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Warmup/Orchard.Warmup.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Warmup</RootNamespace>
     <AssemblyName>Orchard.Warmup</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Orchard.Widgets.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Widgets</RootNamespace>
     <AssemblyName>Orchard.Widgets</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.Workflows/Orchard.Workflows.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Orchard.Workflows.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Workflows</RootNamespace>
     <AssemblyName>Orchard.Workflows</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Orchard.jQuery/Orchard.jQuery.csproj
+++ b/src/Orchard.Web/Modules/Orchard.jQuery/Orchard.jQuery.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.jQuery</RootNamespace>
     <AssemblyName>Orchard.jQuery</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/SysCache/SysCache.csproj
+++ b/src/Orchard.Web/Modules/SysCache/SysCache.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SysCache</RootNamespace>
     <AssemblyName>SysCache</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/TinyMce/TinyMce.csproj
+++ b/src/Orchard.Web/Modules/TinyMce/TinyMce.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TinyMce</RootNamespace>
     <AssemblyName>TinyMce</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
+++ b/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Upgrade</RootNamespace>
     <AssemblyName>Upgrade</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard.Web/Orchard.Web.csproj
+++ b/src/Orchard.Web/Orchard.Web.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Web</RootNamespace>
     <AssemblyName>Orchard.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort>44300</IISExpressSSLPort>

--- a/src/Orchard.Web/Themes/Themes.csproj
+++ b/src/Orchard.Web/Themes/Themes.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Themes</RootNamespace>
     <AssemblyName>Themes</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard</RootNamespace>
     <AssemblyName>Orchard.Framework</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Tools/MSBuild.Orchard.Tasks/MSBuild.Orchard.Tasks.csproj
+++ b/src/Tools/MSBuild.Orchard.Tasks/MSBuild.Orchard.Tasks.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MSBuild.Orchard.Tasks</RootNamespace>
     <AssemblyName>MSBuild.Orchard.Tasks</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Tools/Orchard.Tests/Orchard.Tests.csproj
+++ b/src/Tools/Orchard.Tests/Orchard.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard.Tests</RootNamespace>
     <AssemblyName>Orchard.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Tools/Orchard/Orchard.csproj
+++ b/src/Tools/Orchard/Orchard.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchard</RootNamespace>
     <AssemblyName>Orchard</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Tools/Set-TargetFramework.ps1
+++ b/src/Tools/Set-TargetFramework.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+    For settting the .NET framework version to all projects in the solution
+.PARAMETER TargetFrameworkVersion
+    .NET framework version that you want to target
+.EXAMPLE
+    .\Set-TargetFramework.ps1 -TargetFrameworkVersion v4.6.1
+#>
+
+param(
+    [Parameter(Mandatory = $true)] 
+    [ValidatePattern("^v\d\.\d(\.\d)?$")]
+    [string] $TargetFrameworkVersion
+)
+
+[Reflection.Assembly]::LoadWithPartialName("System.Xml.Linq") | Out-Null
+
+$projectFiles = Get-ChildItem -Path "../" -Filter "*.csproj" -Recurse
+$projectFiles | ForEach-Object {
+    $projectFilePath = $_.FullName
+
+    # Preserving Formatting with LINQ to XML 
+    # https://blogs.msdn.microsoft.com/charlie/2008/09/30/linq-farm-preserving-formatting-with-linq-to-xml/
+    $loadOptions = [System.Xml.Linq.LoadOptions]::PreserveWhitespace 
+    $xDoc = [System.Xml.Linq.XDocument]::Load($projectFilePath, $loadOptions)
+    $ns = [System.Xml.Linq.XNamespace]::Get("http://schemas.microsoft.com/developer/msbuild/2003")
+
+    $targetFramework = $xDoc.Descendants($ns + "TargetFrameworkVersion")
+    $targetFramework.SetValue($TargetFrameworkVersion)
+    $xDoc.Save($projectFilePath, [System.Xml.Linq.SaveOptions]::DisableFormatting)
+}
+


### PR DESCRIPTION
Upgrade all projects to .NET 4.6.1
Please refer to the original PR https://github.com/OrchardCMS/Orchard/pull/8126 that I have been closed because I can't pushed to it.

Main changes:
- Upgrade to .NET 4.6.1 which can be use with .NET Standard library 2.0
- For custom class library can target .NET standard that can be use in both .NET Core and .NET Framework.
- PowerShell script tool to upgrade the .NET framework to all projects

![image](https://user-images.githubusercontent.com/2938310/69910112-76ad1480-1438-11ea-9b99-1fa0fd8b4fde.png)

I know that we should update NuGet package to the latest version after we have upgraded .NET Framework version.
I have tried upgrade all NuGet package and there are many breaking changes.

These are some packages that I have tried to rollback to minimize coding chanages

- Nhibernate 4.0.1.4000
- Fluent Nhibernate 2.0.3.0
- Lesi.Collections4.0.1.4000 
- NUnit 2.5.10.11092
- Autofac 3.5.2
- Autofac.Configuration 3.3.0
- Castle.Core 3.3.1

However, there some other packages e.g. Azure library also need to be rollback, etc. to make all projects compile without any errors.

Therefore, I think we can leave packages.config have targeFramework="net452" for now.
Update many packages at once and causes many breaking change seem risky and need a lot of regression tests.

FYI, after this PR get merged. I am happy to help upgrade NHibernate to the later version.
Thanks.






