### PR TITLE
Avoid SingleTermId being null if at least one term is checked

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -66,6 +66,13 @@ namespace Orchard.Taxonomies.Controllers {
                         var firstTermForCulture = appliedTerms.FirstOrDefault(x => x.As<LocalizationPart>() != null && x.As<LocalizationPart>().Culture != null && x.As<LocalizationPart>().Culture.Culture == culture);
                         if (firstTermForCulture != null) {
                             firstTermIdForCulture = firstTermForCulture.Id;
+                        } else {
+                            // If there is no valid localization, firstTermForCulture is null.
+                            // To avoid that, use the first checked term (if any is checked).
+                            var firstTerm = terms.FirstOrDefault(t => t.IsChecked = appliedTerms.Select(x => x.Id).Contains(t.Id));
+                            if (firstTerm != null) {
+                                firstTermIdForCulture = firstTerm.Id;
+                            }
                         }
                         terms.ForEach(t => t.IsChecked = appliedTerms.Select(x => x.Id).Contains(t.Id));
                     }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -69,12 +69,12 @@ namespace Orchard.Taxonomies.Controllers {
                         } else {
                             // If there is no valid localization, firstTermForCulture is null.
                             // To avoid that, use the first checked term (if any is checked).
-                            var firstTerm = terms.FirstOrDefault(t => t.IsChecked = appliedTerms.Select(x => x.Id).Contains(t.Id));
-                            if (firstTerm != null) {
-                                firstTermIdForCulture = firstTerm.Id;
+                            firstTermForCulture = appliedTerms.FirstOrDefault(t => terms.Any(x => x.Id == t.Id));
+                            if (firstTermForCulture != null) {
+                                firstTermIdForCulture = firstTermForCulture.Id;
                             }
                         }
-                        terms.ForEach(t => t.IsChecked = appliedTerms.Select(x => x.Id).Contains(t.Id));
+                        terms.ForEach(t => t.IsChecked = appliedTerms.Any(x => x.Id == t.Id));
                     }
                     viewModel = new TaxonomyFieldViewModel {
                         DisplayName = taxonomyField.DisplayName,


### PR DESCRIPTION
In reference to #8661 
If no term with the proper culture is found, SingleTermId is the id of the first valid checked term. This patch avoids TaxonomyViewModel.SingleTermId to be null when at least one term has been checked by the user. This was a bug happening when TaxonomyField was configured to allow the selection of a single term only.