### PR TITLE
correct bug Handler BlogArchive

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Blogs/Models/BlogPostPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Models/BlogPostPart.cs
@@ -49,5 +49,10 @@ namespace Orchard.Blogs.Models {
         public DateTime? PublishedUtc {
             get { return this.As<ICommonPart>().PublishedUtc; }
         }
+
+        public DateTime? ArchiveSync {
+            get { return this.Retrieve(x => x.ArchiveSync); }
+            set { this.Store(x => x.ArchiveSync, value); }
+        }
     }
 }


### PR DESCRIPTION
#8305 

For this reason I added a parameter to the blogpostpart infoset which keeps in memory the date of change of the state in order to always have the date of the change and the next one.

I ask you, in your opinion, it is worth adding a button that calls the "BuildArchive()" so that in case there were others unexpected recalculate the Orchard_Blogs_BlogPartArchiveRecord?