### PR TITLE
fix for CPF when other scripts are also adding to sessionStorage

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/ResourceManifest.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/ResourceManifest.cs
@@ -5,7 +5,7 @@ namespace Orchard.ContentPicker {
         public void BuildManifests(ResourceManifestBuilder builder) {
             var manifest = builder.Add();
             manifest.DefineScript("ContentPicker").SetUrl("ContentPicker.js", "ContentPicker.js").SetDependencies("jQuery");
-            manifest.DefineScript("SelectableContentTab").SetUrl("SelectableContentTab.js", "SelectableContentTab.js").SetDependencies("jQuery");
+            manifest.DefineScript("SelectableContentTab").SetUrl("SelectableContentTab.js?v=1.1", "SelectableContentTab.js?v=1.1").SetDependencies("jQuery");
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Scripts/SelectableContentTab.js
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Scripts/SelectableContentTab.js
@@ -32,8 +32,13 @@
         $('.button.addSelected').on('click', function () {
             var itemsToAdd = new Array();
             for (var i = 0; i < sessionStorage.length; i++) {
-                var data = window.sessionStorage.getItem(sessionStorage.key(i));
-                itemsToAdd.push(JSON.parse(data));
+                var key = sessionStorage.key(i);
+                // only add the item if the key is an integer: other scripts may be
+                // adding stuff to sessionStorage
+                if (!isNaN(key - parseInt(key))) {
+                    var data = window.sessionStorage.getItem(sessionStorage.key(i));
+                    itemsToAdd.push(JSON.parse(data));
+                }
             }
             window.sessionStorage.clear();
             window.opener.jQuery[query("callback")](itemsToAdd);


### PR DESCRIPTION
fix #8403 
In the script, check that the key for the stuff we are attempting to fetch from sessionStorage is an int.
Advances version number for the script in the ResourceManifest so a no-cache refresh is not required for it to be loaded.