### PR TITLE
Cache CultureRecords by both Id and Name

### DIFF
--- a/src/Orchard/Localization/Services/DefaultCultureManager.cs
+++ b/src/Orchard/Localization/Services/DefaultCultureManager.cs
@@ -62,12 +62,36 @@ namespace Orchard.Localization.Services {
             return _workContextAccessor.GetContext().CurrentCulture;
         }
 
+        protected Dictionary<int, CultureRecord> GetAllCulturesById() {
+            return _cacheManager.Get("all_culture_records_by_id", true, context => {
+                context.Monitor(_signals.When("culturesChanged"));
+
+                return _cultureRepository.Table
+                    .ToDictionary(cr => cr.Id);
+            });
+        }
         public CultureRecord GetCultureById(int id) {
-            return _cultureRepository.Get(id);
+            var cultures = GetAllCulturesById();
+            CultureRecord result;
+            cultures.TryGetValue(id, out result);
+
+            return result;
         }
 
+        protected Dictionary<string, CultureRecord> GetAllCulturesByName() {
+            return _cacheManager.Get("all_culture_records_by_name", true, context => {
+                context.Monitor(_signals.When("culturesChanged"));
+
+                return _cultureRepository.Table
+                    .ToDictionary(cr => cr.Culture);
+            });
+        }
         public CultureRecord GetCultureByName(string cultureName) {
-            return _cultureRepository.Get(cr => cr.Culture == cultureName);
+            var cultures = GetAllCulturesByName();
+            CultureRecord result;
+            cultures.TryGetValue(cultureName, out result);
+
+            return result;
         }
 
         public string GetSiteCulture() {


### PR DESCRIPTION
Fixes #8706 , in case we want to.
The queries are only ever done again when the appropriate signal is raised (it should be raised whenever the records are changed in any way).

I don't think this is a massive speed up, tbh: it's probably only significant where the connection to the db server is having some trouble.