### PR TITLE
Tweak TermsPartHandler to skip unpublished terms

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TermsPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TermsPartHandler.cs
@@ -79,8 +79,9 @@ namespace Orchard.Taxonomies.Handlers {
                 var ids = part.Terms.Select(t => t.TermRecord.Id).Distinct();
                 var terms = _contentManager.GetMany<TermPart>(ids, VersionOptions.Published, queryHint)
                     .ToDictionary(t => t.Id, t => t);
+                var publishedTermIds = terms.Select(t => t.Key);
                 return
-                    part.Terms.Select(
+                    part.Terms.Where(t => publishedTermIds.Contains(t.TermRecord.Id)).Select(
                         x =>
                             new TermContentItemPart {
                                 Field = x.Field,


### PR DESCRIPTION
When a term gets unpublished, rather than deleted, TermsPartHandler will spit out a  "given key was not present in the dictionary" error any time a linked content item requests its terms. Terms can be unpublished when their content type is listable.