### PR TITLE
Added an event activity for workflows that activates on the first Upd…

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Workflows/Activities/ContentActivity.cs
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Activities/ContentActivity.cs
@@ -78,6 +78,16 @@ namespace Orchard.Workflows.Activities {
         }
     }
 
+    public class ContentFirstUpdatedActivity : ContentActivity {
+        public override string Name {
+            get { return "ContentFirstUpdated"; }
+        }
+
+        public override LocalizedString Description {
+            get { return T("Content is updated for the first time."); }
+        }
+    }
+
     public class ContentPublishedActivity : ContentActivity {
         public override string Name {
             get { return "ContentPublished"; }

--- a/src/Orchard.Web/Modules/Orchard.Workflows/Handlers/WorkflowContentHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Handlers/WorkflowContentHandler.cs
@@ -6,8 +6,16 @@ using Orchard.Workflows.Services;
 namespace Orchard.Workflows.Handlers {
 
     public class WorkflowContentHandler : ContentHandler {
+        // Used to memorize the ids of ContentItems for which we go through the
+        // OnCreated handler.
+        private List<int> _createdItems;
+        // Used to memorize the ids of ContentItems for which we go through the
+        // OnUpdated handler.
+        private List<int> _updatedItems;
 
         public WorkflowContentHandler(IWorkflowManager workflowManager) {
+            _createdItems = new List<int>();
+            _updatedItems = new List<int>();
 
             OnPublished<ContentPart>(
                 (context, part) =>
@@ -34,9 +42,15 @@ namespace Orchard.Workflows.Handlers {
                     () => new Dictionary<string, object> { { "Content", context.BuildingContentItem } }));
 
             OnCreated<ContentPart>(
-                (context, part) =>
+                (context, part) => {
+
                     workflowManager.TriggerEvent("ContentCreated", context.ContentItem,
-                    () => new Dictionary<string, object> { { "Content", context.ContentItem } }));
+                        () => new Dictionary<string, object> { { "Content", context.ContentItem } });
+
+                    if (context.ContentItem != null) { // sanity check
+                        _createdItems.Add(context.ContentItem.Id);
+                    }
+                });
 
             OnUpdated<ContentPart>(
                 (context, part) => {
@@ -49,6 +63,22 @@ namespace Orchard.Workflows.Handlers {
                         context.ContentItem,
                         () => new Dictionary<string, object> { { "Content", context.ContentItem } }
                     );
+
+                    if (context.ContentItem != null) { // sanity check
+                        if (_createdItems.Contains(context.ContentItem.Id)) {
+                            if (!_updatedItems.Contains(context.ContentItem.Id)) {
+                                // first update after creation of item
+                                workflowManager.TriggerEvent(
+                                    "ContentFirstUpdated",
+                                    context.ContentItem,
+                                    () => new Dictionary<string, object> { { "Content", context.ContentItem } }
+                                );
+                            }
+                        }
+                        // in case a further update is invoked, this would prevent
+                        // the FirstUpdate event to be fired again
+                        _updatedItems.Add(context.ContentItem.Id);
+                    }
                 });
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Workflows/Handlers/WorkflowContentHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Handlers/WorkflowContentHandler.cs
@@ -58,15 +58,12 @@ namespace Orchard.Workflows.Handlers {
                         return;
                     }
 
-                    workflowManager.TriggerEvent(
-                        "ContentUpdated",
-                        context.ContentItem,
-                        () => new Dictionary<string, object> { { "Content", context.ContentItem } }
-                    );
-
                     if (context.ContentItem != null) { // sanity check
-                        if (_createdItems.Contains(context.ContentItem.Id)) {
-                            if (!_updatedItems.Contains(context.ContentItem.Id)) {
+                        if (!_updatedItems.Contains(context.ContentItem.Id)) {
+                            // in case a further update is invoked, this would prevent
+                            // the FirstUpdate event to be fired again
+                            _updatedItems.Add(context.ContentItem.Id);
+                            if (_createdItems.Contains(context.ContentItem.Id)) {
                                 // first update after creation of item
                                 workflowManager.TriggerEvent(
                                     "ContentFirstUpdated",
@@ -75,10 +72,14 @@ namespace Orchard.Workflows.Handlers {
                                 );
                             }
                         }
-                        // in case a further update is invoked, this would prevent
-                        // the FirstUpdate event to be fired again
-                        _updatedItems.Add(context.ContentItem.Id);
                     }
+
+                    workflowManager.TriggerEvent(
+                        "ContentUpdated",
+                        context.ContentItem,
+                        () => new Dictionary<string, object> { { "Content", context.ContentItem } }
+                    );
+
                 });
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Workflows/Handlers/WorkflowContentHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Handlers/WorkflowContentHandler.cs
@@ -8,14 +8,14 @@ namespace Orchard.Workflows.Handlers {
     public class WorkflowContentHandler : ContentHandler {
         // Used to memorize the ids of ContentItems for which we go through the
         // OnCreated handler.
-        private List<int> _createdItems;
+        private HashSet<int> _createdItems;
         // Used to memorize the ids of ContentItems for which we go through the
         // OnUpdated handler.
-        private List<int> _updatedItems;
+        private HashSet<int> _updatedItems;
 
         public WorkflowContentHandler(IWorkflowManager workflowManager) {
-            _createdItems = new List<int>();
-            _updatedItems = new List<int>();
+            _createdItems = new HashSet<int>();
+            _updatedItems = new HashSet<int>();
 
             OnPublished<ContentPart>(
                 (context, part) =>
@@ -44,12 +44,12 @@ namespace Orchard.Workflows.Handlers {
             OnCreated<ContentPart>(
                 (context, part) => {
 
-                    workflowManager.TriggerEvent("ContentCreated", context.ContentItem,
-                        () => new Dictionary<string, object> { { "Content", context.ContentItem } });
-
                     if (context.ContentItem != null) { // sanity check
                         _createdItems.Add(context.ContentItem.Id);
                     }
+
+                    workflowManager.TriggerEvent("ContentCreated", context.ContentItem,
+                        () => new Dictionary<string, object> { { "Content", context.ContentItem } });
                 });
 
             OnUpdated<ContentPart>(


### PR DESCRIPTION
Implements the feature described in #8437 
Added an event activity for workflows that activates on the first Updated event after creation of a ContentItem.
We memorize the ids of ContentItems that went through the "Created" event to know which ones have been created.
We memorize the ids of ContentItems that went through the "Updated" event to prevent firing the "ContentFirstUpdated" event several times in case Updated is invoked multiple times.