### PR TITLE
Null check on menu before adding alternates with menu name and level

### DIFF
--- a/src/Orchard.Web/Core/Shapes/CoreShapes.cs
+++ b/src/Orchard.Web/Core/Shapes/CoreShapes.cs
@@ -101,8 +101,10 @@ namespace Orchard.Core.Shapes {
                     int level = menuItem.Level;
 
                     menuItem.Metadata.Alternates.Add("MenuItem__level__" + level);
-                    menuItem.Metadata.Alternates.Add("MenuItem__" + EncodeAlternateElement(menu.MenuName));
-                    menuItem.Metadata.Alternates.Add("MenuItem__" + EncodeAlternateElement(menu.MenuName) + "__level__" + level);
+                    if (menu != null) {
+                        menuItem.Metadata.Alternates.Add("MenuItem__" + EncodeAlternateElement(menu.MenuName));
+                        menuItem.Metadata.Alternates.Add("MenuItem__" + EncodeAlternateElement(menu.MenuName) + "__level__" + level);
+                    }
                 });
 
             builder.Describe("MenuItemLink")


### PR DESCRIPTION
To solve #8654 added a null check before adding alternates based on menu name and menu level.