### PR TITLE
Profile path too long when processing images

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Services/ImageProfileManager.cs
@@ -171,6 +171,8 @@ namespace Orchard.MediaProcessing.Services {
                                             }
                                         }
                                     }
+                                    // the storage provider may have altered the filepath
+                                    filterContext.FilePath = newFile.GetPath();
                                 }
                             }
                             catch(Exception e) {

--- a/src/Orchard/FileSystems/Media/FileSystemStorageProvider.cs
+++ b/src/Orchard/FileSystems/Media/FileSystemStorageProvider.cs
@@ -34,9 +34,26 @@ namespace Orchard.FileSystems.Media {
             _publicPath = appPath + "Media/" + settings.Name + "/";
 
             T = NullLocalizer.Instance;
+            MaxPathLength = 260;
         }
 
         public Localizer T { get; set; }
+
+        public int MaxPathLength {
+            get; set;
+            // The public setter allows injecting this from Sites.MyTenant.Config or Sites.config, by using
+            // an AutoFac component:
+            /*
+             <component instance-scope="per-lifetime-scope"
+                type="Orchard.FileSystems.Media.FileSystemStorageProvider, Orchard.Framework"
+                service="Orchard.FileSystems.Media.IStorageProvider">
+                <properties>
+                    <property name="MaxPathLength" value="500" />
+                </properties>
+            </component>
+
+             */
+        }
 
         /// <summary>
         /// Maps a relative path into the storage path.
@@ -334,6 +351,17 @@ namespace Orchard.FileSystems.Media {
             var dirName = Path.GetDirectoryName(fileInfo.FullName);
             if (!Directory.Exists(dirName)) {
                 Directory.CreateDirectory(dirName);
+            }
+            //Path.GetFileNameWithoutExtension(fileInfo.Name)
+            // If absolute path is longer than the maximum path length (260 characters), file cannot be saved.
+            if (fileInfo.FullName.Length > MaxPathLength) {
+                var fileName = Path.GetFileNameWithoutExtension(fileInfo.Name);
+                var extension = fileInfo.Extension;
+                // try to generate a shorter path for the file
+                var nameHash = fileName.GetHashCode().ToString("x");
+                // Hopefully this new path is short enough now
+                path = Combine(Path.GetDirectoryName(path), nameHash + extension);
+                fileInfo = new FileInfo(MapStorage(path));
             }
             File.WriteAllBytes(fileInfo.FullName, new byte[0]);
 


### PR DESCRIPTION
Reference issue #8602 

When generating a image profile, sometimes resulting path can be very long, especially when a user imports a media with a very long file name. As described into the referenced issue, this can throw exceptions and stop Orchard from processing, for instance, resized images displayed as thumbnails in the media gallery.
Since profile folders are already hashed, when file name is too long I hashed it the same way, eventually trimming it even more in extreme cases (this may happen when path is really long even before appending the file name).