### PR TITLE
Fix for issue 8631: field values are reset when imported

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldDriver.cs
@@ -108,9 +108,7 @@ namespace Orchard.ContentPicker.Drivers {
                     .Select(context.GetItemFromSession)
                     .Select(contentItem => contentItem.Id).ToArray();
             }
-            else {
-                field.Ids = new int[0];
-            }
+            // If nothing about the field is inside the context, field is not modified.
         }
 
         protected override void Exporting(ContentPart part, Fields.ContentPickerField field, ExportContentContext context) {

--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Drivers/ContentPickerFieldDriver.cs
@@ -89,8 +89,7 @@ namespace Orchard.ContentPicker.Drivers {
 
             if (String.IsNullOrEmpty(model.SelectedIds)) {
                 field.Ids = new int[0];
-            }
-            else {
+            } else {
                 field.Ids = model.SelectedIds.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToArray();
             }
 
@@ -102,13 +101,19 @@ namespace Orchard.ContentPicker.Drivers {
         }
 
         protected override void Importing(ContentPart part, Fields.ContentPickerField field, ImportContentContext context) {
-            var contentItemIds = context.Attribute(field.FieldDefinition.Name + "." + field.Name, "ContentItems");
-            if (contentItemIds != null) {
-                field.Ids = contentItemIds.Split(',')
-                    .Select(context.GetItemFromSession)
-                    .Select(contentItem => contentItem.Id).ToArray();
-            }
             // If nothing about the field is inside the context, field is not modified.
+            // For this reason, check if the current element is inside the ImportContentContext.
+            var element = context.Data.Element(field.FieldDefinition.Name + "." + field.Name);
+            if (element != null) {
+                var contentItemIds = context.Attribute(field.FieldDefinition.Name + "." + field.Name, "ContentItems");
+                if (contentItemIds != null) {
+                    field.Ids = contentItemIds.Split(',')
+                        .Select(context.GetItemFromSession)
+                        .Select(contentItem => contentItem.Id).ToArray();
+                } else {
+                    field.Ids = new int[0];
+                }
+            }
         }
 
         protected override void Exporting(ContentPart part, Fields.ContentPickerField field, ExportContentContext context) {

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/NumericFieldDriver.cs
@@ -102,7 +102,13 @@ namespace Orchard.Fields.Drivers {
         }
 
         protected override void Importing(ContentPart part, NumericField field, ImportContentContext context) {
-            context.ImportAttribute(field.FieldDefinition.Name + "." + field.Name, "Value", v => field.Value = decimal.Parse(v, CultureInfo.InvariantCulture), () => field.Value = (decimal?)null);
+            Action empty = (() => field.Value = (decimal?)null);
+            var element = context.Data.Element(field.FieldDefinition.Name + "." + field.Name);
+            // If element is not in the ImportContentContext, field must not be reset.
+            if (element == null) {
+                empty = () => { };
+            }
+            context.ImportAttribute(field.FieldDefinition.Name + "." + field.Name, "Value", v => field.Value = decimal.Parse(v, CultureInfo.InvariantCulture), empty);
         }
 
         protected override void Exporting(ContentPart part, NumericField field, ExportContentContext context) {

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
@@ -78,9 +78,7 @@ namespace Orchard.MediaLibrary.Drivers {
                     .Select(context.GetItemFromSession)
                     .Select(contentItem => contentItem.Id).ToArray();
             }
-            else {
-                field.Ids = new int[0];
-            }
+            // If nothing about the field is inside the context, field is not modified.
         }
 
         protected override void Exporting(ContentPart part, Fields.MediaLibraryPickerField field, ExportContentContext context) {

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Drivers/MediaLibraryPickerFieldDriver.cs
@@ -72,13 +72,21 @@ namespace Orchard.MediaLibrary.Drivers {
         }
 
         protected override void Importing(ContentPart part, Fields.MediaLibraryPickerField field, ImportContentContext context) {
-            var contentItemIds = context.Attribute(field.FieldDefinition.Name + "." + field.Name, "ContentItems");
-            if (contentItemIds != null) {
-                field.Ids = contentItemIds.Split(',')
-                    .Select(context.GetItemFromSession)
-                    .Select(contentItem => contentItem.Id).ToArray();
-            }
             // If nothing about the field is inside the context, field is not modified.
+            // For this reason, check if the current element is inside the ImportContentContext.
+            var element = context.Data.Element(field.FieldDefinition.Name + "." + field.Name);
+            if (element != null) {
+                var contentItemIds = context.Attribute(field.FieldDefinition.Name + "." + field.Name, "ContentItems");
+                if (contentItemIds != null) {
+                    if (!string.IsNullOrWhiteSpace(contentItemIds)) {
+                        field.Ids = contentItemIds.Split(',')
+                            .Select(context.GetItemFromSession)
+                            .Select(contentItem => contentItem.Id).ToArray();
+                    }
+                } else {
+                    field.Ids = new int[0];
+                }
+            }
         }
 
         protected override void Exporting(ContentPart part, Fields.MediaLibraryPickerField field, ExportContentContext context) {


### PR DESCRIPTION
This fixes #8631 , adding a check on the existence of the importing element inside the context. If the field isn't inside the context, the field is not imported (previously its value was being reset).
