### PR TITLE
fixed validation of the LocalizationPart

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Drivers/LocalizationPartDriver.cs
@@ -14,6 +14,7 @@ namespace Orchard.Localization.Drivers {
         private readonly ICultureManager _cultureManager;
         private readonly ILocalizationService _localizationService;
         private readonly IContentManager _contentManager;
+        private string _selectedLanguage = string.Empty;
 
         public LocalizationPartDriver(ICultureManager cultureManager, ILocalizationService localizationService, IContentManager contentManager) {
             _cultureManager = cultureManager;
@@ -59,12 +60,25 @@ namespace Orchard.Localization.Drivers {
                 RetrieveMissingCultures(masterContentItem.As<LocalizationPart>(), true) :
                 RetrieveMissingCultures(part, part.Culture != null);
 
+            // if localizationpart is present remove it from the list of missingcultures
+            if (part.Culture != null && missingCultures.Contains(part.Culture.Culture)) {
+                missingCultures.Remove(part.Culture.Culture);
+            }
+
+            bool displayLanguageSelection = true;
+            if (string.IsNullOrEmpty(_selectedLanguage)) {
+                if (part.Culture != null && !string.IsNullOrEmpty(part.Culture.Culture)) {
+                    displayLanguageSelection = false;
+                }
+            }
+
             var model = new EditLocalizationViewModel {
                 SelectedCulture = GetCulture(part),
                 MissingCultures = missingCultures,
                 ContentItem = part,
                 MasterContentItem = masterContentItem,
-                ContentLocalizations = new ContentLocalizationsViewModel(part) { Localizations = localizations }
+                ContentLocalizations = new ContentLocalizationsViewModel(part) { Localizations = localizations },
+                DisplayLanguageSelection = displayLanguageSelection
             };
 
             return ContentShape("Parts_Localization_ContentTranslations_Edit",
@@ -73,15 +87,16 @@ namespace Orchard.Localization.Drivers {
 
         protected override DriverResult Editor(LocalizationPart part, IUpdateModel updater, dynamic shapeHelper) {
             var model = new EditLocalizationViewModel();
-            if (updater != null && updater.TryUpdateModel(model, TemplatePrefix, null, null)
-                // GetCulture(part) is checked against null value, because the content
-                // culture has to be set only if it's not set already.
-                && GetCulture(part) == null
+            updater.TryUpdateModel(model, TemplatePrefix, null, null);
+            // GetCulture(part) is checked against null value, because the content
+            // culture has to be set only if it's not set already.
+            if (GetCulture(part) == null
                 // model.SelectedCulture is checked against null value, because the editor
                 // group may not contain LocalizationPart when the content item is saved for
                 // the first time.
                 && !string.IsNullOrEmpty(model.SelectedCulture)) {
                 _localizationService.SetContentCulture(part, model.SelectedCulture);
+                _selectedLanguage = model.SelectedCulture;
             }
 
             return Editor(part, shapeHelper);

--- a/src/Orchard.Web/Modules/Orchard.Localization/ViewModels/EditLocalizationViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/ViewModels/EditLocalizationViewModel.cs
@@ -8,5 +8,6 @@ namespace Orchard.Localization.ViewModels {
         public IContent ContentItem { get; set; }
         public IContent MasterContentItem { get; set; }
         public ContentLocalizationsViewModel ContentLocalizations { get; set; }
+        public bool DisplayLanguageSelection { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Views/EditorTemplates/Parts/Localization.ContentTranslations.Edit.cshtml
@@ -7,7 +7,7 @@
 <fieldset class="localization culture-selection">
     <label for="@Html.FieldIdFor(m => m.SelectedCulture)">@T("Content Localization")</label>
     <div>
-        @if (!string.IsNullOrEmpty(Model.SelectedCulture)) {
+        @if ((!string.IsNullOrEmpty(Model.SelectedCulture) && ViewData.ModelState.IsValid) || !Model.DisplayLanguageSelection) {
             @T("This is the <em>{0}</em> variation of the content",
                 Html.Encode(Model.SelectedCulture))
 
@@ -47,7 +47,8 @@
                             Html.FieldIdFor(m => m.SelectedCulture),
                             Html.FieldNameFor(m => m.SelectedCulture),
                             Model.MissingCultures,
-                            Model.SelectedCulture),
+                            Model.SelectedCulture,
+                            !ViewData.ModelState.IsValid),
                         Html.ItemEditLink(masterContent));
             }
             else {
@@ -56,9 +57,10 @@
                             Html.FieldIdFor(m => m.SelectedCulture),
                             Html.FieldNameFor(m => m.SelectedCulture),
                             Model.MissingCultures,
-                            Model.SelectedCulture));
+                            Model.SelectedCulture,
+                            !ViewData.ModelState.IsValid));
             }
-        
+
             if (Model.ContentLocalizations.Localizations.Any()) {
                 <dl class="content-localization">
                     <dt>@T("Other translations:")</dt>
@@ -68,37 +70,48 @@
                             Html.ItemEditLink(c.Culture.Culture, c, new { ReturnUrl = returnUrl }), "localizations");
                         }
                         else {
-                        @Html.UnorderedList(Model.ContentLocalizations.Localizations, (c, i) =>
-                            Html.ItemEditLink(c.Culture.Culture, c), "localizations");
+                            @Html.UnorderedList(Model.ContentLocalizations.Localizations, (c, i) =>
+                                Html.ItemEditLink(c.Culture.Culture, c), "localizations");
                         }
                     </dd>
                 </dl>
             }
         }
-        
+
     </div>
 </fieldset>
 
 
 
 @functions{
-    private IHtmlString BuildSelectedCultureList(string id, string name, IEnumerable<string> siteCultures, string culture) {
+    private IHtmlString BuildSelectedCultureList(string id, string name, IEnumerable<string> siteCultures, string culture, bool addSelectedCulture) {
         TagBuilder selectTag = new TagBuilder("select");
         selectTag.Attributes["id"] = id;
         selectTag.Attributes["name"] = name;
+
+        if (addSelectedCulture) {
+            TagBuilder optionTagCulture = new TagBuilder("option");
+            optionTagCulture.Attributes["data-content-dir"] = CultureInfo.GetCultureInfo(culture).TextInfo.IsRightToLeft ? "rtl" : "ltr";
+            optionTagCulture.Attributes["selected"] = "selected";
+            optionTagCulture.SetInnerText(Html.Encode(culture));
+            selectTag.InnerHtml += optionTagCulture.ToString();
+        }
 
         foreach (var siteCulture in siteCultures) {
             TagBuilder optionTag = new TagBuilder("option");
             optionTag.Attributes["data-content-dir"] = CultureInfo.GetCultureInfo(siteCulture).TextInfo.IsRightToLeft ? "rtl" : "ltr";
 
-            if (string.IsNullOrEmpty(culture)) {
-                if (siteCulture == WorkContext.CurrentSite.SiteCulture) {
-                    optionTag.Attributes["selected"] = "selected";
+            // If the form is in error, the culture remains the one previously selected.
+            if (!addSelectedCulture) {
+                if (string.IsNullOrEmpty(culture)) {
+                    if (siteCulture == WorkContext.CurrentSite.SiteCulture) {
+                        optionTag.Attributes["selected"] = "selected";
+                    }
                 }
-            }
-            else {
-                if (siteCulture == culture) {
-                    optionTag.Attributes["selected"] = "selected";
+                else {
+                    if (siteCulture == culture) {
+                        optionTag.Attributes["selected"] = "selected";
+                    }
                 }
             }
             optionTag.SetInnerText(Html.Encode(siteCulture));


### PR DESCRIPTION
#8463

During the correction of the bug, I realised that in the driver’s edit post, within the condition that decides whether to update the part was the TryUpdateModel of the model, keeping it within the condition means that for any type of validation error even not related to the localisation part, the assignment of the selected culture will not be performed if not if successful.

So I decided to extract the TryUpdateModel so that I can always keep the data up to date, leaving the conditions present.

According to the logic that was there it wasn't enough to solve it, because there were problems with the management of dropdown, if the validation failed, too much the value of culture was recognised, then I proposed this type of solution, in the shape of whether the model was properly validated and handling the language selected during the creation of the dropdown. After the amendment, I still needed the use of a boolean to know during the edit get whether the value within the part was already present and not the value just given by post