### PR TITLE
No term selection option in TaxonomyField

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.cshtml
@@ -26,7 +26,7 @@
     <ul class="terms">
         @if (Model.Settings.SingleChoice && !settings.Required) {
             <li>
-                <input type="radio" value="0" name="@Html.FieldNameFor(m => m.SingleTermId)" id="@noSelectionId" data-term="@T("No selection")" />
+                <input type="radio" value="0" @if (Model.SingleTermId == 0) { <text> checked="checked" </text> } name="@Html.FieldNameFor(m => m.SingleTermId)" id="@noSelectionId" data-term="@T("No selection")" />
                 <label class="forcheckbox" for="@noSelectionId">@T("No selection")</label>
             </li>
         }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyField.cshtml
@@ -11,6 +11,8 @@
 
     int termIndex = 0;
     var settings = Model.Settings;
+
+    var noSelectionId = Guid.NewGuid();
 }
 
 <fieldset class="taxonomy-wrapper" data-name-prefix="@Html.FieldNameFor(m => m)" data-id-prefix="@Html.FieldIdFor(m => m)">
@@ -21,26 +23,31 @@
             <span class="hint">@Model.Settings.Hint</span>
         }
 
-        <ul class="terms">
-            @foreach (var entry in Model.Terms) {
-                var ti = termIndex;
-                <li>
-                    @* Tabs for levels *@ @for (var i = 1; i <= entry.GetLevels(); i++) { <span class="gap">&nbsp;</span> }
-                    @{
-                        var disabled = !entry.Selectable || (Model.Settings.LeavesOnly && Model.Terms.Any(t => t.Path.Contains(entry.Path + entry.Id)));
-                        if (Model.Settings.SingleChoice) {
-                        <input @if (disabled) { <text> disabled="disabled" </text>  } type="radio" value="@Model.Terms[ti].Id" @if (entry.Id == Model.SingleTermId) { <text> checked="checked" </text>  } name="@Html.FieldNameFor(m => m.SingleTermId)" id="@Html.FieldIdFor(m => m.Terms[ti].IsChecked)" data-term="@entry.Name.ToLower()" />
-                        }
-                        else {
-                        <input @if (disabled) { <text> disabled="disabled" </text>  } type="checkbox" value="true" @if (entry.IsChecked) { <text> checked="checked" </text>  } name="@Html.FieldNameFor(m => m.Terms[ti].IsChecked)" id="@Html.FieldIdFor(m => m.Terms[ti].IsChecked)" data-term="@entry.Name.ToLower()" />
-                        }
+    <ul class="terms">
+        @if (Model.Settings.SingleChoice && !settings.Required) {
+            <li>
+                <input type="radio" value="0" name="@Html.FieldNameFor(m => m.SingleTermId)" id="@noSelectionId" data-term="@T("No selection")" />
+                <label class="forcheckbox" for="@noSelectionId">@T("No selection")</label>
+            </li>
+        }
+        @foreach (var entry in Model.Terms) {
+            var ti = termIndex;
+            <li>
+                @* Tabs for levels *@ @for (var i = 1; i <= entry.GetLevels(); i++) {<span class="gap">&nbsp;</span>}
+                @{
+                    var disabled = !entry.Selectable || (Model.Settings.LeavesOnly && Model.Terms.Any(t => t.Path.Contains(entry.Path + entry.Id)));
+                    if (Model.Settings.SingleChoice) {
+                        <input @if (disabled) { <text> disabled="disabled" </text> } type="radio" value="@Model.Terms[ti].Id" @if (entry.Id == Model.SingleTermId) { <text> checked="checked" </text> } name="@Html.FieldNameFor(m => m.SingleTermId)" id="@Html.FieldIdFor(m => m.Terms[ti].IsChecked)" data-term="@entry.Name.ToLower()" />
+                    } else {
+                        <input @if (disabled) { <text> disabled="disabled" </text> } type="checkbox" value="true" @if (entry.IsChecked) { <text> checked="checked" </text> } name="@Html.FieldNameFor(m => m.Terms[ti].IsChecked)" id="@Html.FieldIdFor(m => m.Terms[ti].IsChecked)" data-term="@entry.Name.ToLower()" />
                     }
-                    @Html.HiddenFor(m => m.Terms[ti].Id)
-                    <label class="forcheckbox" for="@Html.FieldIdFor(m => m.Terms[ti].IsChecked)">@entry.Name</label>
-                </li>
-                termIndex++;
-            }
-        </ul>
+                }
+                @Html.HiddenFor(m => m.Terms[ti].Id)
+                <label class="forcheckbox" for="@Html.FieldIdFor(m => m.Terms[ti].IsChecked)">@entry.Name</label>
+            </li>
+            termIndex++;
+        }
+    </ul>
 
          @if (Model.TaxonomyId == 0) {
             <p>@T("You haven't specified a taxonomy for {0}", Model.DisplayName)</p>


### PR DESCRIPTION
In reference to #8666 , added a radio button for a "No selection" option to TaxonomyField editor template.
Also added a guid for the input element (noSelectionId variable).

The conditions the "No selection" option needs to comply with are:
- No "Autocomplete" option for the TaxonomyField: this condition is met, because when autocomplete is enabled the shape executed is TaxonomyField.Autocomplete.cshtml.
- TaxonomyField must not be "required" for the content: "if" clause on row 27.
- TaxonomyField must be a "single choice" field (condition to display radio buttons instead of check boxes): "if" clause on row 27.
