### PR TITLE
Prevent caching GetTaxonomy Action

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -34,6 +34,7 @@ namespace Orchard.Taxonomies.Controllers {
             _localizationService = localizationService;
         }
 
+        [OutputCache(NoStore = true, Duration = 0)]
         public ActionResult GetTaxonomy(string contentTypeName, string taxonomyFieldName, int contentId, string culture) {
             var viewModel = new TaxonomyFieldViewModel();
             bool autocomplete = false;


### PR DESCRIPTION
That action is called by LocalizedTaxonomyField editor view and need to not serve cached data