### PR TITLE
Fix bug in updating settings for fields

### DIFF
--- a/src/Orchard.Web/Modules/TinyMce/Settings/EditorEvents.cs
+++ b/src/Orchard.Web/Modules/TinyMce/Settings/EditorEvents.cs
@@ -29,7 +29,7 @@ namespace TinyMce.Settings {
         }
 
         public override IEnumerable<TemplateViewModel> PartFieldEditorUpdate(ContentPartFieldDefinitionBuilder builder, IUpdateModel updateModel) {
-            if (!_contentLinksDependenciesEnabled || !_htmlFields.Any(x => x.Equals(builder.Name, StringComparison.InvariantCultureIgnoreCase)))
+            if (!_contentLinksDependenciesEnabled || !_htmlFields.Any(x => x.Equals(builder.FieldType, StringComparison.InvariantCultureIgnoreCase)))
                 yield break;
 
             var model = new ContentLinksSettings();


### PR DESCRIPTION
When updating field settings for this "ContentLink" tinymce feature, we were by mistake comparing the field's type with its name, so the update would never happen.
This fixes that.