### PR TITLE
Fixes #8322 - Normalize behavior in the Orchard.Taxonomies Admin Views

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/Admin/Index.cshtml
@@ -53,6 +53,7 @@
                     </td>
                     <td>
                         @if (!taxonomyEntry.IsInternal) {
+                            @Html.ItemDisplayLink(T("View").Text, taxonomyEntry.ContentItem) <text>|</text>
                             if (Authorizer.Authorize(Permissions.CreateTaxonomy)) {
                                 @Html.ItemEditLink(T("Edit").Text, taxonomyEntry.ContentItem, new { ReturnUrl = Request.RawUrl }) <text>|</text>
                             }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/TermAdmin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/TermAdmin/Index.cshtml
@@ -41,11 +41,17 @@
                 <tr>
                     <td>
                         <input type="hidden" value="@Model.Terms[termIndex].Id" name="@Html.NameOf(m => m.Terms[ti].Id)" />
-                        @* Tabs for levels *@ @for (var i = 1; i <= termEntry.GetLevels(); i++) { <span class="gap">&nbsp;</span> }
+                        @* Tabs for levels *@ @for (var i = 1; i <= termEntry.GetLevels(); i++) {<span class="gap">&nbsp;</span>}
                         <input type="checkbox" value="true" name="@Html.NameOf(m => m.Terms[ti].IsChecked)" />
-                        @Html.ItemDisplayLink(termEntry.Name, termEntry.ContentItem)
+                        @if (Authorizer.Authorize(Permissions.EditTerm)) {
+                            @Html.ItemEditLink(termEntry.Name, termEntry.ContentItem, new { returnUrl = Url.Action("Index", "TermAdmin", new { taxonomyId = Model.Taxonomy.Id }) })
+                        }
+                        else {
+                            @Html.ItemDisplayText(termEntry.ContentItem)
+                        }
                     </td>
                     <td>
+                        @Html.ItemDisplayLink(T("View").Text, termEntry.ContentItem) <text>|</text>
                         @if (Authorizer.Authorize(Permissions.EditTerm)) {
                             @Html.ItemEditLink(T("Edit").Text, termEntry.ContentItem, new { returnUrl = Url.Action("Index", "TermAdmin", new { taxonomyId = Model.Taxonomy.Id }) }) <text>|</text>
                             @Html.ActionLink(T("Move").ToString(), "MoveTerm", new { taxonomyId = Model.Taxonomy.Id, termIds = termEntry.Id })


### PR DESCRIPTION
- Adds a link "View" in "Admin/Index.cshtml" to see how it looks the Taxonomony on the front-end
- To click on the name of the term gives now access to its modification as it happens in all the other lists of the admin
- Adds a link "View" in "TermAdmin/Index.cshtml" to see how it looks the Term on the front-end