### PR TITLE
Add FromName and ReplyTo properties to SmtpSettingsPart

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Email/Controllers/EmailAdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Controllers/EmailAdminController.cs
@@ -11,12 +11,12 @@ using Orchard.UI.Admin;
 namespace Orchard.Email.Controllers {
     [Admin]
     public class EmailAdminController : Controller {
-        private readonly ISmtpChannel smtpChannel;
-        private readonly IOrchardServices orchardServices;
+        private readonly ISmtpChannel _smtpChannel;
+        private readonly IOrchardServices _orchardServices;
 
         public EmailAdminController(ISmtpChannel smtpChannel, IOrchardServices orchardServices) {
-            this.smtpChannel = smtpChannel;
-            this.orchardServices = orchardServices;
+            _smtpChannel = smtpChannel;
+            _orchardServices = orchardServices;
             T = NullLocalizer.Instance;
         }
 
@@ -28,13 +28,13 @@ namespace Orchard.Email.Controllers {
             ILogger logger = null;
             try {
                 var fakeLogger = new FakeLogger();
-                if (smtpChannel is Component smtpChannelComponent) {
+                if (_smtpChannel is Component smtpChannelComponent) {
                     logger = smtpChannelComponent.Logger;
                     smtpChannelComponent.Logger = fakeLogger;
                 }
 
                 // Temporarily update settings so that the test will actually use the specified host, port, etc.
-                var smtpSettings = orchardServices.WorkContext.CurrentSite.As<SmtpSettingsPart>();
+                var smtpSettings = _orchardServices.WorkContext.CurrentSite.As<SmtpSettingsPart>();
 
                 smtpSettings.FromAddress = testSettings.FromAddress;
                 smtpSettings.FromName = testSettings.FromName;
@@ -52,7 +52,7 @@ namespace Orchard.Email.Controllers {
                     fakeLogger.Error("Invalid settings.");
                 }
                 else {
-                    smtpChannel.Process(new Dictionary<string, object> {
+                    _smtpChannel.Process(new Dictionary<string, object> {
                         {"Recipients", testSettings.To},
                         {"Subject", T("Orchard CMS - SMTP settings test email").Text}
                     });
@@ -68,12 +68,12 @@ namespace Orchard.Email.Controllers {
                 return Json(new { error = e.Message });
             }
             finally {
-                if (smtpChannel is Component smtpChannelComponent) {
+                if (_smtpChannel is Component smtpChannelComponent) {
                     smtpChannelComponent.Logger = logger;
                 }
 
                 // Undo the temporarily changed SMTP settings.
-                orchardServices.TransactionManager.Cancel();
+                _orchardServices.TransactionManager.Cancel();
             }
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Email/Controllers/EmailAdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Controllers/EmailAdminController.cs
@@ -38,7 +38,9 @@ namespace Orchard.Email.Controllers {
                 // Temporarily update settings so that the test will actually use the specified host, port, etc.
                 var smtpSettings = _orchardServices.WorkContext.CurrentSite.As<SmtpSettingsPart>();
 
-                smtpSettings.Address = testSettings.From;
+                smtpSettings.FromAddress = testSettings.FromAddress;
+                smtpSettings.FromName = testSettings.FromName;
+                smtpSettings.ReplyTo = testSettings.ReplyTo;
                 smtpSettings.Host = testSettings.Host;
                 smtpSettings.Port = testSettings.Port;
                 smtpSettings.EnableSsl = testSettings.EnableSsl;
@@ -72,7 +74,7 @@ namespace Orchard.Email.Controllers {
                     smtpChannelComponent.Logger = logger;
                 }
 
-                // Undo the temporarily changed smtp settings.
+                // Undo the temporarily changed SMTP settings.
                 _orchardServices.TransactionManager.Cancel();
             }
         }
@@ -90,7 +92,9 @@ namespace Orchard.Email.Controllers {
         }
 
         public class TestSmtpSettings {
-            public string From { get; set; }
+            public string FromAddress { get; set; }
+            public string FromName { get; set; }
+            public string ReplyTo { get; set; }
             public string Host { get; set; }
             public int Port { get; set; }
             public bool EnableSsl { get; set; }

--- a/src/Orchard.Web/Modules/Orchard.Email/Migrations.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Migrations.cs
@@ -1,11 +1,39 @@
-﻿using Orchard.Data.Migration;
+﻿using System.Linq;
+using System.Xml;
+using Orchard.ContentManagement;
+using Orchard.Data.Migration;
+using Orchard.Email.Models;
 
 namespace Orchard.Email {
     public class Migrations : DataMigrationImpl {
+        private readonly IContentManager _contentManager;
 
-        public int Create() {
+        public Migrations(IContentManager contentManager) => _contentManager = contentManager;
 
-            return 1;
+        // The first migration without any content should not exist but it has been deployed so we need to keep it.
+        public int Create() => 1;
+
+        public int UpdateFrom1() {
+            // Migrate existing SmtpSettingPart.Address because we rename it to FromAddress.
+            var siteSettingsItem = _contentManager.Query(contentTypeNames: "Site")
+                .Slice(1)
+                .SingleOrDefault();
+
+            var siteSettingsRecord = siteSettingsItem?.Record;
+
+            if (siteSettingsRecord != null) {
+                var xmlDoc = new XmlDocument();
+                xmlDoc.LoadXml(siteSettingsRecord.Data);
+
+                var smtpSettingNode = xmlDoc.SelectSingleNode("//SmtpSettingsPart");
+                if (smtpSettingNode != null) {
+                    var smtpSettingsPart = siteSettingsItem.As<SmtpSettingsPart>();
+                    smtpSettingsPart.FromAddress = smtpSettingNode.Attributes["Address"]?.Value;
+                }
+            }
+
+            return 2;
         }
     }
 }
+

--- a/src/Orchard.Web/Modules/Orchard.Email/Models/EmailMessage.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Models/EmailMessage.cs
@@ -6,7 +6,8 @@ namespace Orchard.Email.Models {
         public string Body { get; set; }
         public string Recipients { get; set; }
         public string ReplyTo { get; set; }
-        public string From { get; set; }
+        public string FromAddress { get; set; }
+        public string FromName { get; set; }
         public string Bcc { get; set; }
         public string Cc { get; set; }
         /// <summary>

--- a/src/Orchard.Web/Modules/Orchard.Email/Models/SmtpSettingsPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Models/SmtpSettingsPart.cs
@@ -1,72 +1,79 @@
 ﻿using System.Configuration;
 using System.Net.Configuration;
 using Orchard.ContentManagement;
-using System;
 using Orchard.ContentManagement.Utilities;
 
 namespace Orchard.Email.Models {
     public class SmtpSettingsPart : ContentPart {
-        private readonly ComputedField<string> _password = new ComputedField<string>();
+        private readonly ComputedField<string> password = new ComputedField<string>();
+        private readonly LazyField<string> addressPlaceholder = new LazyField<string>();
+        internal LazyField<string> AddressPlaceholderField => addressPlaceholder;
 
-        public ComputedField<string> PasswordField {
-            get { return _password; }
+        public ComputedField<string> PasswordField => password;
+
+        public string FromAddress {
+            get => this.Retrieve(x => x.FromAddress);
+            set => this.Store(x => x.FromAddress, value);
         }
 
-        public string Address {
-            get { return this.Retrieve(x => x.Address); }
-            set { this.Store(x => x.Address, value); }
+        public string FromName {
+            get => this.Retrieve(x => x.FromName);
+            set => this.Store(x => x.FromName, value);
         }
 
-        private readonly LazyField<string> _addressPlaceholder = new LazyField<string>();
-        internal LazyField<string> AddressPlaceholderField { get { return _addressPlaceholder; } }
-        public string AddressPlaceholder { get { return _addressPlaceholder.Value; } }
+        public string ReplyTo {
+            get => this.Retrieve(x => x.ReplyTo);
+            set => this.Store(x => x.ReplyTo, value);
+        }
+
+        public string AddressPlaceholder => addressPlaceholder.Value;
 
         public string Host {
-            get { return this.Retrieve(x => x.Host); }
-            set { this.Store(x => x.Host, value); }
+            get => this.Retrieve(x => x.Host);
+            set => this.Store(x => x.Host, value);
         }
 
         public int Port {
-            get { return this.Retrieve(x => x.Port, 25); }
-            set { this.Store(x => x.Port, value); }
+            get => this.Retrieve(x => x.Port, 25);
+            set => this.Store(x => x.Port, value);
         }
 
         public bool EnableSsl {
-            get { return this.Retrieve(x => x.EnableSsl); }
-            set { this.Store(x => x.EnableSsl, value); }
+            get => this.Retrieve(x => x.EnableSsl);
+            set => this.Store(x => x.EnableSsl, value);
         }
 
         public bool RequireCredentials {
-            get { return this.Retrieve(x => x.RequireCredentials); }
-            set { this.Store(x => x.RequireCredentials, value); }
+            get => this.Retrieve(x => x.RequireCredentials);
+            set => this.Store(x => x.RequireCredentials, value);
         }
 
         public bool UseDefaultCredentials {
-            get { return this.Retrieve(x => x.UseDefaultCredentials); }
-            set { this.Store(x => x.UseDefaultCredentials, value); }
+            get => this.Retrieve(x => x.UseDefaultCredentials);
+            set => this.Store(x => x.UseDefaultCredentials, value);
         }
 
         public string UserName {
-            get { return this.Retrieve(x => x.UserName); }
-            set { this.Store(x => x.UserName, value); }
+            get => this.Retrieve(x => x.UserName);
+            set => this.Store(x => x.UserName, value);
         }
 
         public string Password {
-            get { return _password.Value; }
-            set { _password.Value = value; }
+            get => password.Value;
+            set => password.Value = value;
         }
 
         public bool IsValid() {
             var section = (SmtpSection)ConfigurationManager.GetSection("system.net/mailSettings/smtp");
-            if (section != null && !String.IsNullOrWhiteSpace(section.Network.Host)) {
+            if (section != null && !string.IsNullOrWhiteSpace(section.Network.Host)) {
                 return true;
             }
 
-            if (String.IsNullOrWhiteSpace(Address)) {
+            if (string.IsNullOrWhiteSpace(FromAddress)) {
                 return false;
             }
 
-            if (!String.IsNullOrWhiteSpace(Host) && Port == 0) {
+            if (!string.IsNullOrWhiteSpace(Host) && Port == 0) {
                 return false;
             }
 

--- a/src/Orchard.Web/Modules/Orchard.Email/Models/SmtpSettingsPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Models/SmtpSettingsPart.cs
@@ -5,11 +5,9 @@ using Orchard.ContentManagement.Utilities;
 
 namespace Orchard.Email.Models {
     public class SmtpSettingsPart : ContentPart {
-        private readonly ComputedField<string> password = new ComputedField<string>();
-        private readonly LazyField<string> addressPlaceholder = new LazyField<string>();
-        internal LazyField<string> AddressPlaceholderField => addressPlaceholder;
+        private readonly ComputedField<string> _password = new ComputedField<string>();
 
-        public ComputedField<string> PasswordField => password;
+        public ComputedField<string> PasswordField => _password;
 
         public string FromAddress {
             get => this.Retrieve(x => x.FromAddress);
@@ -26,7 +24,9 @@ namespace Orchard.Email.Models {
             set => this.Store(x => x.ReplyTo, value);
         }
 
-        public string AddressPlaceholder => addressPlaceholder.Value;
+        private readonly LazyField<string> _addressPlaceholder = new LazyField<string>();
+        internal LazyField<string> AddressPlaceholderField => _addressPlaceholder;
+        public string AddressPlaceholder => _addressPlaceholder.Value;
 
         public string Host {
             get => this.Retrieve(x => x.Host);
@@ -59,8 +59,8 @@ namespace Orchard.Email.Models {
         }
 
         public string Password {
-            get => password.Value;
-            set => password.Value = value;
+            get => _password.Value;
+            set => _password.Value = value;
         }
 
         // Hotmail only supports the mailto:link. When a user clicks on the 'unsubscribe' option in Hotmail. 

--- a/src/Orchard.Web/Modules/Orchard.Email/Models/SmtpSettingsPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Models/SmtpSettingsPart.cs
@@ -63,6 +63,17 @@ namespace Orchard.Email.Models {
             set => password.Value = value;
         }
 
+        // Hotmail only supports the mailto:link. When a user clicks on the 'unsubscribe' option in Hotmail. 
+        // Hotmail tries to read the mailto:link in the List-Unsubscribe header. 
+        // If the mailto:link is missing, it moves all the messages to the Junk folder.
+        // The mailto:link is supported by Gmail, Hotmail, Yahoo, AOL, ATT, Time Warner and Comcast; 
+        // European ISPs such as GMX, Libero, Ziggo, Orange, BTInternet; Russian ISPs such as mail.ru and Yandex; 
+        // and the Chinese domains qq.com, naver.com etc. So most ISPs support (and prefer) mailto:link.
+        public string ListUnsubscribe {
+            get => this.Retrieve(x => x.ListUnsubscribe);
+            set => this.Store(x => x.ListUnsubscribe, value);
+        }
+
         public bool IsValid() {
             var section = (SmtpSection)ConfigurationManager.GetSection("system.net/mailSettings/smtp");
             if (section != null && !string.IsNullOrWhiteSpace(section.Network.Host)) {

--- a/src/Orchard.Web/Modules/Orchard.Email/Orchard.Email.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Email/Orchard.Email.csproj
@@ -101,6 +101,7 @@
       <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.Email/Orchard.Email.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Email/Orchard.Email.csproj
@@ -69,6 +69,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />

--- a/src/Orchard.Web/Modules/Orchard.Email/Services/EmailMessagingChannel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Services/EmailMessagingChannel.cs
@@ -53,7 +53,7 @@ namespace Orchard.Email.Services {
                 smtpClient.EnableSsl = smtpSettings.EnableSsl;
                 smtpClient.DeliveryMethod = SmtpDeliveryMethod.Network;
 
-                context.MailMessage.From = new MailAddress(smtpSettings.Address);
+                context.MailMessage.From = new MailAddress(smtpSettings.FromAddress);
                 context.MailMessage.IsBodyHtml = !String.IsNullOrWhiteSpace(context.MailMessage.Body) && context.MailMessage.Body.Contains("<") && context.MailMessage.Body.Contains(">");
 
                 try {

--- a/src/Orchard.Web/Modules/Orchard.Email/Services/SmtpMessageChannel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Services/SmtpMessageChannel.cs
@@ -162,6 +162,10 @@ namespace Orchard.Email.Services {
                 }
             }
 
+            if (!string.IsNullOrWhiteSpace(smtpSettings.ListUnsubscribe)){
+                mailMessage.Headers.Add("List-Unsubscribe", smtpSettings.ListUnsubscribe);
+            }
+
             return mailMessage;
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Email/Services/SmtpMessageChannel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Services/SmtpMessageChannel.cs
@@ -9,15 +9,14 @@ using Orchard.ContentManagement;
 using Orchard.DisplayManagement;
 using Orchard.Logging;
 using Orchard.Email.Models;
-using System.Linq;
 using System.IO;
 
 namespace Orchard.Email.Services {
     public class SmtpMessageChannel : Component, ISmtpChannel, IDisposable {
-        private readonly SmtpSettingsPart _smtpSettings;
-        private readonly IShapeFactory _shapeFactory;
-        private readonly IShapeDisplay _shapeDisplay;
-        private readonly Lazy<SmtpClient> _smtpClientField;
+        private readonly SmtpSettingsPart smtpSettings;
+        private readonly IShapeFactory shapeFactory;
+        private readonly IShapeDisplay shapeDisplay;
+        private readonly Lazy<SmtpClient> smtpClientField;
         public static readonly string MessageType = "Email";
 
         public SmtpMessageChannel(
@@ -25,24 +24,23 @@ namespace Orchard.Email.Services {
             IShapeFactory shapeFactory,
             IShapeDisplay shapeDisplay) {
 
-            _shapeFactory = shapeFactory;
-            _shapeDisplay = shapeDisplay;
+            this.shapeFactory = shapeFactory;
+            this.shapeDisplay = shapeDisplay;
 
-            _smtpSettings = orchardServices.WorkContext.CurrentSite.As<SmtpSettingsPart>();
-            _smtpClientField = new Lazy<SmtpClient>(CreateSmtpClient);
+            smtpSettings = orchardServices.WorkContext.CurrentSite.As<SmtpSettingsPart>();
+            smtpClientField = new Lazy<SmtpClient>(CreateSmtpClient);
         }
 
         public void Dispose() {
-            if (!_smtpClientField.IsValueCreated) {
+            if (!smtpClientField.IsValueCreated) {
                 return;
             }
 
-            _smtpClientField.Value.Dispose();
+            smtpClientField.Value.Dispose();
         }
 
         public void Process(IDictionary<string, object> parameters) {
-
-            if (!_smtpSettings.IsValid()) {
+            if (!smtpSettings.IsValid()) {
                 return;
             }
 
@@ -51,10 +49,15 @@ namespace Orchard.Email.Services {
                 Subject = Read(parameters, "Subject"),
                 Recipients = Read(parameters, "Recipients"),
                 ReplyTo = Read(parameters, "ReplyTo"),
-                From = Read(parameters, "From"),
+                FromAddress = Read(parameters, "FromAddress"),
+                FromName = Read(parameters, "FromName"),
                 Bcc = Read(parameters, "Bcc"),
                 Cc = Read(parameters, "CC"),
-                Attachments = (IEnumerable<string>)(parameters.ContainsKey("Attachments") ? parameters["Attachments"] : new List<string>())
+                Attachments = (IEnumerable<string>)(
+                    parameters.ContainsKey("Attachments")
+                        ? parameters["Attachments"]
+                        : new List<string>()
+                )
             };
 
             if (string.IsNullOrWhiteSpace(emailMessage.Recipients)) {
@@ -62,119 +65,134 @@ namespace Orchard.Email.Services {
                 return;
             }
 
-            // Apply default Body alteration for SmtpChannel.
-            var template = _shapeFactory.Create("Template_Smtp_Wrapper", Arguments.From(new {
-                Content = new MvcHtmlString(emailMessage.Body)
-            }));
-
-            var mailMessage = new MailMessage {
-                Subject = emailMessage.Subject,
-                Body = _shapeDisplay.Display(template),
-                IsBodyHtml = true
-            };
-
-            if (parameters.ContainsKey("Message")) {
-                // A full message object is provided by the sender.
-
-                var oldMessage = mailMessage;
-                mailMessage = (MailMessage)parameters["Message"];
-
-                if (String.IsNullOrWhiteSpace(mailMessage.Subject))
-                    mailMessage.Subject = oldMessage.Subject;
-
-                if (String.IsNullOrWhiteSpace(mailMessage.Body)) {
-                    mailMessage.Body = oldMessage.Body;
-                    mailMessage.IsBodyHtml = oldMessage.IsBodyHtml;
-                }
-            }
+            var mailMessage = CreteMailMessage(parameters, emailMessage);
 
             try {
-
-                foreach (var recipient in ParseRecipients(emailMessage.Recipients)) {
-                    mailMessage.To.Add(new MailAddress(recipient));
-                }
-
-                if (!String.IsNullOrWhiteSpace(emailMessage.Cc)) {
-                    foreach (var recipient in ParseRecipients(emailMessage.Cc)) {
-                        mailMessage.CC.Add(new MailAddress(recipient));
-                    }
-                }
-
-                if (!String.IsNullOrWhiteSpace(emailMessage.Bcc)) {
-                    foreach (var recipient in ParseRecipients(emailMessage.Bcc)) {
-                        mailMessage.Bcc.Add(new MailAddress(recipient));
-                    }
-                }
-
-                if (!String.IsNullOrWhiteSpace(emailMessage.From)) {
-                    mailMessage.From = new MailAddress(emailMessage.From);
-                }
-                else {
-                    // Take 'From' address from site settings or web.config.
-                    mailMessage.From = !String.IsNullOrWhiteSpace(_smtpSettings.Address)
-                        ? new MailAddress(_smtpSettings.Address)
-                        : new MailAddress(((SmtpSection)ConfigurationManager.GetSection("system.net/mailSettings/smtp")).From);
-                }
-
-                if (!String.IsNullOrWhiteSpace(emailMessage.ReplyTo)) {
-                    foreach (var recipient in ParseRecipients(emailMessage.ReplyTo)) {
-                        mailMessage.ReplyToList.Add(new MailAddress(recipient));
-                    }
-                }
-                foreach (var attachmentPath in emailMessage.Attachments) {
-                    if (File.Exists(attachmentPath)) {
-                        mailMessage.Attachments.Add(new Attachment(attachmentPath));
-                    }
-                    else {
-                        throw new FileNotFoundException(T("One or more attachments not found.").Text);
-                    }
-                }
-
-                if (parameters.ContainsKey("NotifyReadEmail")) {
-                    if (parameters["NotifyReadEmail"] is bool) {
-                        if ((bool)(parameters["NotifyReadEmail"])) {
-                            mailMessage.Headers.Add("Disposition-Notification-To", mailMessage.From.ToString());
-                        }
-                    }
-                }
-
-                _smtpClientField.Value.Send(mailMessage);
+                smtpClientField.Value.Send(mailMessage);
             }
             catch (Exception e) {
                 Logger.Error(e, "Could not send email");
             }
         }
 
+        private MailMessage CreteMailMessage(IDictionary<string, object> parameters, EmailMessage emailMessage) {
+
+            // Apply default Body alteration for SmtpChannel.
+            var template = shapeFactory.Create("Template_Smtp_Wrapper", Arguments.From(new {
+                Content = new MvcHtmlString(emailMessage.Body)
+            }));
+
+            var mailMessage = new MailMessage {
+                Subject = emailMessage.Subject,
+                Body = shapeDisplay.Display(template),
+                IsBodyHtml = true
+            };
+
+            if (parameters.ContainsKey("Message")) {
+                // A full message object is provided by the sender.
+                var oldMessage = mailMessage;
+                mailMessage = (MailMessage)parameters["Message"];
+
+                if (string.IsNullOrWhiteSpace(mailMessage.Subject))
+                    mailMessage.Subject = oldMessage.Subject;
+
+                if (string.IsNullOrWhiteSpace(mailMessage.Body)) {
+                    mailMessage.Body = oldMessage.Body;
+                    mailMessage.IsBodyHtml = oldMessage.IsBodyHtml;
+                }
+            }
+
+            foreach (var recipient in ParseRecipients(emailMessage.Recipients)) {
+                mailMessage.To.Add(new MailAddress(recipient));
+            }
+
+            if (!string.IsNullOrWhiteSpace(emailMessage.Cc)) {
+                foreach (var recipient in ParseRecipients(emailMessage.Cc)) {
+                    mailMessage.CC.Add(new MailAddress(recipient));
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(emailMessage.Bcc)) {
+                foreach (var recipient in ParseRecipients(emailMessage.Bcc)) {
+                    mailMessage.Bcc.Add(new MailAddress(recipient));
+                }
+            }
+
+            var senderAddress =
+                !string.IsNullOrWhiteSpace(emailMessage.FromAddress) ? emailMessage.FromAddress :
+                !string.IsNullOrWhiteSpace(smtpSettings.FromAddress) ? smtpSettings.FromAddress :
+                // Take 'From' address from site settings or web.config.
+                ((SmtpSection)ConfigurationManager.GetSection("system.net/mailSettings/smtp")).From;
+
+            var senderName = !string.IsNullOrWhiteSpace(emailMessage.FromName)
+                ? emailMessage.FromName
+                : smtpSettings.FromName;
+
+            var sender = (senderAddress, senderName) switch
+            {
+                (string address, string name) => new MailAddress(address, name),
+                (string address, null) => new MailAddress(address),
+                _ => throw new InvalidOperationException("No sender email address")
+            };
+            mailMessage.From = sender;
+
+            var replyTo =
+                !string.IsNullOrWhiteSpace(emailMessage.ReplyTo) ? ParseRecipients(emailMessage.ReplyTo) :
+                !string.IsNullOrWhiteSpace(smtpSettings.ReplyTo) ? new[] { smtpSettings.ReplyTo } :
+                Array.Empty<string>();
+
+            foreach (var recipient in replyTo) {
+                mailMessage.ReplyToList.Add(new MailAddress(recipient));
+            }
+
+            foreach (var attachmentPath in emailMessage.Attachments) {
+                if (File.Exists(attachmentPath)) {
+                    mailMessage.Attachments.Add(new Attachment(attachmentPath));
+                }
+                else {
+                    throw new FileNotFoundException(T("One or more attachments not found.").Text);
+                }
+            }
+
+            if (parameters.ContainsKey("NotifyReadEmail")) {
+                if (parameters["NotifyReadEmail"] is bool) {
+                    if ((bool)(parameters["NotifyReadEmail"])) {
+                        mailMessage.Headers.Add("Disposition-Notification-To", mailMessage.From.ToString());
+                    }
+                }
+            }
+
+            return mailMessage;
+        }
+
         private SmtpClient CreateSmtpClient() {
             // If no properties are set in the dashboard, use the web.config value.
-            if (String.IsNullOrWhiteSpace(_smtpSettings.Host)) {
+            if (string.IsNullOrWhiteSpace(smtpSettings.Host)) {
                 return new SmtpClient();
             }
 
             var smtpClient = new SmtpClient {
-                UseDefaultCredentials = _smtpSettings.RequireCredentials && _smtpSettings.UseDefaultCredentials
+                UseDefaultCredentials = smtpSettings.RequireCredentials && smtpSettings.UseDefaultCredentials
             };
 
-            if (!smtpClient.UseDefaultCredentials && !String.IsNullOrWhiteSpace(_smtpSettings.UserName)) {
-                smtpClient.Credentials = new NetworkCredential(_smtpSettings.UserName, _smtpSettings.Password);
+            if (!smtpClient.UseDefaultCredentials && !string.IsNullOrWhiteSpace(smtpSettings.UserName)) {
+                smtpClient.Credentials = new NetworkCredential(smtpSettings.UserName, smtpSettings.Password);
             }
 
-            if (_smtpSettings.Host != null) {
-                smtpClient.Host = _smtpSettings.Host;
+            if (smtpSettings.Host != null) {
+                smtpClient.Host = smtpSettings.Host;
             }
 
-            smtpClient.Port = _smtpSettings.Port;
-            smtpClient.EnableSsl = _smtpSettings.EnableSsl;
+            smtpClient.Port = smtpSettings.Port;
+            smtpClient.EnableSsl = smtpSettings.EnableSsl;
             smtpClient.DeliveryMethod = SmtpDeliveryMethod.Network;
             return smtpClient;
         }
 
-        private string Read(IDictionary<string, object> dictionary, string key) {
-            return dictionary.ContainsKey(key) ? dictionary[key] as string : null;
-        }
+        private string Read(IDictionary<string, object> dictionary, string key) =>
+            dictionary.ContainsKey(key) ? dictionary[key] as string : null;
 
-        private IEnumerable<string> ParseRecipients(string recipients) {
-            return recipients.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
-        }
+        private IEnumerable<string> ParseRecipients(string recipients) =>
+            recipients.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Email/Views/EditorTemplates/Parts/SmtpSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Email/Views/EditorTemplates/Parts/SmtpSettings.cshtml
@@ -3,7 +3,6 @@
 @{
     var smtpClient = new SmtpClient();
 }
-
 <fieldset>
     <legend>@T("Email")</legend>
     <div>
@@ -45,9 +44,7 @@
         <label for="@Html.FieldIdFor(m => m.RequireCredentials)" class="forcheckbox">@T("Require credentials")</label>
         @Html.ValidationMessage("RequireCredentials", "*")
     </div>
-
     <div data-controllerid="@Html.FieldIdFor(m => m.RequireCredentials)">
-
         <div>
             @Html.RadioButtonFor(m => m.UseDefaultCredentials, false, new { id = "customCredentialsOption", name = "UseDefaultCredentials" })
             <label for="customCredentialsOption" class="forcheckbox">@T("Specify username/password")</label>
@@ -74,6 +71,11 @@
                 <span class="hint">@T("The password for authentication.")</span>
             </span>
         </div>
+    </div>
+    <div>
+        <label for="@Html.FieldIdFor(m => m.ListUnsubscribe)">@T("List-Unsubscribe header")</label>
+        @Html.TextBoxFor(m => m.ListUnsubscribe, new { @class = "text medium" })
+        <span class="hint">@T("A mailto:link to unsubscribe a user when clicking unsubscribe option")</span>
     </div>
 </fieldset>
 <fieldset>
@@ -104,6 +106,7 @@
                     useDefaultCredentials = $("input[name='@Html.NameFor(m => m.UseDefaultCredentials)']"),
                     userName = $("#@Html.FieldIdFor(m => m.UserName)"),
                     password = $("#@Html.FieldIdFor(m => m.Password)"),
+                    listUnsubscribe = $("#@Html.FieldIdFor(m => m.ListUnsubscribe)"),
                     to = $("#emailtestto");
 
                 $("#emailtestsend").click(function () {
@@ -118,6 +121,7 @@
                         useDefaultCredentials: useDefaultCredentials.filter(':checked').val(),
                         userName: userName.val(),
                         password: password.val(),
+                        listUnsubscribe: listUnsubscribe.val(),
                         to: to.val(),
                         __RequestVerificationToken: to.closest("form").find("input[name=__RequestVerificationToken]").val()
                     })

--- a/src/Orchard.Web/Modules/Orchard.Email/Views/EditorTemplates/Parts/SmtpSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Email/Views/EditorTemplates/Parts/SmtpSettings.cshtml
@@ -7,10 +7,20 @@
 <fieldset>
     <legend>@T("Email")</legend>
     <div>
-        <label for="@Html.FieldIdFor(m => m.Address)">@T("Sender email address")</label>
-        @Html.TextBoxFor(m => m.Address, new { @class = "text medium", placeholder = Model.AddressPlaceholder })
-        @Html.ValidationMessage("Address", "*")
+        <label for="@Html.FieldIdFor(m => m.FromAddress)">@T("Sender email address")</label>
+        @Html.TextBoxFor(m => m.FromAddress, new { @class = "text medium", placeholder = Model.AddressPlaceholder })
+        @Html.ValidationMessage("FromAddress", "*")
         <span class="hint">@T("The default email address to use as a sender.")</span>
+    </div>
+    <div>
+        <label for="@Html.FieldIdFor(m => m.FromName)">@T("Sender name")</label>
+        @Html.TextBoxFor(m => m.FromName, new { @class = "text medium" })
+        <span class="hint">@T("The default value to use as a sender name.")</span>
+    </div>
+    <div>
+        <label for="@Html.FieldIdFor(m => m.ReplyTo)">@T("Reply to address")</label>
+        @Html.TextBoxFor(m => m.ReplyTo, new { @class = "text medium" })
+        <span class="hint">@T("The default email address to use for reply to")</span>
     </div>
     <div>
         <label for="@Html.FieldIdFor(m => m.Host)">@T("Host name")</label>
@@ -84,7 +94,9 @@
                 var url = "@Url.Action("TestSettings", "EmailAdmin", new {area = "Orchard.Email"})",
                     error = $("#emailtesterror"),
                     info = $("#emailtestinfo"),
-                    from = $("#@Html.FieldIdFor(m => m.Address)"),
+                    fromAddress = $("#@Html.FieldIdFor(m => m.FromAddress)"),
+                    fromName = $("#@Html.FieldIdFor(m => m.FromName)"),
+                    replyTo = $("#@Html.FieldIdFor(m => m.ReplyTo)"),
                     host = $("#@Html.FieldIdFor(m => m.Host)"),
                     port = $("#@Html.FieldIdFor(m => m.Port)"),
                     enableSsl = $("#@Html.FieldIdFor(m => m.EnableSsl)"),
@@ -96,7 +108,9 @@
 
                 $("#emailtestsend").click(function () {
                     $.post(url, {
-                        from: from.val(),
+                        fromAddress: fromAddress.val(),
+                        fromName: fromName.val(),
+                        replyTo: replyTo.val(),
                         host: host.val(),
                         port: port.val(),
                         enableSsl: enableSsl.prop("checked"),

--- a/src/Orchard.Web/Modules/Orchard.Email/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.Email/packages.config
@@ -6,4 +6,5 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Refer to :
- https://stackoverflow.com/a/14555043/1872200 and
- https://www.postmastery.com/list-unsubscribe-header-critical-for-sustained-email-delivery/

I think adding from name, reply to and List-Unsubscribe can help passing an email spam filter.

Therefore, I have updated SmtpSettingsPart to include FromName, ReplyTo and ListUnsubscribe properties.
In addition, I also updated SmtpMessageChannel to make sure everything work correctly.

BTW, I have changed naming convention of fields to not use _ underscore and use a this keyword.
I know it is more convenient to use underscore but I think it is not .NET naming convention.

Hopefully, this PR is valid and will get approved. I am happy to update this PR from your feedback.

Thanks.