### PR TITLE
Fixes errors during Indexing

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Indexing/Handlers/InfosetFieldIndexingHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Indexing/Handlers/InfosetFieldIndexingHandler.cs
@@ -45,7 +45,7 @@ namespace Orchard.Indexing.Handlers {
                             var fieldStorage = _fieldStorageProvider.BindStorage(localPart, localField);
                             var indexName = infosetPart.TypeDefinition.Name.ToLower() + "-" + field.Name.ToLower();
 
-                            var membersContext = new DescribeMembersContext(fieldStorage, values => {
+                            var membersContext = new DescribeMembersContext(null, fieldStorage, values => {
 
                                 foreach (var value in values) {
 
@@ -92,7 +92,7 @@ namespace Orchard.Indexing.Handlers {
                                             break;
                                     }
                                 }
-                            });
+                            }, localField);
 
                             foreach (var driver in drivers) {
                                 driver.Describe(membersContext);

--- a/src/Orchard.Web/Modules/Orchard.Indexing/Services/IndexingTaskExecutor.cs
+++ b/src/Orchard.Web/Modules/Orchard.Indexing/Services/IndexingTaskExecutor.cs
@@ -20,8 +20,7 @@ namespace Orchard.Indexing.Services {
     /// This class is synchronized using a lock file as both command line and web workers can potentially use it,
     /// and singleton locks would not be shared accross those two.
     /// </remarks>
-    public class IndexingTaskExecutor : IIndexingTaskExecutor, IIndexStatisticsProvider
-    {
+    public class IndexingTaskExecutor : IIndexingTaskExecutor, IIndexStatisticsProvider {
         private readonly IRepository<IndexingTaskRecord> _taskRepository;
         private readonly IRepository<ContentItemVersionRecord> _contentRepository;
         private IIndexProvider _indexProvider;
@@ -160,13 +159,22 @@ namespace Orchard.Indexing.Services {
                         .OrderBy(versionRecord => versionRecord.Id)
                         .Take(ContentItemsPerLoop)
                         .ToList()
+                        .Select(versionRecord => {
+                            try {
+                                    // In some rare cases a ContentItemVersionRecord without a ContentItemRecord can end up in the DB.
+                                    // in that case ContentManager throws a ObjectNotFoundException.
+                                    // e.g. NHibernate.ObjectNotFoundException: No row with the given identifier exists[Orchard.ContentManagement.Records.ContentItemRecord#148]
+                                    return _contentManager.Get(versionRecord.ContentItemRecord.Id, VersionOptions.VersionRecord(versionRecord.Id));
+                            }
+                            catch {
+                                return null;
+                            }
+                        })
                         // In some rare cases a ContentItemRecord without a ContentType can end up in the DB.
                         // We need to filter out such records, otherwise they will crash the ContentManager.
-                        .Where(x => x.ContentItemRecord != null && x.ContentItemRecord.ContentType != null)
-                        .Select(versionRecord => _contentManager.Get(versionRecord.ContentItemRecord.Id, VersionOptions.VersionRecord(versionRecord.Id)))
+                        .Where(content => content != null && content.ContentType != null)
                         .Distinct()
                         .ToList();
-
                     // if no more elements to index, switch to update mode
                     if (contentItems.Count == 0) {
                         indexSettings.Mode = IndexingMode.Update;
@@ -288,7 +296,7 @@ namespace Orchard.Indexing.Services {
                     }
 
                 } while (loop);
-			}
+            }
 
             // save current state of the index
             indexSettings.LastIndexedUtc = _clock.UtcNow;
@@ -328,12 +336,10 @@ namespace Orchard.Indexing.Services {
         /// <summary>
         /// Loads the settings file or create a new default one if it doesn't exist
         /// </summary>
-        public IndexSettings LoadSettings(string indexName)
-        {
+        public IndexSettings LoadSettings(string indexName) {
             var indexSettings = new IndexSettings();
             var settingsFilename = GetSettingsFileName(indexName);
-            if (_appDataFolder.FileExists(settingsFilename))
-            {
+            if (_appDataFolder.FileExists(settingsFilename)) {
                 var content = _appDataFolder.ReadFile(settingsFilename);
                 indexSettings = IndexSettings.Parse(content);
             }
@@ -372,7 +378,7 @@ namespace Orchard.Indexing.Services {
             if (contentItem == null ||
                 contentItem.TypeDefinition == null ||
                 contentItem.TypeDefinition.Settings == null) {
-                return new TypeIndexing {Indexes = ""};
+                return new TypeIndexing { Indexes = "" };
             }
             return contentItem.TypeDefinition.Settings.GetModel<TypeIndexing>();
         }

--- a/src/Orchard/ContentManagement/Handlers/DescribeMembersContext.cs
+++ b/src/Orchard/ContentManagement/Handlers/DescribeMembersContext.cs
@@ -11,15 +11,16 @@ namespace Orchard.ContentManagement.Handlers {
         private readonly Action<IEnumerable> _apply;
         private readonly ContentPartFieldDefinition _contentPartFieldDefinition;
 
-        public DescribeMembersContext(Action<string, Type, LocalizedString, LocalizedString> processMember) : this(processMember, null, null) {
+        public DescribeMembersContext(Action<string, Type, LocalizedString, LocalizedString> processMember)
+            : this(processMember, null, null, null) {
         }
 
         public DescribeMembersContext(IFieldStorage storage, Action<IEnumerable> apply)
-            : this(null, storage, apply) {
+            : this(null, storage, apply, null) {
         }
 
-        public DescribeMembersContext(Action<string, Type, LocalizedString, LocalizedString> processMember, IFieldStorage storage, Action<IEnumerable> apply) :
-            this(null, storage, apply, null) {
+        public DescribeMembersContext(Action<string, Type, LocalizedString, LocalizedString> processMember, IFieldStorage storage, Action<IEnumerable> apply)
+            : this(null, storage, apply, null) {
         }
 
         public DescribeMembersContext(Action<string, Type, LocalizedString, LocalizedString> processMember, IFieldStorage storage, Action<IEnumerable> apply, ContentPartFieldDefinition contentPartFieldDefinition) {
@@ -50,7 +51,9 @@ namespace Orchard.ContentManagement.Handlers {
                 var f = enumerate();
                 var field = Activator.CreateInstance<TField>();
                 field.Storage = _storage;
-                field.PartFieldDefinition = _contentPartFieldDefinition;
+                if (field.PartFieldDefinition == null) {
+                    field.PartFieldDefinition = _contentPartFieldDefinition;
+                }
                 _apply(f(field));
             }
 

--- a/src/Orchard/ContentManagement/Handlers/DescribeMembersContext.cs
+++ b/src/Orchard/ContentManagement/Handlers/DescribeMembersContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using Orchard.ContentManagement.FieldStorage;
+using Orchard.ContentManagement.MetaData.Models;
 using Orchard.Localization;
 
 namespace Orchard.ContentManagement.Handlers {
@@ -8,6 +9,7 @@ namespace Orchard.ContentManagement.Handlers {
         private readonly Action<string, Type, LocalizedString, LocalizedString> _processMember;
         private readonly IFieldStorage _storage;
         private readonly Action<IEnumerable> _apply;
+        private readonly ContentPartFieldDefinition _contentPartFieldDefinition;
 
         public DescribeMembersContext(Action<string, Type, LocalizedString, LocalizedString> processMember) : this(processMember, null, null) {
         }
@@ -16,10 +18,15 @@ namespace Orchard.ContentManagement.Handlers {
             : this(null, storage, apply) {
         }
 
-        public DescribeMembersContext(Action<string, Type, LocalizedString, LocalizedString> processMember, IFieldStorage storage, Action<IEnumerable> apply) {
+        public DescribeMembersContext(Action<string, Type, LocalizedString, LocalizedString> processMember, IFieldStorage storage, Action<IEnumerable> apply) :
+            this(null, storage, apply, null) {
+        }
+
+        public DescribeMembersContext(Action<string, Type, LocalizedString, LocalizedString> processMember, IFieldStorage storage, Action<IEnumerable> apply, ContentPartFieldDefinition contentPartFieldDefinition) {
             _processMember = processMember;
             _storage = storage;
             _apply = apply;
+            _contentPartFieldDefinition = contentPartFieldDefinition;
         }
 
         public DescribeMembersContext Member(string storageName, Type storageType) {
@@ -43,6 +50,7 @@ namespace Orchard.ContentManagement.Handlers {
                 var f = enumerate();
                 var field = Activator.CreateInstance<TField>();
                 field.Storage = _storage;
+                field.PartFieldDefinition = _contentPartFieldDefinition;
                 _apply(f(field));
             }
 


### PR DESCRIPTION
fixes #8348 

IndexingTaskExecutor:
 - wrapped with a try/catch the ContentManager.Get that throws an error when ContentItemVersionRecord has not a ContentItemRecord reference (sometimes happens on Database)

DescribeMembersContext:
 - Adds a new constructor having a ContentPartFieldDefinition parameter, needed because DateTimeField.DateTime property try to access its own PartFieldDefinition.Settings that is null when called by Orchard.ContentManagement.Handlers.Enumerate called by InfosetFieldIndexingHandler.OnIndexing (see below)

InfosetFieldIndexingHandler:
 - Creates a DescribeMembersContext having the ContentPartFieldDefinition defined