### PR TITLE
removed useless separators in EnumerationField

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Fields/EnumerationField.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Fields/EnumerationField.cs
@@ -26,7 +26,7 @@ namespace Orchard.Fields.Fields {
                     Value = String.Empty;
                 }
                 else {
-                    Value = Separator + string.Join(Separator.ToString(), value) + Separator;
+                    Value = string.Join(Separator.ToString(), value);
                 }
             }
         }


### PR DESCRIPTION
Removed useless separators when SelectedValues sets Value property in EnumerationField because they can generate incorrect behaviour durion field edit.
Scenario: let us have an EnumerationField which is rendered by a drop-down list.
If you set the selected value of this field programmatically by means of SelectedValues property
to the value "MyValue", the Value property is set to ";MyValue;". 
When you edit this field, the drop-down list is not set to "MyValue" because it gets ";MyValue;" as the selected value and ";MyValue;" does not match any of the options in the drop-down list.
