### PR TITLE
tokens sort criteria

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -166,10 +166,12 @@ namespace Orchard.Projections.Services {
 
             // iterate over each sort criteria to apply the alterations to the query object
             foreach (var sortCriterion in queryRecord.SortCriteria.OrderBy(s => s.Position)) {
+                var tokenizedState = _tokenizer.Replace(sortCriterion.State, tokens);
                 var sortCriterionContext = new SortCriterionContext {
                     Query = groupQuery,
-                    State = FormParametersHelper.ToDynamic(sortCriterion.State),
-                    QueryPartRecord = queryRecord
+                    State = FormParametersHelper.ToDynamic(tokenizedState),
+                    QueryPartRecord = queryRecord,
+                    Tokens = tokens
                 };
 
                 string category = sortCriterion.Category;

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -212,7 +212,8 @@ namespace Orchard.Projections.Services {
                     var filterContext = new FilterContext {
                         Query = contentQuery,
                         State = FormParametersHelper.ToDynamic(tokenizedState),
-                        QueryPartRecord = queryRecord
+                        QueryPartRecord = queryRecord,
+                        Tokens = tokens
                     };
 
                     string category = filter.Category;
@@ -236,10 +237,12 @@ namespace Orchard.Projections.Services {
 
                 // iterate over each sort criteria to apply the alterations to the query object
                 foreach (var sortCriterion in sortCriteria.OrderBy(s => s.Position)) {
+                    var tokenizedState = _tokenizer.Replace(sortCriterion.State, tokens);
                     var sortCriterionContext = new SortCriterionContext {
                         Query = contentQuery,
-                        State = FormParametersHelper.ToDynamic(sortCriterion.State),
-                        QueryPartRecord = queryRecord
+                        State = FormParametersHelper.ToDynamic(tokenizedState),
+                        QueryPartRecord = queryRecord,
+                        Tokens = tokens
                     };
 
                     string category = sortCriterion.Category;


### PR DESCRIPTION
Fixes #8381 
Tokenized the state for sort criteria.
Pass the tokens dictionary in the corresponding property of SortCriterionContext and FilterContext (the property was there already, bu the dictionary was not passed along)