### PR TITLE
Fixes Boolean Conversion error

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Web.Mvc;
 using System.Web.Security;
@@ -80,6 +81,10 @@ namespace Orchard.Users.Controllers {
 
             var user = ValidateLogOn(userNameOrEmail, password);
             if (!ModelState.IsValid) {
+                if (ModelState["rememberMe"].Errors.Any()) {
+                    // We need to remove "remeberMe" from ModelState because the Html.CheckBox() in LogOn.cshtml view throws exception if ModelState contains non-convertable value
+                    ModelState.Remove("rememberMe");
+                }
                 var shape = _orchardServices.New.LogOn().Title(T("Log On").Text);
                 return new ShapeResult(this, shape);
             }

--- a/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Web.Mvc;
 using System.Web.Security;
@@ -81,10 +80,6 @@ namespace Orchard.Users.Controllers {
 
             var user = ValidateLogOn(userNameOrEmail, password);
             if (!ModelState.IsValid) {
-                if (ModelState["rememberMe"].Errors.Any()) {
-                    // We need to remove "remeberMe" from ModelState because the Html.CheckBox() in LogOn.cshtml view throws exception if ModelState contains non-convertable value
-                    ModelState.Remove("rememberMe");
-                }
                 var shape = _orchardServices.New.LogOn().Title(T("Log On").Text);
                 return new ShapeResult(this, shape);
             }

--- a/src/Orchard/Mvc/ModelBinders/BooleanBinderProvider.cs
+++ b/src/Orchard/Mvc/ModelBinders/BooleanBinderProvider.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Web.Mvc;
-using System.Xml;
-using System.Xml.Linq;
-using Orchard.Mvc.ModelBinders;
 
 namespace Orchard.Mvc.ModelBinders {
     public class BooleanBinderProvider : IModelBinderProvider, IModelBinder {

--- a/src/Orchard/Mvc/ModelBinders/BooleanBinderProvider.cs
+++ b/src/Orchard/Mvc/ModelBinders/BooleanBinderProvider.cs
@@ -17,7 +17,7 @@ namespace Orchard.Mvc.ModelBinders {
         public object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext) {
             var value = false;
             var requestBooleanValue = controllerContext.HttpContext.Request[bindingContext.ModelName].Split(',')[0]; //Html.CheckBox and Html.CheckBoxFor return "true,false" string
-            if (!bool.TryParse(requestBooleanValue.Split(',')[0], out value)) {
+            if (!bool.TryParse(requestBooleanValue, out value)) {
                 bindingContext.ModelState.AddModelError(bindingContext.ModelName, new FormatException());
             }
             return value;

--- a/src/Orchard/Mvc/ModelBinders/BooleanBinderProvider.cs
+++ b/src/Orchard/Mvc/ModelBinders/BooleanBinderProvider.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web.Mvc;
+using System.Xml;
+using System.Xml.Linq;
+using Orchard.Mvc.ModelBinders;
+
+namespace Orchard.Mvc.ModelBinders {
+    public class BooleanBinderProvider : IModelBinderProvider, IModelBinder {
+
+        public IEnumerable<ModelBinderDescriptor> GetModelBinders() {
+            return new[] {
+                             new ModelBinderDescriptor {
+                                                           ModelBinder = this,
+                                                           Type = typeof(bool)
+                                                       }
+                         };
+        }
+
+        public object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext) {
+            var value = false;
+            var requestBooleanValue = controllerContext.HttpContext.Request[bindingContext.ModelName].Split(',')[0]; //Html.CheckBox and Html.CheckBoxFor return "true,false" string
+            if (!bool.TryParse(requestBooleanValue.Split(',')[0], out value)) {
+                bindingContext.ModelState.AddModelError(bindingContext.ModelName, new FormatException());
+            }
+            return value;
+        }
+    }
+}

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Data\Migration\Schema\DropUniqueConstraintCommand.cs" />
     <Compile Include="Environment\Extensions\Models\LifecycleStatus.cs" />
     <Compile Include="Environment\ShellBuilders\ICompositionStrategy.cs" />
+    <Compile Include="Mvc\ModelBinders\BooleanBinderProvider.cs" />
     <Compile Include="Mvc\Updater.cs" />
     <Compile Include="Recipes\Models\ConfigurationContext.cs" />
     <Compile Include="Recipes\Models\RecipeBuilderStepConfigurationContext.cs" />


### PR DESCRIPTION
Fixes #8392 removing "remeberMe" from ModelState when it is in error state: the Html.CheckBox() in LogOn.cshtml view throws exception if ModelState contains non-convertable value