### PR TITLE
Remove newly added terms before processing

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -281,7 +281,7 @@ namespace Orchard.Taxonomies.Services {
             // adding new terms list
             foreach (var term in terms) {
                 // Remove the newly added terms because they will get processed by the Published-Event
-                termList.RemoveAll(t => t.Term.Id == term.Id);
+                termList.RemoveAll(t => t.Term.TermRecord.Id == term.Id);
                 termsPart.Terms.Add(
                     new TermContentItem {
                         TermsPartRecord = termsPart.Record,


### PR DESCRIPTION
`// Remove the newly added terms because they will get processed by the Published-Event
                termList.RemoveAll(t => t.Term.Id == term.Id);`

This code on line 284 of the TaxonomyService claims to remove newly added terms, because they will be processed by their own published event anyway. I don't think it's currently doing that however, since it's comparing the id of the TermPart to the id of the TermContentItem record. This is unlikely to cause any issues besides some overhead, but there is a theoretical edge case where a TermContentItem could have the same id as an existing term, causing that term not to update.

I believe this is what was intended:
`termList.RemoveAll(t => t.Term.TermRecord.Id == term.Id);`