### PR TITLE
Updated SharpZipLib to 1.3.3

### DIFF
--- a/src/Orchard.Tests.Modules/Orchard.Tests.Modules.csproj
+++ b/src/Orchard.Tests.Modules/Orchard.Tests.Modules.csproj
@@ -74,8 +74,8 @@
     <Reference Include="FluentPath, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Orchard.FluentPath.1.0.0.1\lib\FluentPath.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.1.9, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.1.3.1\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.3.11, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.1.3.3\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>

--- a/src/Orchard.Tests.Modules/packages.config
+++ b/src/Orchard.Tests.Modules/packages.config
@@ -17,5 +17,5 @@
   <package id="NUnit" version="2.5.10.11092" targetFramework="net48" />
   <package id="Orchard.FluentPath" version="1.0.0.1" targetFramework="net48" />
   <package id="Orchard.NuGet.Core" version="1.1.0.0" targetFramework="net48" />
-  <package id="SharpZipLib" version="1.3.1" targetFramework="net48" />
+  <package id="SharpZipLib" version="1.3.3" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Lucene/Lucene.csproj
+++ b/src/Orchard.Web/Modules/Lucene/Lucene.csproj
@@ -55,8 +55,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.1.9, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\SharpZipLib.1.3.1\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.3.11, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\SharpZipLib.1.3.3\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>

--- a/src/Orchard.Web/Modules/Lucene/packages.config
+++ b/src/Orchard.Web/Modules/Lucene/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
-  <package id="SharpZipLib" version="1.3.1" targetFramework="net48" />
+  <package id="SharpZipLib" version="1.3.3" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
https://github.com/advisories/GHSA-m22m-h4rf-pwq3

Solution to the vulnerability in reference. SharpZipLib is referenced by Lucene.