### PR TITLE
Logon crash when checking if password is expired

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Controllers/AccountController.cs
@@ -332,7 +332,11 @@ namespace Orchard.Users.Controllers {
             var membershipSettings = _membershipService.GetSettings();
             var userPart = _membershipService.GetUser(username).As<UserPart>();
             var lastPasswordChangeUtc = userPart.LastPasswordChangeUtc;
-            if (lastPasswordChangeUtc.Value.AddDays(membershipSettings.PasswordExpirationTimeInDays) > _clock.UtcNow &&
+            // If there is no last password change date, use user creation date.
+            if (lastPasswordChangeUtc == null) {
+                lastPasswordChangeUtc = userPart.CreatedUtc;
+            }
+            if (lastPasswordChangeUtc != null && lastPasswordChangeUtc.Value.AddDays(membershipSettings.PasswordExpirationTimeInDays) > _clock.UtcNow &&
                     !userPart.ForcePasswordChange) {
                 return RedirectToAction("LogOn");
             }

--- a/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
@@ -171,13 +171,14 @@ namespace Orchard.Users.Services {
             // Null check on LastPasswordChangeUtc.
             // If this is null, use CreatedUtc as if it's the last password change date.
             // If both are null, consider the password to be expired.
-            var date = user.As<UserPart>().LastPasswordChangeUtc.Value;
-            if (date == null) {
-                date = user.As<UserPart>().CreatedUtc.Value;
-            }
             var passwordIsExpired = true;
+            DateTime? date = null;
+            date = user.As<UserPart>().LastPasswordChangeUtc;                       
+            if (date == null) {
+                date = user.As<UserPart>().CreatedUtc;
+            }
             if (date != null) {
-                passwordIsExpired = date.AddDays(days) < _clock.UtcNow;
+                passwordIsExpired = date.Value.AddDays(days) < _clock.UtcNow;
             }
             var securityPart = user.As<UserSecurityConfigurationPart>();
             var preventExpiration = securityPart != null && securityPart.PreventPasswordExpiration;

--- a/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Services/MembershipService.cs
@@ -167,7 +167,18 @@ namespace Orchard.Users.Services {
 
         public bool PasswordIsExpired(IUser user, int days) {
             // TODO: add providers to extend this
-            var passwordIsExpired = user.As<UserPart>().LastPasswordChangeUtc.Value.AddDays(days) < _clock.UtcNow;
+
+            // Null check on LastPasswordChangeUtc.
+            // If this is null, use CreatedUtc as if it's the last password change date.
+            // If both are null, consider the password to be expired.
+            var date = user.As<UserPart>().LastPasswordChangeUtc.Value;
+            if (date == null) {
+                date = user.As<UserPart>().CreatedUtc.Value;
+            }
+            var passwordIsExpired = true;
+            if (date != null) {
+                passwordIsExpired = date.AddDays(days) < _clock.UtcNow;
+            }
             var securityPart = user.As<UserSecurityConfigurationPart>();
             var preventExpiration = securityPart != null && securityPart.PreventPasswordExpiration;
             return passwordIsExpired


### PR DESCRIPTION
#8623 

Added null check for last password change date. If that is null, use user creation date to check for password expiration.