### PR TITLE
Remove ArchiveLaterTask if content item is deleted

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ArchiveLater/Handlers/ArchiveLaterPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.ArchiveLater/Handlers/ArchiveLaterPartHandler.cs
@@ -12,6 +12,7 @@ namespace Orchard.ArchiveLater.Handlers {
             OnLoading<ArchiveLaterPart>((context, part) => LazyLoadHandlers(part));
             OnVersioning<ArchiveLaterPart>((context, part, newVersionPart) => LazyLoadHandlers(newVersionPart));
             OnRemoved<ArchiveLaterPart>((context, part) => _archiveLaterService.RemoveArchiveLaterTasks(part.ContentItem));
+            OnDestroyed<ArchiveLaterPart>((context, part) => _archiveLaterService.RemoveArchiveLaterTasks(part.ContentItem));
         }
 
         protected void LazyLoadHandlers(ArchiveLaterPart part) {

--- a/src/Orchard.Web/Modules/Orchard.ArchiveLater/Handlers/ArchiveLaterPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.ArchiveLater/Handlers/ArchiveLaterPartHandler.cs
@@ -11,6 +11,7 @@ namespace Orchard.ArchiveLater.Handlers {
 
             OnLoading<ArchiveLaterPart>((context, part) => LazyLoadHandlers(part));
             OnVersioning<ArchiveLaterPart>((context, part, newVersionPart) => LazyLoadHandlers(newVersionPart));
+            OnRemoved<ArchiveLaterPart>((context, part) => _archiveLaterService.RemoveArchiveLaterTasks(part.ContentItem));
         }
 
         protected void LazyLoadHandlers(ArchiveLaterPart part) {


### PR DESCRIPTION
Replication Steps:
- Enable Archive Later module
- Add Archive later part to a content definiton (e.g Page)
- Create a new content (e.g Page) and set a archive later date
- Examine the [dbo].[Scheduling_ScheduledTaskRecord] table and observe that task is there.
- Delete the created content
- Examine the [dbo].[Scheduling_ScheduledTaskRecord] table and observe that task is still there.

By not removing the task when the content is deleted, when the task runs an exception is thrown inside `UnpublishingTaskHandler Process()` and the task will persist in the database causing an endless cycle of errors.

Noticed that this is already being done for the PublishLaterPart: https://github.com/OrchardCMS/Orchard/blob/1.10.x/src/Orchard.Web/Modules/Orchard.PublishLater/Handlers/PublishLaterPartHandler.cs#L17