### PR TITLE
Update nhibernate

### DIFF
--- a/src/Orchard.Core.Tests/App.config
+++ b/src/Orchard.Core.Tests/App.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Core.Tests/Orchard.Core.Tests.csproj
+++ b/src/Orchard.Core.Tests/Orchard.Core.Tests.csproj
@@ -74,8 +74,8 @@
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.5.10.11092, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.5.10.11092\lib\nunit.framework.dll</HintPath>

--- a/src/Orchard.Core.Tests/packages.config
+++ b/src/Orchard.Core.Tests/packages.config
@@ -8,6 +8,6 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="NUnit" version="2.5.10.11092" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Specs/App.Config
+++ b/src/Orchard.Specs/App.Config
@@ -12,7 +12,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Specs/Orchard.Specs.csproj
+++ b/src/Orchard.Specs/Orchard.Specs.csproj
@@ -83,8 +83,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.5.10.11092, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.5.10.11092\lib\nunit.framework.dll</HintPath>

--- a/src/Orchard.Specs/packages.config
+++ b/src/Orchard.Specs/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="NUnit" version="2.5.10.11092" targetFramework="net48" />
   <package id="Orchard.FluentPath" version="1.0.0.1" targetFramework="net48" />
   <package id="SpecFlow" version="1.9.0" targetFramework="net48" />

--- a/src/Orchard.Tests.Modules/App.config
+++ b/src/Orchard.Tests.Modules/App.config
@@ -20,7 +20,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />

--- a/src/Orchard.Tests.Modules/Orchard.Tests.Modules.csproj
+++ b/src/Orchard.Tests.Modules/Orchard.Tests.Modules.csproj
@@ -111,8 +111,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Orchard.NuGet.Core.1.1.0.0\lib\NuGet.Core.dll</HintPath>

--- a/src/Orchard.Tests.Modules/packages.config
+++ b/src/Orchard.Tests.Modules/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="NUnit" version="2.5.10.11092" targetFramework="net48" />
   <package id="Orchard.FluentPath" version="1.0.0.1" targetFramework="net48" />
   <package id="Orchard.NuGet.Core" version="1.1.0.0" targetFramework="net48" />

--- a/src/Orchard.Tests/App.config
+++ b/src/Orchard.Tests/App.config
@@ -20,7 +20,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />

--- a/src/Orchard.Tests/Orchard.Framework.Tests.csproj
+++ b/src/Orchard.Tests/Orchard.Framework.Tests.csproj
@@ -108,8 +108,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.5.10.11092, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.5.10.11092\lib\nunit.framework.dll</HintPath>

--- a/src/Orchard.Tests/packages.config
+++ b/src/Orchard.Tests/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="NUnit" version="2.5.10.11092" targetFramework="net48" />
   <package id="NUnitTestAdapter" version="2.3.0" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web.Tests/app.config
+++ b/src/Orchard.Web.Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Core/Web.config
+++ b/src/Orchard.Web/Core/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Lucene/Web.config
+++ b/src/Orchard.Web/Modules/Lucene/Web.config
@@ -46,7 +46,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Markdown/Web.config
+++ b/src/Orchard.Web/Modules/Markdown/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Alias/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Alias/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.AntiSpam/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.AntiSpam/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.ArchiveLater/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.ArchiveLater/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Orchard.AuditTrail.csproj
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Orchard.AuditTrail.csproj
@@ -67,8 +67,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Web.config
@@ -48,7 +48,7 @@
             </dependentAssembly>
             <dependentAssembly>
                  <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                 <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                 <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
             </dependentAssembly>
             <dependentAssembly>
                  <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="XMLDiffPatch" version="1.0.8.28" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Web.config
@@ -46,7 +46,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Orchard.Azure.MediaServices.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Orchard.Azure.MediaServices.csproj
@@ -115,8 +115,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/Web.config
@@ -68,7 +68,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.Azure.MediaServices/packages.config
@@ -17,7 +17,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="Orchard.WindowsAzure.Diagnostics" version="2.7.0.0" targetFramework="net48" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.2.4" targetFramework="net48" />
   <package id="System.Spatial" version="5.8.4" targetFramework="net48" />

--- a/src/Orchard.Web/Modules/Orchard.Azure/Orchard.Azure.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Azure/Orchard.Azure.csproj
@@ -105,8 +105,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Orchard.Web/Modules/Orchard.Azure/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Azure/Web.config
@@ -71,7 +71,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Azure/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.Azure/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.WindowsAzure.Caching" version="2.4.0.0" targetFramework="net48" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="Orchard.WindowsAzure.ServiceRuntime" version="2.7.0.0" targetFramework="net48" />
   <package id="System.Spatial" version="5.8.4" targetFramework="net48" />
   <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net48" />

--- a/src/Orchard.Web/Modules/Orchard.Blogs/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Blogs/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Caching/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Caching/Web.config
@@ -41,7 +41,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.CodeGeneration/CodeGenerationTemplates/ModuleRootWebConfig.txt
+++ b/src/Orchard.Web/Modules/Orchard.CodeGeneration/CodeGenerationTemplates/ModuleRootWebConfig.txt
@@ -52,7 +52,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="NHibernate" publicKeyToken="AA95F207798DFDB4" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000"/>
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000"/>
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Iesi.Collections" publicKeyToken="AA95F207798DFDB4" culture="neutral"/>

--- a/src/Orchard.Web/Modules/Orchard.CodeGeneration/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.CodeGeneration/Web.config
@@ -41,7 +41,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Comments/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Comments/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Conditions/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Conditions/Web.config
@@ -44,7 +44,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.ContentPermissions/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.ContentPermissions/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Orchard.ContentPicker.csproj
@@ -65,8 +65,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Dashboards/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Dashboards/Web.config
@@ -48,7 +48,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.DesignerTools/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.DesignerTools/Web.config
@@ -48,7 +48,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.DynamicForms/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.DynamicForms/Web.config
@@ -50,7 +50,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Email/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Email/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Fields/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Forms/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Forms/Web.config
@@ -43,7 +43,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.ImageEditor/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.ImageEditor/Web.config
@@ -48,7 +48,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Orchard.ImportExport.csproj
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Orchard.ImportExport.csproj
@@ -67,8 +67,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/packages.config
@@ -7,5 +7,5 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.Indexing/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Indexing/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.JobsQueue/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.JobsQueue/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Layouts/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Layouts/Web.config
@@ -52,7 +52,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Lists/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Lists/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Localization/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Media/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Media/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Web.config
@@ -48,7 +48,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.MediaPicker/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.MediaPicker/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.MessageBus/Orchard.MessageBus.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MessageBus/Orchard.MessageBus.csproj
@@ -58,8 +58,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Orchard.Web/Modules/Orchard.MessageBus/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.MessageBus/Web.config
@@ -41,7 +41,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.MessageBus/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.MessageBus/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.Migrations/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Migrations/Web.config
@@ -41,7 +41,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Modules/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Modules/Web.config
@@ -46,7 +46,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.MultiTenancy/Orchard.MultiTenancy.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MultiTenancy/Orchard.MultiTenancy.csproj
@@ -67,8 +67,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations">

--- a/src/Orchard.Web/Modules/Orchard.MultiTenancy/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.MultiTenancy/Web.config
@@ -46,7 +46,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.MultiTenancy/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.MultiTenancy/packages.config
@@ -7,5 +7,5 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Packaging/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Packaging/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Pages/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Pages/Web.config
@@ -43,7 +43,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Orchard.Projections.csproj
@@ -65,8 +65,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Orchard.Web/Modules/Orchard.Projections/Tests/Orchard.Projections.Tests.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Tests/Orchard.Projections.Tests.csproj
@@ -49,8 +49,8 @@
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.5.10.11092, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\NUnit.2.5.10.11092\lib\nunit.framework.dll</HintPath>

--- a/src/Orchard.Web/Modules/Orchard.Projections/Tests/app.config
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Projections/Tests/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Tests/packages.config
@@ -4,6 +4,6 @@
   <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net48" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net48" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="NUnit" version="2.5.10.11092" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.Projections/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Projections/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.Projections/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.PublishLater/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.PublishLater/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Recipes/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Web.config
@@ -45,7 +45,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Redis/Orchard.Redis.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Redis/Orchard.Redis.csproj
@@ -58,8 +58,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\StackExchange.Redis.1.0.481\lib\net45\StackExchange.Redis.dll</HintPath>

--- a/src/Orchard.Web/Modules/Orchard.Redis/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Redis/Web.config
@@ -41,7 +41,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Redis/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.Redis/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="StackExchange.Redis" version="1.0.481" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.Resources/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Resources/Web.config
@@ -48,7 +48,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Roles/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Rules/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Rules/Web.config
@@ -50,7 +50,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Scripting.CSharp/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Scripting.CSharp/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Scripting.Dlr/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Scripting.Dlr/Web.config
@@ -41,7 +41,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Scripting/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Scripting/Web.config
@@ -41,7 +41,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Search/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Search/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.SecureSocketsLayer/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Setup/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Setup/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Tags/Orchard.Tags.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Tags/Orchard.Tags.csproj
@@ -65,8 +65,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Orchard.Web/Modules/Orchard.Tags/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Tags/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Tags/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.Tags/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.TaskLease/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.TaskLease/Web.config
@@ -41,7 +41,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Web.config
@@ -50,7 +50,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Templates/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Templates/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Themes/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Themes/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Tokens/Tests/app.config
+++ b/src/Orchard.Web/Modules/Orchard.Tokens/Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Tokens/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Tokens/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Users/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Users/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Warmup/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Warmup/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Widgets/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Widgets/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.Workflows/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.Workflows/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Orchard.jQuery/Web.config
+++ b/src/Orchard.Web/Modules/Orchard.jQuery/Web.config
@@ -47,7 +47,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/SysCache/SysCache.csproj
+++ b/src/Orchard.Web/Modules/SysCache/SysCache.csproj
@@ -56,8 +56,8 @@
       <HintPath>..\..\..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="NHibernate.Caches.SysCache2, Version=4.0.0.4000, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NHibernate.Caches.SysCache2.4.0.0.4000\lib\net40\NHibernate.Caches.SysCache2.dll</HintPath>

--- a/src/Orchard.Web/Modules/SysCache/Web.config
+++ b/src/Orchard.Web/Modules/SysCache/Web.config
@@ -41,7 +41,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/SysCache/packages.config
+++ b/src/Orchard.Web/Modules/SysCache/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="NHibernate.Caches.SysCache2" version="4.0.0.4000" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/TinyMce/Web.config
+++ b/src/Orchard.Web/Modules/TinyMce/Web.config
@@ -46,7 +46,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
+++ b/src/Orchard.Web/Modules/Upgrade/Upgrade.csproj
@@ -67,8 +67,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Orchard.Web/Modules/Upgrade/Web.config
+++ b/src/Orchard.Web/Modules/Upgrade/Web.config
@@ -53,7 +53,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Modules/Upgrade/packages.config
+++ b/src/Orchard.Web/Modules/Upgrade/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Themes/Web.config
+++ b/src/Orchard.Web/Themes/Web.config
@@ -70,7 +70,7 @@
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-                       <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+                       <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
                 </dependentAssembly>
                 <dependentAssembly>
                        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard.Web/Web.config
+++ b/src/Orchard.Web/Web.config
@@ -151,7 +151,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -89,8 +89,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.4.0.1.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.4.1.2.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="NHibernate.Linq, Version=1.1.0.1001, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Orchard/app.config
+++ b/src/Orchard/app.config
@@ -12,7 +12,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />

--- a/src/Orchard/packages.config
+++ b/src/Orchard/packages.config
@@ -15,6 +15,6 @@
   <package id="Microsoft.Owin" version="4.1.1" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="NHibernate" version="4.0.1.4000" targetFramework="net48" />
+  <package id="NHibernate" version="4.1.2.4000" targetFramework="net48" />
   <package id="Owin" version="1.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
We have been having a few weird exceptions related to nHibernate (looks to be something to do with concurrency) in one of our tenants lately. In an (ongoing) attempt to fix them, we updated nHibernate to the most recent nuget package to be fully compatible to everything in Orchard.