### PR TITLE
Cache list of configured layers

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Widgets/Models/LayerPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Models/LayerPart.cs
@@ -29,5 +29,10 @@ namespace Orchard.Widgets.Models {
             get { return Retrieve(x => x.LayerRule); }
             set { Store(x => x.LayerRule, value); }
         }
+
+        public static string AllLayersCacheEvictSignal =
+            "LayerPart_AllLayers_EvictCache";
+        public static string AllLayersCacheKey =
+            "LayerPart_AllLayers_CacheKey";
     }
 }


### PR DESCRIPTION
fix #8372 

On every page load on frontend we were querying for all existing layers to test
for the ones that are currently active. Since that information is not bound to
change often, we added a cache layer to prevent querying every time. The cache
is evicted whenever a Layer gets updated.