### PR TITLE
Force enumeration of list of permissions when importing roles

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Roles/Recipes/Executors/RolesStep.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Recipes/Executors/RolesStep.cs
@@ -40,7 +40,7 @@ namespace Orchard.Roles.Recipes.Executors {
                     var permissionsValid = permissions.Where(permission => installedPermissions.Any(x => x.Name == permission)).ToList();
 
                     // Union to keep existing permissions.
-                    _roleService.UpdateRole(role.Id, role.Name, permissionsValid.Union(role.RolesPermissions.Select(p => p.Permission.Name)));
+                    _roleService.UpdateRole(role.Id, role.Name, permissionsValid.Union(role.RolesPermissions.Select(p => p.Permission.Name)).ToList());
                 }
                 catch (Exception ex) {
                     Logger.Error(ex, "Error while importing role '{0}'.", roleName);


### PR DESCRIPTION
Force enumeration of list of permissions. Without this, imported permissions would always replace existing ones: i.e. if an existing permission is not in the list being imported it would be removed for the role.