### PR TITLE
Added tokenizable default value to ContentPickerFields

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Fields/ContentPickerField.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Fields/ContentPickerField.cs
@@ -21,7 +21,7 @@ namespace Orchard.ContentPicker.Fields {
             }
         }
 
-        private string EncodeIds(ICollection<int> ids) {
+        private static string EncodeIds(ICollection<int> ids) {
             if (ids == null || !ids.Any()) {
                 return string.Empty;
             }
@@ -30,12 +30,25 @@ namespace Orchard.ContentPicker.Fields {
             return "{" + string.Join("},{", ids.ToArray()) + "}";
         }
 
-        private int[] DecodeIds(string ids) {
+        public static int[] DecodeIds(string ids) {
             if(String.IsNullOrWhiteSpace(ids)) {
                 return new int[0];
             }
-
-            return ids.Split(separator, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToArray();
+            // if some of the slices of the string cannot be properly parsed,
+            // we still will return those that can.
+            return ids
+                .Split(separator, StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => {
+                    int i = -1;
+                    if(int.TryParse(s, out i)) {
+                        return i;
+                    }
+                    // if we can't parse return a negative value
+                    return -1;
+                })
+                // take only those that parsed properly
+                .Where(i => i > 0)
+                .ToArray();
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
@@ -26,6 +26,7 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -195,6 +196,10 @@
     <ProjectReference Include="..\Orchard.Localization\Orchard.Localization.csproj">
       <Project>{fbc8b571-ed50-49d8-8d9d-64ab7454a0d6}</Project>
       <Name>Orchard.Localization</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Orchard.Tokens\Orchard.Tokens.csproj">
+      <Project>{6f759635-13d7-4e94-bcc9-80445d63f117}</Project>
+      <Name>Orchard.Tokens</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Settings/ContentPickerFieldEditorEvents.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Settings/ContentPickerFieldEditorEvents.cs
@@ -28,6 +28,7 @@ namespace Orchard.ContentPicker.Settings {
                 builder.WithSetting("ContentPickerFieldSettings.Multiple", model.Multiple.ToString(CultureInfo.InvariantCulture));
                 builder.WithSetting("ContentPickerFieldSettings.ShowContentTab", model.ShowContentTab.ToString(CultureInfo.InvariantCulture));
                 builder.WithSetting("ContentPickerFieldSettings.DisplayedContentTypes", model.DisplayedContentTypes);
+                builder.WithSetting("ContentPickerFieldSettings.DefaultValue", model.DefaultValue);
             }
 
             yield return DefinitionTemplate(model);

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Settings/ContentPickerFieldSettings.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Settings/ContentPickerFieldSettings.cs
@@ -10,5 +10,7 @@
 
         public bool ShowContentTab { get; set; }
         public string DisplayedContentTypes { get; set; }
+
+        public string DefaultValue { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/DefinitionTemplates/ContentPickerFieldSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Views/DefinitionTemplates/ContentPickerFieldSettings.cshtml
@@ -14,7 +14,7 @@
 </fieldset>
 <fieldset>
     <label for="@Html.FieldIdFor(m => m.Hint)">@T("Help text")</label>
-    @Html.TextAreaFor(m => m.Hint, new { @class = "text medium", rows = "5" } )
+    @Html.TextAreaFor(m => m.Hint, new { @class = "text medium", rows = "5" })
     <span class="hint">@T("The help text is written under the field when authors are selecting content items.")</span>
     @Html.ValidationMessageFor(m => m.Hint)
 </fieldset>
@@ -27,7 +27,16 @@
 <fieldset>
     <div>
         <label for="@Html.FieldIdFor(m => m.DisplayedContentTypes)">@T("Content Types and Parts")</label>
-        @Html.TextBoxFor(m => m.DisplayedContentTypes) 
+        @Html.TextBoxFor(m => m.DisplayedContentTypes)
         <span class="hint">@T("A comma separated value of all the content types or content parts to display.")</span>
     </div>
 </fieldset>
+<fieldset>
+    <div>
+        <label for="@Html.FieldIdFor(m => m.DefaultValue)">@T("Default value for the array of selected Ids")</label>
+        @Html.TextBoxFor(m => m.DefaultValue, new { @class = "text large tokenized"})
+        <span class="hint">@T("A comma separated list of the ids of selected Items. It also accepts {{ or }} as separators, in line with the serialization normally used for this field.")</span>
+    </div>
+</fieldset>
+
+@Display.TokenHint()


### PR DESCRIPTION
fixes #8350 
As described in the issue, I added that tokenized default value.

I had to add Orchard.Tokens as a reference to Orchard.ContentPicker, of course.

I also made the method ContentPickerFiled.DecodeIds(string) public, so I could use it withing the driver to parse the results of tokenizer.Replace(string, Dictionary). I changed that method to prevent it from throwing in case the string is not just integers, by using TryParse rather than Parse and removing those values that could not be parsed to int correctly.