### PR TITLE
Remove whitespace when importing list of permissions

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Roles/Recipes/Executors/RolesStep.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Recipes/Executors/RolesStep.cs
@@ -35,7 +35,7 @@ namespace Orchard.Roles.Recipes.Executors {
                         role = _roleService.GetRoleByName(roleName);
                     }
 
-                    var permissions = roleElement.Attribute("Permissions").Value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    var permissions = roleElement.Attribute("Permissions").Value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(value => value.Trim());
                     // Only import permissions for currenlty installed modules.
                     var permissionsValid = permissions.Where(permission => installedPermissions.Any(x => x.Name == permission)).ToList();
 


### PR DESCRIPTION
Similarly to what's already being done when we import features.
this allows to go to a new line in the xml that we import, and even tabulate for readability and maintenance.