### PR TITLE
Prevent queries from LocalizationPart

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Localization/Handlers/LocalizationPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Localization/Handlers/LocalizationPartHandler.cs
@@ -31,22 +31,26 @@ namespace Orchard.Localization.Handlers {
 
         protected static void PropertySetHandlers(ActivatedContentContext context, LocalizationPart localizationPart) {
             localizationPart.CultureField.Setter(cultureRecord => {
-                localizationPart.Record.CultureId = cultureRecord.Id;
+                localizationPart.Store<LocalizationPart, LocalizationPartRecord, int>(r => r.CultureId,
+                    cultureRecord != null ? cultureRecord.Id : 0);
                 return cultureRecord;
             });
-            
+
             localizationPart.MasterContentItemField.Setter(masterContentItem => {
-                localizationPart.Record.MasterContentItemId = masterContentItem.ContentItem.Id;
+                localizationPart.Store<LocalizationPart, LocalizationPartRecord, int>(r => r.MasterContentItemId,
+                    masterContentItem.ContentItem.Id);
                 return masterContentItem;
-            });            
+            });
         }
 
         protected void LazyLoadHandlers(LocalizationPart localizationPart) {
-            localizationPart.CultureField.Loader(() => 
-                _cultureManager.GetCultureById(localizationPart.Record.CultureId));
+            localizationPart.CultureField.Loader(() =>
+                _cultureManager.GetCultureById(
+                    localizationPart.Retrieve<LocalizationPart, LocalizationPartRecord, int>(r => r.CultureId)));
 
             localizationPart.MasterContentItemField.Loader(() =>
-                _contentManager.Get(localizationPart.Record.MasterContentItemId, VersionOptions.AllVersions));
+                _contentManager.Get(
+                    localizationPart.Retrieve<LocalizationPart, LocalizationPartRecord, int>(r => r.MasterContentItemId), VersionOptions.AllVersions));
         }
     }
 }


### PR DESCRIPTION
Fixes #8692 

Changed Loader and Setter delegates of the LazyFields of LocalizationPart to use Store/Retrieve implementations rather than go directly to the Record.