### PR TITLE
Fixes disposed LifetimeScope issue

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.OutputCache/Filters/OutputCacheFilter.cs
@@ -237,6 +237,7 @@ namespace Orchard.OutputCache.Filters {
                             return;
                         }
                         using (var scope = _workContextAccessor.CreateWorkContextScope()) {
+                            // ask for the WorkContext again so it refreshes in case the scope has been disposed
                             _workContext = _workContextAccessor.GetContext(filterContext.HttpContext);
                             var cachedOutput = ReplaceRequestVerificationTokenWithBeaconTag(output, response.ContentEncoding);
 
@@ -650,7 +651,6 @@ namespace Orchard.OutputCache.Filters {
         private bool PreventCachingRequestVerificationToken() {
             return _cacheSettings.CacheAuthenticatedRequests
                 && (!_cacheSettings.VaryByAuthenticationState
-                    // ask for the WorkContext again so it refreshes in case the scope has been disposed
                     || _workContext.CurrentUser != null);
         }
 


### PR DESCRIPTION
We found an issue where in some configurations a call to `_workContext.CurrentUser` would attempt to use an expired scope while computing what should be cached for the page. This PR fixes that by ensuring the available WorkContext is refreshed.