### PR TITLE
8557 check valid taxonomy

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -223,6 +223,10 @@ namespace Orchard.Taxonomies.Services {
         }
 
         public TermPart GetTerm(int id) {
+            // If term id isn't valid, return null without executing the query.
+            if (id <= 0) {
+                return null;
+            }
             return GetTermsQuery()
                 .Where(x => x.Id == id).List().FirstOrDefault();
         }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -64,10 +64,6 @@ namespace Orchard.Taxonomies.Services {
         }
 
         public virtual TaxonomyPart GetTaxonomy(int id) {
-            // If id isn't valid, return null without executing the query.
-            if (id <= 0) {
-                return null;
-            }
             return _contentManager.Get(id, VersionOptions.Published).As<TaxonomyPart>();
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -64,6 +64,10 @@ namespace Orchard.Taxonomies.Services {
         }
 
         public virtual TaxonomyPart GetTaxonomy(int id) {
+            // If id isn't valid, return null without executing the query.
+            if (id <= 0) {
+                return null;
+            }
             return _contentManager.Get(id, VersionOptions.Published).As<TaxonomyPart>();
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -169,6 +169,10 @@ namespace Orchard.Taxonomies.Services {
         }
 
         public IEnumerable<TermPart> GetTerms(int taxonomyId) {
+            // If taxonomyId isn't valid, return a empty list without executing the query.
+            if (taxonomyId <= 0) {
+                return new List<TermPart>();
+            }
             var result = GetTermsQuery(taxonomyId)
                 .OrderBy(x => x.FullWeight)
                 .List();
@@ -177,6 +181,10 @@ namespace Orchard.Taxonomies.Services {
         }
 
         public IEnumerable<TermPart> GetRootTerms(int taxonomyId) {
+            // If taxonomyId isn't valid, return a empty list without executing the query.
+            if (taxonomyId <= 0) {
+                return new List<TermPart>();
+            }
             var result = GetTermsQuery(taxonomyId)
                 .Where(x => x.Path == "/")
                 .OrderBy(x => x.FullWeight)
@@ -202,6 +210,10 @@ namespace Orchard.Taxonomies.Services {
         }
 
         public int GetTermsCount(int taxonomyId) {
+            // If taxonomyId isn't valid, return 0 without executing the query.
+            if (taxonomyId <= 0) {
+                return 0;
+            }
             return GetTermsQuery(taxonomyId)
                 .Count();
         }
@@ -231,6 +243,10 @@ namespace Orchard.Taxonomies.Services {
         }
 
         public TermPart GetTermByName(int taxonomyId, string name) {
+            // If taxonomyId isn't valid, return null without executing the query.
+            if (taxonomyId <= 0) {
+                return null;
+            }
             return GetTermsQuery(taxonomyId)
                 .Join<TitlePartRecord>()
                 .Where(r => r.Title == name)

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyService.cs
@@ -171,7 +171,7 @@ namespace Orchard.Taxonomies.Services {
         public IEnumerable<TermPart> GetTerms(int taxonomyId) {
             // If taxonomyId isn't valid, return a empty list without executing the query.
             if (taxonomyId <= 0) {
-                return new List<TermPart>();
+                return Array.Empty<TermPart>();
             }
             var result = GetTermsQuery(taxonomyId)
                 .OrderBy(x => x.FullWeight)
@@ -183,7 +183,7 @@ namespace Orchard.Taxonomies.Services {
         public IEnumerable<TermPart> GetRootTerms(int taxonomyId) {
             // If taxonomyId isn't valid, return a empty list without executing the query.
             if (taxonomyId <= 0) {
-                return new List<TermPart>();
+                return Array.Empty<TermPart>();
             }
             var result = GetTermsQuery(taxonomyId)
                 .Where(x => x.Path == "/")

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyServiceDraftable.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyServiceDraftable.cs
@@ -53,10 +53,6 @@ namespace Orchard.Taxonomies.Services {
         }
         
         public override TaxonomyPart GetTaxonomy(int id) {
-            // If id isn't valid, return null without executing the query.
-            if (id <= 0) {
-                return null;
-            }
             return _contentManager.Get(id, VersionOptions.Latest).As<TaxonomyPart>();
         }
         

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyServiceDraftable.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Services/TaxonomyServiceDraftable.cs
@@ -53,6 +53,10 @@ namespace Orchard.Taxonomies.Services {
         }
         
         public override TaxonomyPart GetTaxonomy(int id) {
+            // If id isn't valid, return null without executing the query.
+            if (id <= 0) {
+                return null;
+            }
             return _contentManager.Get(id, VersionOptions.Latest).As<TaxonomyPart>();
         }
         


### PR DESCRIPTION
#8557 
Added id checks on every function executing queries on taxonomy or term id to avoid executing the query when the parameter is not valid (id <= 0) and avoid some queries when they would clearly return a empty result.
This mostly is a sanity check but, in some scenario, id = 0 is passed as a parameter and a query on the database is executed, giving no results.