### PR TITLE
Issue #8318: Managing multiple scopes in localization concurrent dictionary.

### DIFF
--- a/src/Orchard.Tests/Localization/TextTests.cs
+++ b/src/Orchard.Tests/Localization/TextTests.cs
@@ -5,6 +5,7 @@ using Orchard.Localization;
 using Orchard.Localization.Services;
 using Orchard.Mvc;
 using Orchard.Tests.Stubs;
+using System.Collections.Generic;
 using System.Web;
 
 namespace Orchard.Tests.Localization {
@@ -17,8 +18,8 @@ namespace Orchard.Tests.Localization {
         public void Init() {
             var mockLocalizedManager = new Mock<ILocalizedStringManager>();
             mockLocalizedManager
-                .Setup(x => x.GetLocalizedString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns("foo {0}");
+                .Setup(x => x.GetLocalizedString(new List<string> { It.IsAny<string>() }, It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(new System.Tuple<string, string>("foo {0}", null));
 
             var builder = new ContainerBuilder();
             builder.RegisterInstance(new StubCultureSelector("fr-CA")).As<ICultureSelector>();

--- a/src/Orchard.Tests/Localization/TextTests.cs
+++ b/src/Orchard.Tests/Localization/TextTests.cs
@@ -19,7 +19,7 @@ namespace Orchard.Tests.Localization {
             var mockLocalizedManager = new Mock<ILocalizedStringManager>();
             mockLocalizedManager
                 .Setup(x => x.GetLocalizedString(new List<string> { It.IsAny<string>() }, It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new System.Tuple<string, string>("foo {0}", null));
+                .Returns(new FormatForScope("foo {0}", null));
 
             var builder = new ContainerBuilder();
             builder.RegisterInstance(new StubCultureSelector("fr-CA")).As<ICultureSelector>();

--- a/src/Orchard/Localization/FormatForScope.cs
+++ b/src/Orchard/Localization/FormatForScope.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orchard.Localization {
+    public class FormatForScope {
+        public FormatForScope(string format, string scope) {
+            Scope = scope;
+            Format = format;
+        }
+        public string Scope { get; set; }
+        public string Format { get; set; }
+    }
+}

--- a/src/Orchard/Localization/LocalizationModule.cs
+++ b/src/Orchard/Localization/LocalizationModule.cs
@@ -25,6 +25,7 @@ namespace Orchard.Localization {
             if (userProperty != null) {
                 List<string> scopes = new List<string>();
                 var type = registration.Activator.LimitType;
+                // we don't need this behavior on CLR types, so that's an optimization
                 while (!type.Namespace.Equals("System")) {
                     scopes.Add(type.FullName);
                     type = type.BaseType;

--- a/src/Orchard/Localization/LocalizationModule.cs
+++ b/src/Orchard/Localization/LocalizationModule.cs
@@ -9,7 +9,7 @@ using Module = Autofac.Module;
 
 namespace Orchard.Localization {
     public class LocalizationModule : Module {
-        private readonly ConcurrentDictionary<string, Localizer> _localizerCache;//TODO IEnumerable
+        private readonly ConcurrentDictionary<string, Localizer> _localizerCache;
 
         public LocalizationModule() {
             _localizerCache = new ConcurrentDictionary<string, Localizer>();

--- a/src/Orchard/Localization/LocalizationModule.cs
+++ b/src/Orchard/Localization/LocalizationModule.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Autofac;
 using Autofac.Core;
@@ -7,7 +9,7 @@ using Module = Autofac.Module;
 
 namespace Orchard.Localization {
     public class LocalizationModule : Module {
-        private readonly ConcurrentDictionary<string, Localizer> _localizerCache;
+        private readonly ConcurrentDictionary<string, Localizer> _localizerCache;//TODO IEnumerable
 
         public LocalizationModule() {
             _localizerCache = new ConcurrentDictionary<string, Localizer>();
@@ -20,18 +22,23 @@ namespace Orchard.Localization {
         protected override void AttachToComponentRegistration(IComponentRegistry componentRegistry, IComponentRegistration registration) {
 
             var userProperty = FindUserProperty(registration.Activator.LimitType);
-
             if (userProperty != null) {
-                var scope = registration.Activator.LimitType.FullName;
+                List<string> scopes = new List<string>();
+                var type = registration.Activator.LimitType;
+                while (!type.Namespace.Equals("System")) {
+                    scopes.Add(type.FullName);
+                    type = type.BaseType;
+                }
 
-                registration.Activated += (sender, e) => {
-                    if (e.Instance.GetType().FullName != scope) {
-                        return;
-                    }
-
-                    var localizer = _localizerCache.GetOrAdd(scope, key => LocalizationUtilities.Resolve(e.Context, scope));
-                    userProperty.SetValue(e.Instance, localizer, null);
-                };
+                foreach(var scope in scopes) {
+                    registration.Activated += (sender, e) => {
+                        if (e.Instance.GetType().FullName != scope) {
+                            return;
+                        }
+                        var localizer = _localizerCache.GetOrAdd(scope, key => LocalizationUtilities.Resolve(e.Context, scopes));
+                        userProperty.SetValue(e.Instance, localizer, null);
+                    };
+                }
             }
         }
 

--- a/src/Orchard/Localization/LocalizationUtilities.cs
+++ b/src/Orchard/Localization/LocalizationUtilities.cs
@@ -1,19 +1,25 @@
-﻿using System.Web.Mvc;
+﻿using System.Collections.Generic;
+using System.Web.Mvc;
 using Autofac;
 
 namespace Orchard.Localization {
     public class LocalizationUtilities {
         public static Localizer Resolve(WorkContext workContext, string scope) {
-            return workContext == null ? NullLocalizer.Instance : Resolve(workContext.Resolve<ILifetimeScope>(), scope);
+            return workContext == null ? NullLocalizer.Instance : Resolve(workContext.Resolve<ILifetimeScope>(), new List<string> { scope });
         }
 
         public static Localizer Resolve(ControllerContext controllerContext, string scope) {
             var workContext = controllerContext.GetWorkContext();
-            return Resolve(workContext, scope);
+            return Resolve(workContext,  scope );
         }
 
         public static Localizer Resolve(IComponentContext context, string scope) {
-            var text = context.Resolve<IText>(new NamedParameter("scope", scope));
+            var text = context.Resolve<IText>(new NamedParameter("scope", new List<string> { scope }));
+            return text.Get;
+        }
+
+        public static Localizer Resolve(IComponentContext context, IEnumerable<string> scopes) {
+            var text = context.Resolve<IText>(new NamedParameter("scopes", scopes));
             return text.Get;
         }
     }

--- a/src/Orchard/Localization/Services/DefaultLocalizedStringManager.cs
+++ b/src/Orchard/Localization/Services/DefaultLocalizedStringManager.cs
@@ -49,26 +49,26 @@ namespace Orchard.Localization.Services {
         ILogger Logger { get; set; }
         public bool DisableMonitoring { get; set; }
 
-        public Tuple<string, string> GetLocalizedString(IEnumerable<string> scopes, string text, string cultureName) {
+        public FormatForScope GetLocalizedString(IEnumerable<string> scopes, string text, string cultureName) {
             var culture = LoadCulture(cultureName);
             foreach (var scope in scopes) {
                 string scopedKey = (scope + "|" + text).ToLowerInvariant();
                 if (culture.Translations.ContainsKey(scopedKey)) {
-                    return new Tuple<string, string>(culture.Translations[scopedKey], scope);
+                    return new FormatForScope(culture.Translations[scopedKey], scope);
                 }
             }
             string genericKey = ("|" + text).ToLowerInvariant();
             if (culture.Translations.ContainsKey(genericKey)) {
-                return new Tuple<string, string>(culture.Translations[genericKey], null);
+                return new FormatForScope(culture.Translations[genericKey], null);
             }
 
             foreach (var scope in scopes) {
                 string parent_text = GetParentTranslation(scope, text, cultureName);
                 if (!parent_text.Equals(text)) {
-                    return new Tuple<string, string>(parent_text, scope);
+                    return new FormatForScope(parent_text, scope);
                 }
             }
-            return new Tuple<string, string>(text, scopes.FirstOrDefault());
+            return new FormatForScope(text, scopes.FirstOrDefault());
         }
 
         // This will translate a string into a string in the target cultureName.

--- a/src/Orchard/Localization/Services/ILocalizedStringManager.cs
+++ b/src/Orchard/Localization/Services/ILocalizedStringManager.cs
@@ -1,5 +1,9 @@
-﻿namespace Orchard.Localization.Services {
+﻿using System.Collections.Generic;
+
+
+namespace Orchard.Localization.Services {
     public interface ILocalizedStringManager : IDependency {
-        string GetLocalizedString(string scope, string text, string cultureName);
+        //string GetLocalizedString(string scope, string text, string cultureName);
+        System.Tuple<string, string> GetLocalizedString(IEnumerable<string> scopes, string text, string cultureName);
     }
 }

--- a/src/Orchard/Localization/Services/ILocalizedStringManager.cs
+++ b/src/Orchard/Localization/Services/ILocalizedStringManager.cs
@@ -3,7 +3,6 @@
 
 namespace Orchard.Localization.Services {
     public interface ILocalizedStringManager : IDependency {
-        //string GetLocalizedString(string scope, string text, string cultureName);
-        System.Tuple<string, string> GetLocalizedString(IEnumerable<string> scopes, string text, string cultureName);
+        FormatForScope GetLocalizedString(IEnumerable<string> scopes, string text, string cultureName);
     }
 }

--- a/src/Orchard/Localization/Text.cs
+++ b/src/Orchard/Localization/Text.cs
@@ -12,13 +12,6 @@ namespace Orchard.Localization {
         private readonly IWorkContextAccessor _workContextAccessor;
         private readonly ILocalizedStringManager _localizedStringManager;
 
-        //public Text(string scope, IWorkContextAccessor workContextAccessor, ILocalizedStringManager localizedStringManager) {
-        //    _scope = scope;
-        //    _workContextAccessor = workContextAccessor;
-        //    _localizedStringManager = localizedStringManager;
-        //    Logger = NullLogger.Instance;
-        //}
-
         public Text(IEnumerable<string> scopes, IWorkContextAccessor workContextAccessor, ILocalizedStringManager localizedStringManager) {
             _scopes = scopes;
             _workContextAccessor = workContextAccessor;

--- a/src/Orchard/Localization/Text.cs
+++ b/src/Orchard/Localization/Text.cs
@@ -4,43 +4,53 @@ using Orchard.Localization.Services;
 using Orchard.Logging;
 using System.Web;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Orchard.Localization {
     public class Text : IText {
-        private readonly string _scope;
+        private readonly IEnumerable<string> _scopes;
         private readonly IWorkContextAccessor _workContextAccessor;
         private readonly ILocalizedStringManager _localizedStringManager;
 
-        public Text(string scope, IWorkContextAccessor workContextAccessor, ILocalizedStringManager localizedStringManager) {
-            _scope = scope;
+        //public Text(string scope, IWorkContextAccessor workContextAccessor, ILocalizedStringManager localizedStringManager) {
+        //    _scope = scope;
+        //    _workContextAccessor = workContextAccessor;
+        //    _localizedStringManager = localizedStringManager;
+        //    Logger = NullLogger.Instance;
+        //}
+
+        public Text(IEnumerable<string> scopes, IWorkContextAccessor workContextAccessor, ILocalizedStringManager localizedStringManager) {
+            _scopes = scopes;
             _workContextAccessor = workContextAccessor;
             _localizedStringManager = localizedStringManager;
             Logger = NullLogger.Instance;
         }
 
+
         public ILogger Logger { get; set; }
 
         public LocalizedString Get(string textHint, params object[] args) {
-            Logger.Debug("{0} localizing '{1}'", _scope, textHint);
-
+            Logger.Debug("{0} localizing '{1}'", _scopes.FirstOrDefault(), textHint);
+            string scope = null;
             var workContext = _workContextAccessor.GetContext();
-            
+
             if (workContext != null) {
                 var currentCulture = workContext.CurrentCulture;
-                var localizedFormat = _localizedStringManager.GetLocalizedString(_scope, textHint, currentCulture);
-
+                string localizedFormat;
+                Tuple<string,string> localizedFormatScope = _localizedStringManager.GetLocalizedString(_scopes, textHint, currentCulture);
+                scope = localizedFormatScope.Item2;
                 // localization arguments are HTML-encoded unless they implement IHtmlString
 
                 return args.Length == 0
-                ? new LocalizedString(localizedFormat, _scope, textHint, args)
+                ? new LocalizedString(localizedFormatScope.Item1, scope, textHint, args)
 				: new LocalizedString(
-                    String.Format(GetFormatProvider(currentCulture), localizedFormat, args.Select(Encode).ToArray()), 
-                    _scope, 
+                    String.Format(GetFormatProvider(currentCulture), localizedFormatScope.Item1, args.Select(Encode).ToArray()),
+                    scope, 
                     textHint, 
                     args);
             }
 
-            return new LocalizedString(textHint, _scope, textHint, args);
+            return new LocalizedString(textHint, scope, textHint, args);
         }
 
         private static IFormatProvider GetFormatProvider(string currentCulture) {

--- a/src/Orchard/Localization/Text.cs
+++ b/src/Orchard/Localization/Text.cs
@@ -29,15 +29,14 @@ namespace Orchard.Localization {
 
             if (workContext != null) {
                 var currentCulture = workContext.CurrentCulture;
-                string localizedFormat;
-                Tuple<string,string> localizedFormatScope = _localizedStringManager.GetLocalizedString(_scopes, textHint, currentCulture);
-                scope = localizedFormatScope.Item2;
+                FormatForScope localizedFormatScope = _localizedStringManager.GetLocalizedString(_scopes, textHint, currentCulture);
+                scope = localizedFormatScope.Scope;
                 // localization arguments are HTML-encoded unless they implement IHtmlString
 
                 return args.Length == 0
-                ? new LocalizedString(localizedFormatScope.Item1, scope, textHint, args)
+                ? new LocalizedString(localizedFormatScope.Format, scope, textHint, args)
 				: new LocalizedString(
-                    String.Format(GetFormatProvider(currentCulture), localizedFormatScope.Item1, args.Select(Encode).ToArray()),
+                    String.Format(GetFormatProvider(currentCulture), localizedFormatScope.Format, args.Select(Encode).ToArray()),
                     scope, 
                     textHint, 
                     args);

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Data\Migration\Schema\DropUniqueConstraintCommand.cs" />
     <Compile Include="Environment\Extensions\Models\LifecycleStatus.cs" />
     <Compile Include="Environment\ShellBuilders\ICompositionStrategy.cs" />
+    <Compile Include="Localization\FormatForScope.cs" />
     <Compile Include="Locking\ILockingProvider.cs" />
     <Compile Include="Locking\LockingProvider.cs" />
     <Compile Include="Mvc\Updater.cs" />


### PR DESCRIPTION
Issue #8318:
Managing multiple scopes in localization concurrent dictionary. Target dev beacause i changed the signature:
ILocalizedStringManager
System.Tuple<string, string> GetLocalizedString(IEnumerable scopes, string text, string cultureName);
(rebased branch on dev)