### PR TITLE
filterTaxonomyCulture function is now named with a proper unique name, based on part and field

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/LocalizedTaxonomyFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Drivers/LocalizedTaxonomyFieldDriver.cs
@@ -30,12 +30,13 @@ namespace Orchard.Taxonomies.Drivers {
 
                         }
                     }
-               
+
                 var viewModel = new LocalizedTaxonomiesViewModel {
                     ContentType = part.ContentItem.ContentType,
                     FieldName = field.Name,
                     Id = part.ContentItem.Id,
-                    Setting = taxonomySettings
+                    Setting = taxonomySettings,
+                    PartName = part.PartDefinition.Name
                 };
                 return shapeHelper.EditorTemplate(TemplateName: templateName, Model: viewModel, Prefix: GetPrefix(field, part));
             });

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/ViewModels/LocalizedTaxonomiesViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/ViewModels/LocalizedTaxonomiesViewModel.cs
@@ -7,6 +7,7 @@ namespace Orchard.Taxonomies.ViewModels {
         public string ContentType { get; set; }
         public string FieldName { get; set; }
         public int Id { get; set; }
+        public string PartName { get; set; }
         public TaxonomyFieldSettings Setting { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
@@ -5,7 +5,7 @@
     Script.Require("jQuery");
     var Taxonomyprefix = ((ViewData)).TemplateInfo.HtmlFieldPrefix.Replace('.', '_');
     using (Script.Foot()) {
-        <script type="text/javascript">
+    <script type="text/javascript">
             //<![CDATA[
             $(document).ready(function () {
                 var pageurl = '@Url.Action("GetTaxonomy", "LocalizedTaxonomy", new { area = "Orchard.Taxonomies" })';
@@ -14,7 +14,21 @@
                         url: pageurl,
                         data: { contentTypeName: '@Model.ContentType', taxonomyFieldName: '@Model.FieldName', contentId: @Model.Id, culture: culture },
                         success: function (html) {
+                            var container = $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']");
+                            var checkedItems = $(".terms input[checked='checked']", container);
+
                             $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']").replaceWith(html);
+
+                            $("input", $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']")).each(function () {
+                                //$(this).prop("checked", false);
+                            });
+
+                            // Check back previously selected items.
+                            checkedItems.each(function () {
+                                var idToCheck = this.id;
+                                $("input[id='" + idToCheck + "']", $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']")).attr("checked", "checked");
+                            });
+
                             $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix'] legend").expandoControl(function (controller) { return controller.nextAll(".expando"); }, { collapse: true, remember: false });
                             @if (Model.Setting.Autocomplete) {
                                 <text>
@@ -143,6 +157,6 @@
                 $("#Localization_SelectedCulture").trigger("change");
             });
             //]]>
-        </script>
+    </script>
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
@@ -5,7 +5,7 @@
     Script.Require("jQuery");
     var Taxonomyprefix = ((ViewData)).TemplateInfo.HtmlFieldPrefix.Replace('.', '_');
     using (Script.Foot()) {
-    <script type="text/javascript">
+        <script type="text/javascript">
             //<![CDATA[
             $(document).ready(function () {
                 var pageurl = '@Url.Action("GetTaxonomy", "LocalizedTaxonomy", new { area = "Orchard.Taxonomies" })';
@@ -20,13 +20,13 @@
                             $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']").replaceWith(html);
 
                             $("input", $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']")).each(function () {
-                                //$(this).prop("checked", false);
+                                $(this).prop("checked", false);
                             });
 
                             // Check back previously selected items.
                             checkedItems.each(function () {
                                 var idToCheck = this.id;
-                                $("input[id='" + idToCheck + "']", $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']")).attr("checked", "checked");
+                                $("input[id='" + idToCheck + "']", $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']")).prop("checked", true);
                             });
 
                             $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix'] legend").expandoControl(function (controller) { return controller.nextAll(".expando"); }, { collapse: true, remember: false });
@@ -157,6 +157,6 @@
                 $("#Localization_SelectedCulture").trigger("change");
             });
             //]]>
-    </script>
+        </script>
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
@@ -4,17 +4,21 @@
 @{
     Script.Require("jQuery");
     var Taxonomyprefix = ((ViewData)).TemplateInfo.HtmlFieldPrefix.Replace('.', '_');
+
+    var partField = Model.PartName + "_" + Model.FieldName;
+    var functionName = "filterTaxonomyCulture_" + partField;
+
     using (Script.Foot()) {
-    <script type="text/javascript">
-            //<![CDATA[
+        <script type="text/javascript">
+                        //<![CDATA[
             $(document).ready(function () {
                 var pageurl = '@Url.Action("GetTaxonomy", "LocalizedTaxonomy", new { area = "Orchard.Taxonomies" })';
-                function @("filterTaxonomyCulture_" + Model.PartName + "_" + Model.FieldName)(culture) {
+                function @(functionName)(culture) {
                     $.ajax({
-                        url: pageurl,
+                            url: pageurl,
                         data: { contentTypeName: '@Model.ContentType', taxonomyFieldName: '@Model.FieldName', contentId: @Model.Id, culture: culture },
                         success: function (html) {
-                            var container = $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']");
+                                    var container = $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']");
 
                             $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']").replaceWith(html);
 
@@ -22,99 +26,99 @@
                             @if (Model.Setting.Autocomplete) {
                                 <text>
                                     var createTermCheckbox = function($wrapper, tag, checked) {
-                                    var $ul = $("ul.terms", $wrapper);
-                                    var singleChoice = $(".terms-editor", $wrapper).data("singlechoice");
-                                    var namePrefix = $wrapper.data("name-prefix");
-                                    var idPrefix = $wrapper.data("id-prefix");
-                                    var nextIndex = $("li", $ul).length;
-                                    var id = isNaN(tag.value) ? -nextIndex : tag.value;
-                                    var checkboxId = idPrefix + "_Terms_" + nextIndex + "__IsChecked";
-                                    var checkboxName = namePrefix + ".Terms[" + nextIndex + "].IsChecked";
-                                    var radioName = namePrefix + ".SingleTermId";
-                                    var checkboxHtml = "<input type=\"checkbox\" value=\"" + (checked ? "true\" checked=\"checked\"" : "false") + " data-term=\"" + tag.label + "\" data-term-identity=\"" + tag.label.toLowerCase() + "\" id=\"" + checkboxId + "\" name=\"" + checkboxName + "\" />";
-                                    var radioHtml = "<input type=\"radio\" value=\"" + id + (checked ? "\" checked=\"checked\"" : "\"") + " data-term=\"" + tag.label + "\" data-term-identity=\"" + tag.label.toLowerCase() + "\" id=\"" + checkboxId + "\" name=\"" + radioName + "\" />";
-                                    var inputHtml = singleChoice ? radioHtml : checkboxHtml;
-                                    var $li = $("<li>" +
-                                                inputHtml +
-                                                "<input type=\"hidden\" value=\"" + id + "\" id=\"" + idPrefix + "_Terms_" + nextIndex + "__Id" + "\" name=\"" + namePrefix + ".Terms[" + nextIndex + "].Id" + "\" />" +
-                                                "<input type=\"hidden\" value=\"" + tag.label + "\" id=\"" + idPrefix + "_Terms_" + nextIndex + "__Name" + "\" name=\"" + namePrefix + ".Terms[" + nextIndex + "].Name" + "\" />" +
-                                                "<label class=\"forcheckbox\" for=\"" + checkboxId + "\">" + tag.label + "</label>" +
-                                                "</li>").hide();
+                                            var $ul = $("ul.terms", $wrapper);
+                                            var singleChoice = $(".terms-editor", $wrapper).data("singlechoice");
+                                            var namePrefix = $wrapper.data("name-prefix");
+                                            var idPrefix = $wrapper.data("id-prefix");
+                                            var nextIndex = $("li", $ul).length;
+                                            var id = isNaN(tag.value) ? -nextIndex : tag.value;
+                                            var checkboxId = idPrefix + "_Terms_" + nextIndex + "__IsChecked";
+                                            var checkboxName = namePrefix + ".Terms[" + nextIndex + "].IsChecked";
+                                            var radioName = namePrefix + ".SingleTermId";
+                                            var checkboxHtml = "<input type=\"checkbox\" value=\"" + (checked ? "true\" checked=\"checked\"" : "false") + " data-term=\"" + tag.label + "\" data-term-identity=\"" + tag.label.toLowerCase() + "\" id=\"" + checkboxId + "\" name=\"" + checkboxName + "\" />";
+                                            var radioHtml = "<input type=\"radio\" value=\"" + id + (checked ? "\" checked=\"checked\"" : "\"") + " data-term=\"" + tag.label + "\" data-term-identity=\"" + tag.label.toLowerCase() + "\" id=\"" + checkboxId + "\" name=\"" + radioName + "\" />";
+                                            var inputHtml = singleChoice ? radioHtml : checkboxHtml;
+                                            var $li = $("<li>" +
+                                                        inputHtml +
+                                                        "<input type=\"hidden\" value=\"" + id + "\" id=\"" + idPrefix + "_Terms_" + nextIndex + "__Id" + "\" name=\"" + namePrefix + ".Terms[" + nextIndex + "].Id" + "\" />" +
+                                                        "<input type=\"hidden\" value=\"" + tag.label + "\" id=\"" + idPrefix + "_Terms_" + nextIndex + "__Name" + "\" name=\"" + namePrefix + ".Terms[" + nextIndex + "].Name" + "\" />" +
+                                                        "<label class=\"forcheckbox\" for=\"" + checkboxId + "\">" + tag.label + "</label>" +
+                                                        "</li>").hide();
 
-                                    if (checked && singleChoice) {
+                                            if (checked && singleChoice) {
                                         $("input[type='radio']", $ul).removeAttr("checked");
                                         $("input[type='radio'][name$='IsChecked']", $ul).val("false");
-                                                }
+                                            }
 
                                     $ul.append($li);
                                     $li.fadeIn();
-                                            };
+                                        };
 
-                                            /* Event handlers
-                                            **********************************************************************/
-                                            var onTagsChanged = function(tagLabelOrValue, action, tag) {
+                                        /* Event handlers
+                                        **********************************************************************/
+                                        var onTagsChanged = function(tagLabelOrValue, action, tag) {
 
-                                                if (tagLabelOrValue == null)
-                                                    return;
+                                            if (tagLabelOrValue == null)
+                                                return;
 
-                                                var $input = this.appendTo;
-                                                var $wrapper = $input.parents("fieldset:first");
-                                                var $tagIt = $("ul.tagit", $wrapper);
-                                                var singleChoice = $(".terms-editor", $wrapper).data("singlechoice");
-                                                var $terms = $("ul.terms", $wrapper);
-                                                var initialTags = $(".terms-editor", $wrapper).data("selected-terms");
+                                            var $input = this.appendTo;
+                                            var $wrapper = $input.parents("fieldset:first");
+                                            var $tagIt = $("ul.tagit", $wrapper);
+                                            var singleChoice = $(".terms-editor", $wrapper).data("singlechoice");
+                                            var $terms = $("ul.terms", $wrapper);
+                                            var initialTags = $(".terms-editor", $wrapper).data("selected-terms");
 
-                                                if (singleChoice && action == "added") {
+                                            if (singleChoice && action == "added") {
                                         $tagIt.tagit("fill", tag);
-                                                }
+                                            }
 
                                     $terms.empty();
 
-                                                var tags = $tagIt.tagit("tags");
+                                            var tags = $tagIt.tagit("tags");
                                     $(tags).each(function(index, tag) {
-                                                    createTermCheckbox($wrapper, tag, true);
-                                                });
+                                                createTermCheckbox($wrapper, tag, true);
+                                            });
 
-                                                // Add any tags that are no longer selected but were initially on page load.
-                                                // These are required to be posted back so they can be removed.
-                                                var removedTags = $.grep(initialTags, function(initialTag) { return $.grep(tags, function(tag) { return tag.value === initialTag.value }).length === 0 });
+                                            // Add any tags that are no longer selected but were initially on page load.
+                                            // These are required to be posted back so they can be removed.
+                                            var removedTags = $.grep(initialTags, function(initialTag) { return $.grep(tags, function(tag) { return tag.value === initialTag.value }).length === 0 });
                                     $(removedTags).each(function(index, tag) {
-                                                    createTermCheckbox($wrapper, tag, false);
-                                                });
+                                                createTermCheckbox($wrapper, tag, false);
+                                            });
 
                                     $(".no-terms", $wrapper).hide();
-                                            };
+                                        };
 
-                                            var renderAutocompleteItem = function(ul, item) {
+                                        var renderAutocompleteItem = function(ul, item) {
 
-                                                var label = item.label;
+                                            var label = item.label;
 
-                                                for (var i = 0; i < item.levels; i++) {
-                                                    label = "<span class=\"gap\">&nbsp;</span>" + label;
-                                                }
+                                            for (var i = 0; i < item.levels; i++) {
+                                                label = "<span class=\"gap\">&nbsp;</span>" + label;
+                                            }
 
-                                                var li = item.disabled ? "<li class=\"disabled\"></li>" : "<li></li>";
+                                            var li = item.disabled ? "<li class=\"disabled\"></li>" : "<li></li>";
 
-                                                return $(li)
-                                                    .data("item.autocomplete", item)
-                                                    .append($("<a></a>").html(label))
-                                                    .appendTo(ul);
-                                            };
+                                            return $(li)
+                                                .data("item.autocomplete", item)
+                                                .append($("<a></a>").html(label))
+                                                .appendTo(ul);
+                                        };
 
                                 /* Initialization
                                 **********************************************************************/
                                 $(".terms-editor").each(function() {
-                                                var selectedTerms = $(this).data("selected-terms");
+                                            var selectedTerms = $(this).data("selected-terms");
 
-                                                var autocompleteUrl = $(this).data("autocomplete-url");
+                                            var autocompleteUrl = $(this).data("autocomplete-url");
 
-                                                var $tagit = $("> ul", this).tagit({
-                                                tagSource: function(request, response) {
-                                                        var termsEditor = $(this.element).parents(".terms-editor");
+                                            var $tagit = $("> ul", this).tagit({
+                                            tagSource: function(request, response) {
+                                                    var termsEditor = $(this.element).parents(".terms-editor");
                                             $.getJSON(autocompleteUrl, { taxonomyId: termsEditor.data("taxonomy-id"), leavesOnly: termsEditor.data("leaves-only"), query: request.term }, function(data, status, xhr) {
-                                                            response(data);
-                                                        });
-                                                    },
+                                                        response(data);
+                                                    });
+                                                },
                                         initialTags: selectedTerms,
                                         triggerKeys: ['enter', 'tab'], // default is ['enter', 'space', 'comma', 'tab'] but we remove comma and space to allow them in the terms
                                         allowNewTags: $(this).data("allow-new-terms"),
@@ -136,24 +140,24 @@
                                 ///////////////////////////
                         }
                     }).fail(function () {
-                                    alert("@T("Loading taxonomy fail, Retry")");
-                                });
+                        alert("@T("Loading taxonomy fail, Retry")");
+                    });
                 }
                 $("#Localization_SelectedCulture").on('change', function (p) {
                     var optionSelected = $("option:selected", this);
                     var refreshTerms = false;
                     if (p != undefined) {
-                        if (p == "@(Model.PartName + "_" + Model.FieldName)") {
+                        if (p == "@(partField)") {
                             refreshTerms = true;
                         }
                     }
                     if (refreshTerms) {
-                        @("filterTaxonomyCulture_" + Model.PartName + "_" + Model.FieldName)($("#Localization_SelectedCulture").val());
+                        @(functionName)($("#Localization_SelectedCulture").val());
                     }
                 });
-                $("#Localization_SelectedCulture").trigger("change", "@(Model.PartName + "_" + Model.FieldName)");
+                $("#Localization_SelectedCulture").trigger("change", "@(partField)");
             });
             //]]>
-    </script>
+        </script>
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Views/EditorTemplates/Fields/TaxonomyFieldList.cshtml
@@ -5,29 +5,18 @@
     Script.Require("jQuery");
     var Taxonomyprefix = ((ViewData)).TemplateInfo.HtmlFieldPrefix.Replace('.', '_');
     using (Script.Foot()) {
-        <script type="text/javascript">
+    <script type="text/javascript">
             //<![CDATA[
             $(document).ready(function () {
                 var pageurl = '@Url.Action("GetTaxonomy", "LocalizedTaxonomy", new { area = "Orchard.Taxonomies" })';
-                function filterTaxonomyCulture(culture) {
+                function @("filterTaxonomyCulture_" + Model.PartName + "_" + Model.FieldName)(culture) {
                     $.ajax({
                         url: pageurl,
                         data: { contentTypeName: '@Model.ContentType', taxonomyFieldName: '@Model.FieldName', contentId: @Model.Id, culture: culture },
                         success: function (html) {
                             var container = $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']");
-                            var checkedItems = $(".terms input[checked='checked']", container);
 
                             $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']").replaceWith(html);
-
-                            $("input", $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']")).each(function () {
-                                $(this).prop("checked", false);
-                            });
-
-                            // Check back previously selected items.
-                            checkedItems.each(function () {
-                                var idToCheck = this.id;
-                                $("input[id='" + idToCheck + "']", $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix']")).prop("checked", true);
-                            });
 
                             $(".taxonomy-wrapper[data-id-prefix='@Taxonomyprefix'] legend").expandoControl(function (controller) { return controller.nextAll(".expando"); }, { collapse: true, remember: false });
                             @if (Model.Setting.Autocomplete) {
@@ -150,13 +139,21 @@
                                     alert("@T("Loading taxonomy fail, Retry")");
                                 });
                 }
-                $("#Localization_SelectedCulture").on('change', function () {
+                $("#Localization_SelectedCulture").on('change', function (p) {
                     var optionSelected = $("option:selected", this);
-                    filterTaxonomyCulture($("#Localization_SelectedCulture").val());
+                    var refreshTerms = false;
+                    if (p != undefined) {
+                        if (p == "@(Model.PartName + "_" + Model.FieldName)") {
+                            refreshTerms = true;
+                        }
+                    }
+                    if (refreshTerms) {
+                        @("filterTaxonomyCulture_" + Model.PartName + "_" + Model.FieldName)($("#Localization_SelectedCulture").val());
+                    }
                 });
-                $("#Localization_SelectedCulture").trigger("change");
+                $("#Localization_SelectedCulture").trigger("change", "@(Model.PartName + "_" + Model.FieldName)");
             });
             //]]>
-        </script>
+    </script>
     }
 }


### PR DESCRIPTION
After trying to force to check back selected terms, I noticed the problem was the one referenced in issue #8701 
Added part name and field name to the javascript function name, to avoid being called multiple times when culture is changed.
Added a parameter to the "change" event for "#Localization_SelectedCulture" control to ensure that, when triggered by TaxonomyFieldListShape, it triggers the filterTaxonomyCulture for the current TaxonomyField only.
Modified LocalizedTaxonomiesViewModel to add PartName property.