### PR TITLE
Removes useless and case sensitive check

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Controllers/ItemController.cs
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Controllers/ItemController.cs
@@ -72,13 +72,10 @@ namespace Orchard.CustomForms.Controllers {
             var customForm = form.As<CustomFormPart>();
 
             // Retrieve the id of the content to edit
-            int contentId = 0;
             var queryString = Services.WorkContext.HttpContext.Request.QueryString;
 
-            if (queryString.AllKeys.Contains("contentId")) {
-                int.TryParse(queryString["contentId"], out contentId);
-            }
-
+            int.TryParse(queryString["contentId"], out int contentId);
+            
             ContentItem contentItem;
             if (contentId > 0) {
                 contentItem = _contentManager.Get(contentId);


### PR DESCRIPTION
That check was useless because we use a int.TryParse. Morevoer queryString.AllKeys.Contains() is case sensitive.