### PR TITLE
Revert "Fix/8392 remeber me model state exception"

### DIFF
--- a/src/Orchard/Mvc/ModelBinders/BooleanBinderProvider.cs
+++ b/src/Orchard/Mvc/ModelBinders/BooleanBinderProvider.cs
@@ -16,7 +16,6 @@ namespace Orchard.Mvc.ModelBinders {
 
         public object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext) {
             var value = false;
-            if (string.IsNullOrWhiteSpace(controllerContext.HttpContext.Request[bindingContext.ModelName])) return false;
             var requestBooleanValue = controllerContext.HttpContext.Request[bindingContext.ModelName].Split(',')[0]; //Html.CheckBox and Html.CheckBoxFor return "true,false" string
             if (!bool.TryParse(requestBooleanValue, out value)) {
                 bindingContext.ModelState.AddModelError(bindingContext.ModelName, new FormatException());


### PR DESCRIPTION
Reverts OrchardCMS/Orchard#8410

We found that this change introduced several issues.
i.e. in the back office, listable ContentItems were not detected as such, or there was an exception thrown when trying to edit a ContentItem that had a MediaLibraryPickerField.

I propose to revert this and try again later, because we haven't had a change to test and fix all possible conditions.