### PR TITLE
fixed a typo in MediaLibraryPickerFieldDriver

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
@@ -45,7 +45,7 @@ namespace Orchard.MediaLibrary.Drivers {
                         ContentItems = _contentManager.GetMany<ContentItem>(field.Ids, VersionOptions.Published, QueryHints.Empty).ToList(),
                     };
 
-                    model.SelectedIds = string.Concat(",", field.Ids);
+                    model.SelectedIds = string.Join(",", field.Ids);
 
                     return shapeHelper.EditorTemplate(TemplateName: "Fields/MediaLibraryPicker.Edit", Model: model, Prefix: GetPrefix(field, part));
                 });


### PR DESCRIPTION
In some cases, this typo generate an exception when parsing MediaLibraryPickerFieldViewModel.SelectedIds because it contains ",System.Int32[]" instead of a number such as "84".
See also line 55 of the same file where SelectedIds is correctly set.