### PR TITLE
Fix to replace media when original file has been deleted from filesystem

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/ClientStorageController.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/ClientStorageController.cs
@@ -178,7 +178,14 @@ namespace Orchard.MediaLibrary.Controllers {
                                                                 .Where(x => x.FolderPath == replaceMedia.FolderPath && x.FileName == replaceMedia.FileName)
                                                                 .Count();
                     if (mediaItemsUsingTheFile == 1) { // if the file is referenced only by the deleted media content, the file too can be removed.
-                        _mediaLibraryService.DeleteFile(replaceMedia.FolderPath, replaceMedia.FileName);
+                        try {
+                            _mediaLibraryService.DeleteFile(replaceMedia.FolderPath, replaceMedia.FileName);
+                        } catch (ArgumentException) { // File not found by FileSystemStorageProvider is thrown as ArgumentException.
+                            statuses.Add(new {
+                                error = T("Error when deleting file to replace: file {0} does not exist in folder {1}. Media has been updated anyway.", replaceMedia.FileName, replaceMedia.FolderPath).Text,
+                                progress = 1.0
+                            });
+                        }
                     }
                     else {
                         // it changes the media file name

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/ClientStorageController.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/ClientStorageController.cs
@@ -186,8 +186,7 @@ namespace Orchard.MediaLibrary.Controllers {
                                 progress = 1.0
                             });
                         }
-                    }
-                    else {
+                    } else {
                         // it changes the media file name
                         replaceMedia.FileName = filename;
                     }


### PR DESCRIPTION
Referencing issue #8554 
Added a try-catch statement around MediaLibraryService.DeleteFile call inside Replace action. ArgumentException thrown by FileSystemStorageProvider.DeleteFile in case the original file is missing interrupted the actual replace of the media, making how to solve this uncommon scenario unclear to the back office operator (he needed to delete the original media and import another media with the exact same name to make it work properly again). With this patch now the replace operation isn't stopped anymore, adding to the status message hints to the anomaly ("can't delete original file") but completing the replacement of the "broken" file.