### PR TITLE
8657 roleactivities: adds role event activities and handlers for workflows

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Roles/Activities/RoleEventActivity.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Activities/RoleEventActivity.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using Orchard.Localization;
+using Orchard.Workflows.Models;
+using Orchard.Workflows.Services;
+
+namespace Orchard.Roles.Activities {
+    public class RoleEventActivity : Event {
+        public Localizer T { get; set; }
+
+        public RoleEventActivity() {
+            T = NullLocalizer.Instance;
+        }
+
+        public override bool CanStartWorkflow {
+            get { return true; }
+        }
+
+        public override string Name {
+            get {
+                return "OnRoleEvent";
+            }
+        }
+
+        public override LocalizedString Category {
+            get {
+                return T("Roles");
+            }
+        }
+
+        public override LocalizedString Description {
+            get {
+                return T("Manage Role Event");
+            }
+        }
+
+        public override IEnumerable<LocalizedString> Execute(WorkflowContext workflowContext, ActivityContext activityContext) {
+            string operatore = workflowContext.Tokens["Action"].ToString();
+            LocalizedString msg = T(operatore);
+            yield return msg;
+        }
+
+        public override IEnumerable<LocalizedString> GetPossibleOutcomes(WorkflowContext workflowContext, ActivityContext activityContext) {
+            return new[] {
+                T("Created"),
+                T("Removed"),
+                T("Renamed"),
+                T("UserAdded"),
+                T("UserRemoved"),
+                T("PermissionAdded"),
+                T("PermissionRemoved")
+            };
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Roles/Events/RoleEventHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Events/RoleEventHandler.cs
@@ -53,8 +53,10 @@ namespace Orchard.Roles.Events {
         }
 
         public void UserAdded(UserAddedContext context) {
+            // Content of workflow event is the user
+            var content = context.User.ContentItem;
             _workflowManager.TriggerEvent("OnRoleEvent",
-                null,
+                content,
                 () => new Dictionary<string, object> {
                     { "Role", context.Role },
                     { "User", context.User },
@@ -62,8 +64,10 @@ namespace Orchard.Roles.Events {
         }
 
         public void UserRemoved(UserRemovedContext context) {
+            // Content of workflow event is the user
+            var content = context.User.ContentItem;
             _workflowManager.TriggerEvent("OnRoleEvent",
-               null,
+               content,
                () => new Dictionary<string, object> {
                     { "Role", context.Role },
                     { "User", context.User },

--- a/src/Orchard.Web/Modules/Orchard.Roles/Events/RoleEventHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Events/RoleEventHandler.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Orchard.Workflows.Services;
+
+namespace Orchard.Roles.Events {
+    public class RoleEventHandler : IRoleEventHandler {
+        private readonly IWorkflowManager _workflowManager;
+
+        public RoleEventHandler(IWorkflowManager workflowManager) {
+            _workflowManager = workflowManager;
+        }
+
+        public void Created(RoleCreatedContext context) {
+            _workflowManager.TriggerEvent("OnRoleEvent",
+               null,
+               () => new Dictionary<string, object> {
+                    { "Role", context.Role },
+                    { "Action", "RoleCreated" } });
+        }
+
+        public void PermissionAdded(PermissionAddedContext context) {
+            _workflowManager.TriggerEvent("OnRoleEvent",
+               null,
+               () => new Dictionary<string, object> {
+                    { "Role", context.Role },
+                    { "Permission", context.Permission },
+                    { "Action", "PermissionAdded" } });
+        }
+
+        public void PermissionRemoved(PermissionRemovedContext context) {
+            _workflowManager.TriggerEvent("OnRoleEvent",
+               null,
+               () => new Dictionary<string, object> {
+                    { "Role", context.Role },
+                    { "Permission", context.Permission },
+                    { "Action", "PermissionRemoved" } });
+        }
+
+        public void Removed(RoleRemovedContext context) {
+            _workflowManager.TriggerEvent("OnRoleEvent",
+               null,
+               () => new Dictionary<string, object> {
+                    { "Role", context.Role },
+                    { "Action", "RoleRemoved" } });
+        }
+
+        public void Renamed(RoleRenamedContext context) {
+            _workflowManager.TriggerEvent("OnRoleEvent",
+               null,
+               () => new Dictionary<string, object> {
+                    { "PreviousName", context.PreviousRoleName },
+                    { "NewName", context.NewRoleName },
+                    { "Action", "RoleRenamed" } });
+        }
+
+        public void UserAdded(UserAddedContext context) {
+            _workflowManager.TriggerEvent("OnRoleEvent",
+                null,
+                () => new Dictionary<string, object> {
+                    { "Role", context.Role },
+                    { "User", context.User },
+                    { "Action", "UserAdded" } });
+        }
+
+        public void UserRemoved(UserRemovedContext context) {
+            _workflowManager.TriggerEvent("OnRoleEvent",
+               null,
+               () => new Dictionary<string, object> {
+                    { "Role", context.Role },
+                    { "User", context.User },
+                    { "Action", "UserRemoved" } });
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.Roles/Events/RoleEventHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Events/RoleEventHandler.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+﻿using System.Collections.Generic;
 using Orchard.Workflows.Services;
 
 namespace Orchard.Roles.Events {

--- a/src/Orchard.Web/Modules/Orchard.Roles/Orchard.Roles.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Orchard.Roles.csproj
@@ -92,6 +92,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Activities\RoleEventActivity.cs" />
     <Compile Include="Activities\UnassignRoleActivity.cs" />
     <Compile Include="Activities\AssignRoleActivity.cs" />
     <Compile Include="Activities\IsInRoleActivity.cs" />
@@ -107,6 +108,7 @@
     <Compile Include="Events\PermissionRoleContext.cs" />
     <Compile Include="Events\RoleContext.cs" />
     <Compile Include="Events\RoleCreatedContext.cs" />
+    <Compile Include="Events\RoleEventHandler.cs" />
     <Compile Include="Events\RoleRemovedContext.cs" />
     <Compile Include="Events\RoleRenamedContext.cs" />
     <Compile Include="Events\UserAddedContext.cs" />


### PR DESCRIPTION
Referencing issue #8657 

Event and IRoleEventHandler have been implemented to open up to the possibility of managing role events inside workflows.
For the moment, the activity has one possible outcome for each role event ("Created", "Removed", "Renamed", "UserAdded", "UserRemoved", "PermissionAdded" and "PermissionRemoved"). If user needs to check for a specific role, a proper workflow activity must be added (e.g. a Razor execution activity).