### PR TITLE
Perf: shapetable sorting

### DIFF
--- a/src/Orchard.Web/Config/HostComponents.config
+++ b/src/Orchard.Web/Config/HostComponents.config
@@ -9,6 +9,14 @@
             </Properties>
         </Component>
 
+        <Component Type="Orchard.DisplayManagement.Descriptors.DefaultShapeTableManager">
+            <Properties>
+                <!-- Set Value="true" to enable an optimization in the sorting step of the ShapeAlterations.
+                     Warning: Rendered results should not be affected, but intermediate steps might. -->
+                <Property Name="GroupByFeatures" Value="false"/>
+            </Properties>
+        </Component>
+
         <Component Type="Orchard.DisplayManagement.Descriptors.ShapePlacementStrategy.PlacementFileParser">
             <Properties>
                 <!-- Set Value="true" to disable Placement files monitoring (Placement.info) -->


### PR DESCRIPTION
PR for #8674 
As discussed there, since the criteria used for sorting ShapeAlterations only involve Features, we are grouping them by Feature, then sorting the groups, then spreading the groups again.
