### PR TITLE
Added sequential upload parameter to fileupload() parameters when importing media

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Models/MediaLibrarySettingsPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Models/MediaLibrarySettingsPart.cs
@@ -13,6 +13,11 @@ namespace Orchard.MediaLibrary.Models {
             set { this.Store(x => x.UploadAllowedFileTypeWhitelist, value); }
         }
 
+        public int LimitConcurrentUploads {
+            get { return this.Retrieve(x => x.LimitConcurrentUploads); }
+            set { this.Store(x => x.LimitConcurrentUploads, value); }
+        }
+
         public bool IsFileAllowed(string filename) {
 
             var allowedExtensions = (UploadAllowedFileTypeWhitelist ?? "")

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/ClientStorage/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/ClientStorage/Index.cshtml
@@ -1,4 +1,7 @@
-﻿@model Orchard.MediaLibrary.ViewModels.ImportMediaViewModel
+﻿@using Orchard.MediaLibrary.Models;
+@using Orchard.ContentManagement;
+
+@model Orchard.MediaLibrary.ViewModels.ImportMediaViewModel
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -12,6 +15,8 @@
 
         Script.Require("jQueryFileUpload").AtFoot();
         Script.Require("Knockout").AtFoot();
+
+        var settings = WorkContext.CurrentSite.As<MediaLibrarySettingsPart>();
     }
 
     @Display.Metas()
@@ -23,7 +28,7 @@
     <div id="clientstorage-main">
         <div id="message">@T("Click here, Drop files or Paste images")</div>
         <div id="fileupload">
-            <input type="file" name="files[]" @if(Model.Replace == null) { <text>multiple="multiple"</text> } >
+            <input type="file" name="files[]" @if (Model.Replace == null) {<text>multiple="multiple" </text>} />
             <ul id="fileupload-transfers" data-bind="foreach: transfers">
                 <li data-bind="css: status()" class="transfer">
                     <div class="media-thumbnail" data-bind="html: thumbnail(), visible: status() == 'success'"></div>
@@ -36,9 +41,9 @@
             </ul>
         </div>
     </div>
-        
+
     @using (Script.Foot()) {
-    <script type="text/javascript">
+        <script type="text/javascript">
         //<![CDATA[
         $(function () {
 
@@ -80,7 +85,7 @@
             // Add drag-n-drop HTML5 support
             $('#fileupload').fileupload({
                 autoUpload: true,
-                sequentialUploads: true,
+                @((settings.LimitConcurrentUploads != null && settings.LimitConcurrentUploads > 0) ? "limitConcurrentUploads:" + settings.LimitConcurrentUploads + "," : "")
                 @if(Model.Replace == null) {
                 <text>
                 url: '@Url.Action("Upload")',
@@ -171,9 +176,9 @@
             });
         })
         //]]>
-    </script>
+        </script>
     }
-    
+
     @Display.FootScripts()
 </body>
 </html>

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/ClientStorage/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/ClientStorage/Index.cshtml
@@ -80,6 +80,7 @@
             // Add drag-n-drop HTML5 support
             $('#fileupload').fileupload({
                 autoUpload: true,
+                sequentialUploads: true,
                 @if(Model.Replace == null) {
                 <text>
                 url: '@Url.Action("Upload")',

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/EditorTemplates/Parts/MediaLibrary.MediaLibrarySettings.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/EditorTemplates/Parts/MediaLibrary.MediaLibrarySettings.cshtml
@@ -6,5 +6,8 @@
         <label for="@Html.IdFor(m => m.UploadAllowedFileTypeWhitelist)">@T("Accepted file extensions")</label>
         @Html.TextBoxFor(m => m.UploadAllowedFileTypeWhitelist, new { @class = "text large"})
         <span class="hint">@T("A comma separated list of file extensions, e.g., \".jpg, .avi, .txt\". Leave empty to accept any file types.")</span>
+        <label for="@Html.IdFor(m => m.LimitConcurrentUploads)">@T("Concurrent uploads limit")</label>
+        @Html.TextBoxFor(m => m.LimitConcurrentUploads, new { @class = "text medium"})
+        <span class="hint">@T("To limit the number of concurrent uploads, set this value to an integer greater than 0")</span>
     </div>
 </fieldset>


### PR DESCRIPTION
To solve issue #8648 , added "sequentialUploads" parameter to fileupload options. This forces the files to be uploaded sequentially, avoiding the "progress bar stuck" problem and shortening upload times when importing multiple files.