### PR TITLE
Prevent TermsFilter from having to deal with empty strings

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilter.cs
@@ -36,7 +36,10 @@ namespace Orchard.Taxonomies.Projections {
             var termIds = (string)context.State.TermIds;
 
             if (!String.IsNullOrEmpty(termIds)) {
-                var ids = termIds.Split(new[] { ',' }).Select(Int32.Parse).ToArray();
+                var ids = termIds.Split(new[] { ',' })
+                    // Int32.Parse throws for empty strings
+                    .Where(x => !string.IsNullOrWhiteSpace(x))
+                    .Select(Int32.Parse).ToArray();
 
                 if (ids.Length == 0) {
                     return;

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilter.cs
@@ -36,7 +36,7 @@ namespace Orchard.Taxonomies.Projections {
             var termIds = (string)context.State.TermIds;
 
             if (!String.IsNullOrEmpty(termIds)) {
-                var ids = termIds.Split(new[] { ',' })
+                var ids = termIds.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                     // Int32.Parse throws for empty strings
                     .Where(x => !string.IsNullOrWhiteSpace(x))
                     .Select(Int32.Parse).ToArray();

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilterForms.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilterForms.cs
@@ -57,7 +57,8 @@ namespace Orchard.Taxonomies.Projections {
                     );
 
                     foreach (var taxonomy in _taxonomyService.GetTaxonomies()) {
-                        f._Terms.Add(new SelectListItem { Value = String.Empty, Text = taxonomy.Name });
+                        var tGroup = new SelectListGroup { Name = taxonomy.Name };
+                        f._Terms.Add(tGroup);
                         foreach (var term in _taxonomyService.GetTerms(taxonomy.Id)) {
                             var gap = new string('-', term.GetLevels());
 
@@ -65,7 +66,11 @@ namespace Orchard.Taxonomies.Projections {
                                 gap += " ";
                             }
 
-                            f._Terms.Add(new SelectListItem { Value = term.Id.ToString(), Text = gap + term.Name });
+                            f._Terms.Add(new SelectListItem {
+                                Value = term.Id.ToString(),
+                                Text = gap + term.Name,
+                                Group = tGroup
+                            });
                         }
                     }
 


### PR DESCRIPTION
We noticed there was a chance for the TermsFilter to throw an exception, locking backoffice users from being able to edit the filter and use it. This happened in some cases when the user would select the taxonomy rather than a term, because the value for the taxonomy is an empty string: that could result in the filter attempting to parse empty strings to integers.
So:

- filter them out before parsing them to int
- in the form, convert taxonomies to OptionGroups rather than options with no value, so they should not be selected so easily.