### PR TITLE
Fix for TermContentItem deadlocks

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -216,11 +216,13 @@ namespace Orchard.Taxonomies.Services {
 
             var termIds = string.IsNullOrEmpty(field)
                 ? _termContentItemRepository
-                    .Fetch(x => x.TermsPartRecord.ContentItemRecord.Id == contentItemId)
-                    .Select(t => t.TermRecord.Id)
+                    .Table
+                    .Where(x => x.TermsPartRecord.ContentItemRecord.Id == contentItemId)
+                    .Select(x => x.Id)
                     .ToArray()
                 : _termContentItemRepository
-                    .Fetch(x => x.TermsPartRecord.Id == contentItemId && x.Field == field)
+                    .Table
+                    .Where(x => x.TermsPartRecord.Id == contentItemId && x.Field == field)
                     .Select(t => t.TermRecord.Id)
                     .ToArray();
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -218,7 +218,7 @@ namespace Orchard.Taxonomies.Services {
                 ? _termContentItemRepository
                     .Table
                     .Where(x => x.TermsPartRecord.ContentItemRecord.Id == contentItemId)
-                    .Select(x => x.Id)
+                    .Select(t => t.TermRecord.Id)
                     .ToArray()
                 : _termContentItemRepository
                     .Table


### PR DESCRIPTION
The deadlocks were caused by refetching the TermContentItem records after having just written them. Luckily, the same information is already available in the ViewModel produced for the update, so I changed the delegate for the shape so it doesn't ask anything to the database that it has in the viewmodel already.

I also changed the underlying query to only fetch the desired Ids rather than all columns.