### PR TITLE
Added lock on md5 variable to avoid concurrent hash generations for feature list

### DIFF
--- a/src/Orchard/Environment/Extensions/ExtensionManager.cs
+++ b/src/Orchard/Environment/Extensions/ExtensionManager.cs
@@ -25,7 +25,7 @@ namespace Orchard.Environment.Extensions {
         private readonly ICacheManager _cacheManager;
         private readonly IParallelCacheContext _parallelCacheContext;
         private readonly IEnumerable<IExtensionLoader> _loaders;
-
+       
         public Localizer T { get; set; }
         public ILogger Logger { get; set; }
 
@@ -107,14 +107,16 @@ namespace Orchard.Environment.Extensions {
             Logger.Information("Loading features");
 
             // generate a cachekey by hashing the ids of all feature descriptors
-            var cacheKey = BitConverter.ToString(
-                _md5.ComputeHash(
-                    Encoding.UTF8.GetBytes(
-                        string.Join(";",
-                            featureDescriptors
-                                .Select(fd => fd.Id)
-                                .OrderBy(x => x)))));
-
+            string cacheKey;
+            lock (_md5) {
+                cacheKey = BitConverter.ToString(
+                    _md5.ComputeHash(
+                        Encoding.UTF8.GetBytes(
+                            string.Join(";",
+                                featureDescriptors
+                                    .Select(fd => fd.Id)
+                                    .OrderBy(x => x)))));
+            }
 
             var result = _cacheManager.Get(cacheKey,
                 true,


### PR DESCRIPTION
In refernce to issue #8696 , added a lock to _md5 variable to avoid concurrent has generations for features list, which brought to wrong feature lists being generated..
