### PR TITLE
Deploy to Azure App Service with GitHub Actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ trim_trailing_whitespace = true
 [*.cs]
 csharp_new_line_before_open_brace = none
 dotnet_sort_system_directives_first = true
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/deploy-to-azure-app-service.yml
+++ b/.github/workflows/deploy-to-azure-app-service.yml
@@ -1,0 +1,127 @@
+# How to use this GitHub Actions workflow
+
+# - Enable GitHub Action in your repository .
+# - Create Azure App Service code publish with .NET 4.8
+# - Add required GitHub Secrets:
+#   - NAME: AZURE_WEBAPP_NAME
+#     VALUE: Your Azure App Service name (only name, not a full URL)
+#   - NAME: AZURE_WEBAPP_PUBLISH_PROFILE
+#     VALUE: A content of downloaded publish profile from your App Service in Azure portal
+#     *** Before downloading a publish profile, please make sure you have set a configuration WEBSITE_WEBDEPLOY_USE_SCM = true.
+# - Push code to a main branch.
+# - GitHub Actions will automatic build and deploy the project to Azure App Service.
+
+name: Deploy Orchard CMS (.NET Framework) to Azure App Service
+
+# This workflow is triggered when pushing to a specific branch.
+on:
+  push:
+    branches:
+      - main
+
+env:
+  # Set MSBuild version to use. "[ or ]" means inclusive and "( or )" means exclusive.
+  # You can find release version at https://github.com/dotnet/msbuild/releases
+  MSBUILD_VERSION: "[16.9,17.0)"
+
+  NUGET_VERSION: 5.x # Set NuGet version to use.
+  NODE_VERSION: 10.x # Set Node.js version to use.
+
+  SOLUTION_PATH: src/Orchard.sln
+  # For Azure deployment, we use a custom MS Build at the root of the project.
+  PROJECT_PATH: Orchard.proj
+  PRECOMPILED_DIR: build/precompiled
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set supportedAppService variable
+        id: setvar
+        run: |
+          if [ -z "${{ secrets.AZURE_WEBAPP_NAME }}" ] # test -z return True if the length of String is zero.
+          then
+            echo "::set-output name=supportedAppService::0"
+            echo "No 'AZURE_WEBAPP_NAME' secret, skip deploy job."
+          else
+            echo "::set-output name=supportedAppService::1"
+          fi
+    outputs:
+      supportedAppService: ${{ steps.setvar.outputs.supportedAppService }}
+
+  deploy:
+    needs: [validate]
+    if: ${{ needs.validate.outputs.supportedAppService == 1 }} # Run deploy job when AZURE_WEBAPP_NAME is defined only
+    runs-on: windows-2019
+
+    # You can use default run to set default working directory.
+    # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
+    defaults:
+      run:
+        # Use a specific shell.
+        # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+        shell: powershell
+
+    steps:
+      - name: Checkout the latest source code from ${{ github.ref }} commit
+        # Find a release version https://github.com/actions/checkout/releases
+        uses: actions/checkout@v2
+
+      - name: Check if the project has Yarn Workspaces and set YARN_WORKSPACES_EXIST variable
+        working-directory: src # We need to change a working directory to a path that has workspaces package.json.
+        run: |
+          $workspaces_info_result = PowerShell -NoProfile -Command { yarn workspaces info 2>&1 | out-null; $LastExitCode }
+          # Use an environment file. https://github.community/t/empty-github-env-variables-on-powershell/147626/2
+          if($workspaces_info_result -eq 0) { echo "YARN_WORKSPACES_EXIST=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append }
+
+      # https://github.com/actions/setup-node
+      - name: Use Node.js version ${{ env.NODE_VERSION }}
+        if: ${{ env.YARN_WORKSPACES_EXIST == 1 }}
+        # Find a release version https://github.com/actions/setup-node/releases
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Build all Node.js projects if Yarn Workspaces exist
+        if: ${{ env.YARN_WORKSPACES_EXIST == 1 }}
+        working-directory: src
+        run: |
+          node --version
+          npm install yarn@1.22.5 --global
+          yarn --version
+          yarn install
+          yarn workspaces run build
+
+      - name: Setup NuGet version ${{ env.NUGET_VERSION }}
+        # Find a release version. https://github.com/NuGet/setup-nuget/releases/
+        uses: NuGet/setup-nuget@v1
+        with:
+          nuget-version: ${{ env.NUGET_VERSION }}
+
+      - name: Restore NuGet packages
+        run: nuget restore ${{ env.SOLUTION_PATH }}
+
+      - name: Setup MSBuild version ${{ env.MSBUILD_VERSION }}
+        # Find a release version. https://github.com/microsoft/setup-msbuild/releases
+        uses: microsoft/setup-msbuild@v1
+        with:
+          vs-version: ${{ env.MSBUILD_VERSION }}
+
+      - name: Build a solution/project
+        run: |
+          msbuild -version
+          msbuild ${{ env.PROJECT_PATH }} `
+            /t:Precompiled `
+            /p:PreCompiledDir=${{ env.PRECOMPILED_DIR }} `
+            /verbosity:minimal `
+            /maxcpucount `
+            /nologo
+
+      - name: Deploy to Azure App Service using publish profile credentials
+        # Find a release version. https://github.com/Azure/webapps-deploy/releases
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          # Before downloading a publish profile, please make sure you have set a configuration WEBSITE_WEBDEPLOY_USE_SCM = true.
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: ${{ env.PRECOMPILED_DIR }}

--- a/src/Orchard.sln
+++ b/src/Orchard.sln
@@ -267,10 +267,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DF3909B0-1DDD-4D8A-9919-56FC438E25E2}"
 	ProjectSection(SolutionItems) = preProject
 		..\.deployment = ..\.deployment
-		.editorconfig = .editorconfig
+		..\.editorconfig = ..\.editorconfig
+		..\.github\workflows\deploy-to-azure-app-service.yml = ..\.github\workflows\deploy-to-azure-app-service.yml
 		..\deploy.ps1 = ..\deploy.ps1
-		NuGet.config = NuGet.config
 		..\DeploymentUtility.psm1 = ..\DeploymentUtility.psm1
+		NuGet.config = NuGet.config
 		Rebracer.xml = Rebracer.xml
 		WebEssentials-Settings.json = WebEssentials-Settings.json
 	EndProjectSection
@@ -1262,7 +1263,7 @@ Global
 		{8EE141BE-7217-4F5B-8214-3146BEFA07E3} = {E9C9F120-07BA-4DFB-B9C3-3AFB9D44C9D5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {3585D970-275B-4363-9F61-CD37CFC9DCD3}
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4
+		SolutionGuid = {3585D970-275B-4363-9F61-CD37CFC9DCD3}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
# Changes:
- Add GitHub Actions workflow for deploying to Azure App Service
- Move .editorconfig to root of the project

**Here is the reason why I want to add `deploy-to-azure-app-service.yml` to the project.**
- Deployment with traditional Kudu can take 25 - 30 minutes which is quite slow.

![image](https://user-images.githubusercontent.com/2938310/116780254-a46f1080-aaa5-11eb-907e-19080e93f2db.png)

- For Kudu deployment it requires many files: 
  - .deployment
  - deploy.ps1
  - DeploymentUtility.psm1  
- Build script should be more declarative but our PowerShell scripts are more imperative.
- I sometime found these PowerShell scripts are not reliable when building Node.js projects because it fails sometime which shouldn't happened. 
- Kudu deployment does not support **Yarn Workspaces** which is very useful for managing Node.js packages in each Orchard modules. This is due to the file permission issue.
- I think right now Microsoft try to promote GitHub Actions more. As you can see, it is a default build provider option when you select GitHub as a source of a project.
![image](https://user-images.githubusercontent.com/2938310/116780223-738edb80-aaa5-11eb-8867-5d9039eae1ea.png)
- When deploy with GitHub Actions, it takes around 7 minutes.
![image](https://user-images.githubusercontent.com/2938310/116780263-bcdf2b00-aaa5-11eb-8dfb-a0b49c60b87a.png)

# How to use GitHub Actions in this PR
Please refer to README at the top of **deploy-to-azure-app-service.yml** file.

# When will the workflow start
- This GitHub workflow will run when `pushing code to a main branch &  AZURE_WEBAPP_NAME defined`
- It will try build Yarn Workspace packages if exist.

# Deployment result
- Here is a website deployed with GitHub Actions workflow in this PR
- https://orchard-cms-pr.azurewebsites.net/
- To log in admin panel, user
  - username: admin
  - password: 12345Abc% 
 - GitHub Actions log https://github.com/aaronamm/Orchard/actions



