### PR TITLE
8599 nullable field values

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/BooleanFieldDriver.cs
@@ -67,7 +67,7 @@ namespace Orchard.Fields.Drivers {
 
         protected override void Describe(DescribeMembersContext context) {
             context
-                .Member(null, typeof(Boolean), T("Value"), T("The boolean value of the field."))
+                .Member(null, typeof(Boolean?), T("Value"), T("The boolean value of the field."))
                 .Enumerate<BooleanField>(() => field => new [] { field.Value })
                 ;
         }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
@@ -111,7 +111,7 @@ namespace Orchard.Fields.Drivers {
 
         protected override void Describe(DescribeMembersContext context) {
             context
-                .Member(null, typeof(decimal?), T("Value"), T("The value of the field."))
+                .Member(null, typeof(decimal), T("Value"), T("The value of the field."))
                 .Enumerate<NumericField> (() => field => new[] { field.Value });
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
@@ -111,7 +111,7 @@ namespace Orchard.Fields.Drivers {
 
         protected override void Describe(DescribeMembersContext context) {
             context
-                .Member(null, typeof(decimal), T("Value"), T("The value of the field."))
+                .Member(null, typeof(decimal?), T("Value"), T("The value of the field."))
                 .Enumerate<NumericField> (() => field => new[] { field.Value });
         }
     }


### PR DESCRIPTION
This solves #8599 treating the value member of DescribeMemberContext as a nullable Boolean instead then a standard Boolean.