### PR TITLE
Process ignored paths while being aware of RequestUrlPrefix

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -497,8 +497,9 @@ namespace Orchard.OutputCache.Filters {
                     ?? (_ignoredRelativePaths = _cacheManager.Get($"{CacheSettings.CacheKey}_IgnoredUrls", true, ContextBoundObject => {
                         ContextBoundObject.Monitor(_signals.When(CacheSettings.CacheKey));
                         return CacheSettings.IgnoredUrls
-                            .Select(s => s.TrimStart(new[] { '~' }).Trim())
-                            .Where(s => !string.IsNullOrWhiteSpace(s) && !s.StartsWith("#"));
+                            ?.Select(s => s.TrimStart(new[] { '~' }).Trim())
+                            ?.Where(s => !string.IsNullOrWhiteSpace(s) && !s.StartsWith("#"))
+                            ?? Enumerable.Empty<string>();
                     }));
             }
         }

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -80,6 +80,7 @@ namespace Orchard.OutputCache.Filters {
         private string _invariantCacheKey;
         private bool _transformRedirect;
         private bool _isCachingRequest;
+        private IEnumerable<string> _ignoredRelativePaths;
 
         public void OnActionExecuting(ActionExecutingContext filterContext) {
 
@@ -325,7 +326,7 @@ namespace Orchard.OutputCache.Filters {
             }
 
             // Don't cache ignored URLs.
-            if (IsIgnoredUrl(filterContext.RequestContext.HttpContext.Request.AppRelativeCurrentExecutionFilePath, CacheSettings.IgnoredUrls)) {
+            if (IsIgnoredUrl(filterContext.RequestContext.HttpContext.Request.AppRelativeCurrentExecutionFilePath)) {
                 Logger.Debug("Request for item '{0}' ignored because the URL is configured as ignored.", itemDescriptor);
                 return false;
             }
@@ -490,6 +491,18 @@ namespace Orchard.OutputCache.Filters {
             }
         }
 
+        private IEnumerable<string> IgnoredRelativePaths {
+            get {
+                return _ignoredRelativePaths
+                    ?? (_ignoredRelativePaths = _cacheManager.Get($"{CacheSettings.CacheKey}_IgnoredUrls", true, ContextBoundObject => {
+                        ContextBoundObject.Monitor(_signals.When(CacheSettings.CacheKey));
+                        return CacheSettings.IgnoredUrls
+                            .Select(s => s.TrimStart(new[] { '~' }).Trim())
+                            .Where(s => !string.IsNullOrWhiteSpace(s) && !s.StartsWith("#"));
+                    }));
+            }
+        }
+
         private void ServeCachedItem(ActionExecutingContext filterContext, CacheItem cacheItem) {
             var response = filterContext.HttpContext.Response;
             var request = filterContext.HttpContext.Request;
@@ -574,6 +587,37 @@ namespace Orchard.OutputCache.Filters {
             }
         }
 
+        protected virtual bool IsIgnoredUrl(string url) {
+            if (IgnoredRelativePaths == null || !IgnoredRelativePaths.Any()) {
+                return false;
+            }
+
+            url = url.TrimStart(new[] { '~' });
+
+            if (string.IsNullOrWhiteSpace(_shellSettings.RequestUrlPrefix)) {
+                foreach (var relativePath in IgnoredRelativePaths) {
+                    if (String.Equals(relativePath, url, StringComparison.OrdinalIgnoreCase)) {
+                        return true;
+                    }
+                }
+            } else {
+                // if there is a RequestUrlPrefix, we want to check by also removing it from the
+                // url we are verifying, because the configuration might have been done without it
+                var tmp = url;
+                if (tmp.StartsWith(_shellSettings.RequestUrlPrefix)) {
+                    tmp = tmp.TrimStart(new[] { '/' }).Substring(_shellSettings.RequestUrlPrefix.Length);
+                }
+                foreach (var relativePath in IgnoredRelativePaths) {
+                    if (String.Equals(relativePath, url, StringComparison.OrdinalIgnoreCase)
+                        || String.Equals(relativePath, tmp, StringComparison.OrdinalIgnoreCase)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         protected virtual bool IsIgnoredUrl(string url, IEnumerable<string> ignoredUrls) {
             if (ignoredUrls == null || !ignoredUrls.Any()) {
                 return false;
@@ -596,6 +640,29 @@ namespace Orchard.OutputCache.Filters {
                     return true;
                 }
             }
+            // repeat the check by removing the RequestUrlPrefix if it exists.
+            if (!string.IsNullOrWhiteSpace(_shellSettings.RequestUrlPrefix)) {
+                var tmp = url.TrimStart(new[] { '/' });
+                if (tmp.StartsWith(_shellSettings.RequestUrlPrefix)) {
+                    tmp = tmp.Substring(_shellSettings.RequestUrlPrefix.Length);
+                    foreach (var ignoredUrl in ignoredUrls) {
+                        var relativePath = ignoredUrl.TrimStart(new[] { '~' }).Trim();
+                        if (String.IsNullOrWhiteSpace(relativePath)) {
+                            continue;
+                        }
+
+                        // Ignore comments
+                        if (relativePath.StartsWith("#")) {
+                            continue;
+                        }
+
+                        if (String.Equals(relativePath, tmp, StringComparison.OrdinalIgnoreCase)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+
 
             return false;
         }

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -603,9 +603,9 @@ namespace Orchard.OutputCache.Filters {
             } else {
                 // if there is a RequestUrlPrefix, we want to check by also removing it from the
                 // url we are verifying, because the configuration might have been done without it
-                var tmp = url;
+                var tmp = url.TrimStart(new[] { '/' });
                 if (tmp.StartsWith(_shellSettings.RequestUrlPrefix)) {
-                    tmp = tmp.TrimStart(new[] { '/' }).Substring(_shellSettings.RequestUrlPrefix.Length);
+                    tmp = tmp.Substring(_shellSettings.RequestUrlPrefix.Length);
                 }
                 foreach (var relativePath in IgnoredRelativePaths) {
                     if (String.Equals(relativePath, url, StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Fixes #8383 

If there is a ReequestUrlPrefix, and the url we are processing begins with it, try to remove it. But also try to keep it for retrocompatibility with current configurations.

basically:
RequestUrlPrefix: "foo"
Request Url: "/foo/bar"

We test whether we should ignore either "/bar" or "/foo/bar".
The second test in this example is to ensure that anything that works before this change, keeps working afterwards.

If there is no RequestUrlPrefix, nothing changes compared to the current.

I took the liberty of caching the urls to ignore, evicting that cache whenever the cache for the settings as a whole is also evicted.