### PR TITLE
Fixed various typos

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/DefinitionTemplates/MediaLibraryPickerFieldLocalizationSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/DefinitionTemplates/MediaLibraryPickerFieldLocalizationSettings.cshtml
@@ -7,7 +7,7 @@
     <div data-controllerid="@Html.FieldIdFor(m => m.TryToLocalizeMedia)">
         @Html.CheckBoxFor(m => m.RemoveItemsWithoutLocalization)
         <label for="@Html.FieldIdFor(m => m.RemoveItemsWithoutLocalization)" class="forcheckbox">@T("Remove items that do not have the correct translation.")</label>
-        <span class="hint">@T("Check to remove media items from the MediaLibraryPickerField when the items selected do not have a version in the correct culture (they have a LocalizationPart, but not a translation in the main ContentItem's culture').")</span>
+        <span class="hint">@T("Check to remove media items from the MediaLibraryPickerField when the items selected do not have a version in the correct culture (they have a LocalizationPart, but not a translation in the main ContentItem's culture).")</span>
         @Html.CheckBoxFor(m => m.RemoveItemsWithNoLocalizationPart)
         <label for="@Html.FieldIdFor(m => m.RemoveItemsWithNoLocalizationPart)" class="forcheckbox">@T("Remove items that cannot be localized.")</label>
         <span class="hint">@T("Check to remove media items from the MediaLibraryPickerField when the items selected cannot be localized (do not have a LocalizationPart).")</span>

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/DefinitionTemplates/TaxonomyFieldLocalizationSettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/DefinitionTemplates/TaxonomyFieldLocalizationSettings.cshtml
@@ -3,5 +3,5 @@
     <label>@T("Localization")</label>
     @Html.CheckBoxFor(m => m.TryToLocalize)
     <label for="@Html.FieldIdFor(m => m.TryToLocalize)" class="forcheckbox">@T("Try to translate the selected terms")</label>
-    <span class="hint">@T("Check to attempt to replace the selected terms with their translation in the main content culture when saving. This only applies if the main content has a LocalizationPart. If term as not translation on content culture then term will be removed.")</span>
+    <span class="hint">@T("Check to attempt to replace the selected terms with their translation in the main content culture when saving. This only applies if the main content has a LocalizationPart. If term has no translation on content culture then term will be removed.")</span>
 </fieldset>

--- a/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Upgrade/Controllers/TaxonomyController.cs
@@ -64,7 +64,7 @@ namespace Upgrade.Controllers {
             ViewBag.CanMigrate = false;
 
             if (_featureManager.GetEnabledFeatures().All(x => x.Id != "Orchard.Taxonomies")) {
-                _orchardServices.Notifier.Warning(T("You need to enable Orchard.Taxonomies in upgrade the terms' weights."));
+                _orchardServices.Notifier.Warning(T("You need to enable Orchard.Taxonomies in order to upgrade the terms' weights."));
             } else {
                 ViewBag.CanMigrate = true;
             }


### PR DESCRIPTION
While translating strings, I found some typos in Orchard localized strings. This PR is to correct those typos.