### PR TITLE
Added orchardFeature attribute where it was missing in Orchard.Roles

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Roles/Activities/RoleEventActivity.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Activities/RoleEventActivity.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using Orchard.Environment.Extensions;
 using Orchard.Localization;
 using Orchard.Workflows.Models;
 using Orchard.Workflows.Services;
 
 namespace Orchard.Roles.Activities {
+    [OrchardFeature("Orchard.Roles.Workflows")]
     public class RoleEventActivity : Event {
         public Localizer T { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Roles/Events/RoleEventHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Events/RoleEventHandler.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using Orchard.Environment.Extensions;
 using Orchard.Workflows.Services;
 
 namespace Orchard.Roles.Events {
+    [OrchardFeature("Orchard.Roles.Workflows")]
     public class RoleEventHandler : IRoleEventHandler {
         private readonly IWorkflowManager _workflowManager;
 


### PR DESCRIPTION
We found that a few files we touched (https://github.com/OrchardCMS/Orchard/commit/97288315564d6aed63c6a1925628669b030ab094) had an issue:
they did not have the `OrchardFeature` attribute, so the ahndler they implemented could be invoke out of turn.
For example, it would be triggered when the "admin" user is created during the "default" startup recipe that creates a tenant, logging an error as the workflow feature is not active at that point.

This PR fixes that.