### PR TITLE
CustomForms throws an error when used within a Widget

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Views/EditorTemplates/Parts.CustomForm.Fields.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Views/EditorTemplates/Parts.CustomForm.Fields.cshtml
@@ -25,10 +25,11 @@
     <label for="@Html.FieldIdFor(m => m.CustomFormPart.SaveContentItem)" class="forcheckbox">@T("Save the content item once the form is submitted")</label>
     <span class="hint">@T("Check if you want to save the content item associated to the form. Leave empty if you just want to trigger an action on the event.")</span>
 </fieldset>
-<fieldset>
+<fieldset data-controllerid="@Html.FieldIdFor(m => m.CustomFormPart.SaveContentItem)">
+    <h3>@T("For versionable contents ONLY")</h3>
     @Html.EditorFor(m => m.CustomFormPart.SavePublishContentItem)
-    <label for="@Html.FieldIdFor(m => m.CustomFormPart.SavePublishContentItem)" class="forcheckbox">@T("Save and publish the content item once the form is submitted")</label>
-    <span class="hint">@T("Check if you want to save the content item associated to the form. Leave empty if you just want to trigger an action on the event.")</span>
+    <label for="@Html.FieldIdFor(m => m.CustomFormPart.SavePublishContentItem)" class="forcheckbox">@T("Publish the content item once it has been saved")</label>
+    <span class="hint">@T("Check if you want to also publish the content. Leave empty if you just want to save the content as draft.")</span>
 </fieldset>
 
 <fieldset>

--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Parts.CustomForm.Wrapper.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Parts.CustomForm.Wrapper.cshtml
@@ -15,7 +15,8 @@
     @Display(editor)
 
     @Html.Hidden("returnUrl", Request.RawUrl, new { id = string.Empty });
-    @Html.Hidden("contentId", Request.QueryString["contentId"], new { id = string.Empty });
+    @Html.Hidden("contentId", !string.IsNullOrWhiteSpace(Request.QueryString["contentId"]) ? Request.QueryString["contentId"] : "0", new { id = string.Empty });
+
 
     <fieldset class="submit-button">
        

--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Parts.CustomForm.Wrapper.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Parts.CustomForm.Wrapper.cshtml
@@ -13,15 +13,10 @@
     @Html.ValidationSummary()
     // Model is a Shape, calling Display() so that it is rendered using the most specific template for its Shape type
     @Display(editor)
-
     @Html.Hidden("returnUrl", Request.RawUrl, new { id = string.Empty });
     @Html.Hidden("contentId", !string.IsNullOrWhiteSpace(Request.QueryString["contentId"]) ? Request.QueryString["contentId"] : "0", new { id = string.Empty });
-
-
     <fieldset class="submit-button">
-       
             <button type="submit" name="submit.Save" value="submit.Save">@Model.ContentPart.SubmitButtonText</button>
-        }
         @if (Model.ContentItem.CustomFormPart.SavePublishContentItem == true) {
             <button type="submit" name="submit.Publish" value="submit.Publish">@Model.ContentPart.PublishButtonText</button>
         }


### PR DESCRIPTION
The "ContentId" field is mandatory and needs to be set to "0" when the form action calls ItemController.Create