### PR TITLE
Added descriptor to context

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Services/AuditTrailManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Services/AuditTrailManager.cs
@@ -173,7 +173,8 @@ namespace Orchard.AuditTrail.Services {
                 Properties = properties,
                 EventData = eventData,
                 EventFilterKey = eventFilterKey,
-                EventFilterData = eventFilterData
+                EventFilterData = eventFilterData,
+                EventDescriptor = eventDescriptor
             };
 
             _auditTrailEventHandlers.Create(context);

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Services/Models/AuditTrailContext.cs
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Services/Models/AuditTrailContext.cs
@@ -13,5 +13,6 @@ namespace Orchard.AuditTrail.Services.Models {
         public IDictionary<string, object> EventData { get; set; }
         public string EventFilterKey { get; set; }
         public string EventFilterData { get; set; }
+        public AuditTrailEventDescriptor EventDescriptor { get; set; }
     }
 }


### PR DESCRIPTION
Added the EventDescriptor as a property to the AuditTrailContext. This allows handlers to know something about the source of the event that is being logged for audit.

A lot of the details of the event are contained in that descriptor. As it is now live, handlers have no clean way to figure that information out. With this PR, the information is passed along in the context.