### PR TITLE
Memorize query results in blog service

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Services/BlogService.cs
@@ -51,8 +51,14 @@ namespace Orchard.Blogs.Services {
             return blogPart == null ? null : blogPart.ContentItem;
         }
 
+        private IEnumerable<BlogPart> _publishedBlogs;
         public IEnumerable<BlogPart> Get() {
-            return Get(VersionOptions.Published);
+            // this is currently called at least twice per request on the
+            // back-office, both times by the code building the admin menu.
+            if (_publishedBlogs == null) {
+                _publishedBlogs = Get(VersionOptions.Published);
+            }
+            return _publishedBlogs;
         }
 
         public IEnumerable<BlogPart> Get(VersionOptions versionOptions) {


### PR DESCRIPTION
The query for all published blogs is being called twice while building the admin menu,
so we are memorizing its results.