### PR TITLE
Remove cache by tag on Unpublished

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Handlers/CacheItemInvalidationHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Handlers/CacheItemInvalidationHandler.cs
@@ -13,6 +13,7 @@ namespace Orchard.OutputCache.Handlers {
 
             // Evict cached content when updated, removed or destroyed.
             OnPublished<IContent>((context, part) => Invalidate(part));
+            OnUnpublished<IContent>((context, part) => Invalidate(part));
             OnRemoved<IContent>((context, part) => Invalidate(part));
             OnDestroyed<IContent>((context, part) => Invalidate(part));
         }


### PR DESCRIPTION
As it was, cached lists/projections would not be evicted when a ContentItem they contained was unpublished.