### PR TITLE
Prevent NREs for null text

### DIFF
--- a/src/Orchard/Localization/Services/DefaultLocalizedStringManager.cs
+++ b/src/Orchard/Localization/Services/DefaultLocalizedStringManager.cs
@@ -51,6 +51,7 @@ namespace Orchard.Localization.Services {
 
         public FormatForScope GetLocalizedString(IEnumerable<string> scopes, string text, string cultureName) {
             var culture = LoadCulture(cultureName);
+            text = text ?? string.Empty; // prevent NREs with this string
             foreach (var scope in scopes) {
                 string scopedKey = (scope + "|" + text).ToLowerInvariant();
                 if (culture.Translations.ContainsKey(scopedKey)) {


### PR DESCRIPTION
When the text we are localizing is null (which potentially happens when localizing dynamic content), it could result in a null parent translation, which would throw when used as "basis" for comparisons.