### PR TITLE
Upgrade host resolution

### DIFF
--- a/src/Orchard.Tests/Environment/RunningShellTableTests.cs
+++ b/src/Orchard.Tests/Environment/RunningShellTableTests.cs
@@ -128,9 +128,10 @@ namespace Orchard.Tests.Environment {
             var settingsG = new ShellSettings { Name = "Gamma", RequestUrlHost = "wiki.example.com" };
             var settingsD = new ShellSettings { Name = "Delta", RequestUrlPrefix = "Quux" };
             table.Add(settings);
+            // add this shell first, because the order the shells where processed used to matter
+            table.Add(settingsG);
             table.Add(settingsA);
             table.Add(settingsB);
-            table.Add(settingsG);
             table.Add(settingsD);
 
             Assert.That(table.Match(new StubHttpContext("~/foo/bar", "wiki.example.com")), Is.EqualTo(settingsA).Using(new ShellComparer()));

--- a/src/Orchard.Tests/Orchard.Framework.Tests.csproj
+++ b/src/Orchard.Tests/Orchard.Framework.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props" Condition="Exists('..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -32,6 +33,8 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -458,5 +461,11 @@
   </Target>
   <Target Name="AfterBuild">
     <CallTarget Targets="CopySqlCeBinaries" />
+  </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props'))" />
   </Target>
 </Project>

--- a/src/Orchard.Tests/Orchard.Framework.Tests.csproj
+++ b/src/Orchard.Tests/Orchard.Framework.Tests.csproj
@@ -33,8 +33,6 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -461,11 +459,5 @@
   </Target>
   <Target Name="AfterBuild">
     <CallTarget Targets="CopySqlCeBinaries" />
-  </Target>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props'))" />
   </Target>
 </Project>

--- a/src/Orchard.Tests/packages.config
+++ b/src/Orchard.Tests/packages.config
@@ -17,4 +17,5 @@
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="NHibernate" version="4.0.1.4000" targetFramework="net452" />
   <package id="NUnit" version="2.5.10.11092" targetFramework="net452" />
+  <package id="NUnitTestAdapter" version="2.3.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
implements #8386 
I am proposing this for 1.10.x rather than dev because this introduces no breaking change in the way things are done: as it is, everything that is working right now, will keep working the same, but the new setting, when set to true, allows reversing some logic in selecting the tenant/shell that should respond to a request.