### PR TITLE
Added missing module dependency

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Recipes/Module.txt
+++ b/src/Orchard.Web/Modules/Orchard.Recipes/Module.txt
@@ -7,3 +7,4 @@ OrchardVersion: 1.10.3
 Description: Provides Orchard Recipes.
 FeatureDescription: Implementation of Orchard recipes.
 Category: Core
+Dependencies: PackagingServices


### PR DESCRIPTION
https://github.com/OrchardCMS/Orchard/blob/610b3c4f53ce9a4bdbe26a5a095bd606bfabc811/src/Orchard.Web/Modules/Orchard.Recipes/Providers/Executors/ModuleStep.cs#L14

if feature PackagingServices is not enabled, `ModuleStep` cannot be constructed by Autofac, causing several things to fail (e.g. import/export).