### PR TITLE
Implemented ability to add localizations of selected terms to filter

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilter.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilter.cs
@@ -6,6 +6,8 @@ using Orchard.Taxonomies.Services;
 using Orchard.ContentManagement;
 using Orchard.Events;
 using Orchard.Localization;
+using Orchard.Localization.Services;
+using Orchard.Taxonomies.Drivers;
 
 namespace Orchard.Taxonomies.Projections {
     public interface IFilterProvider : IEventHandler {
@@ -14,10 +16,13 @@ namespace Orchard.Taxonomies.Projections {
 
     public class TermsFilter : IFilterProvider {
         private readonly ITaxonomyService _taxonomyService;
+        private readonly IWorkContextAccessor _workContextAccessor;
         private int _termsFilterId;
 
-        public TermsFilter(ITaxonomyService taxonomyService) {
+        public TermsFilter(ITaxonomyService taxonomyService,
+            IWorkContextAccessor workContextAccessor) {
             _taxonomyService = taxonomyService;
+            _workContextAccessor = workContextAccessor;
             T = NullLocalizer.Instance;
         }
 
@@ -45,13 +50,30 @@ namespace Orchard.Taxonomies.Projections {
                 int op = Convert.ToInt32(context.State.Operator);
 
                 var terms = ids.Select(_taxonomyService.GetTerm).ToList();
+
+                bool.TryParse(context.State.TranslateTerms?.Value, out bool translateTerms);
+                if (translateTerms &&
+                    _workContextAccessor.GetContext().TryResolve<ILocalizationService>(out var localizationService)) {
+                    var localizedTerms = new List<TermPart>();
+                    foreach (var termPart in terms) {
+                        localizedTerms.AddRange(
+                            localizationService.GetLocalizations(termPart)
+                                .Select(l => l.As<TermPart>()));
+                    }
+                    terms.AddRange(localizedTerms);
+                    terms = terms.Distinct(new TermPartComparer()).ToList();
+                }
+
                 var allChildren = new List<TermPart>();
+                bool.TryParse(context.State.ExcludeChildren?.Value, out bool excludeChildren);
                 foreach (var term in terms) {
-                    bool.TryParse(context.State.ExcludeChildren?.Value, out bool excludeChildren);
-                    if (!excludeChildren)
+                    if (term == null) {
+                        continue;
+                    }
+                    allChildren.Add(term);
+                    if (!excludeChildren) {
                         allChildren.AddRange(_taxonomyService.GetChildren(term));
-                    if (term != null)
-                        allChildren.Add(term);
+                    }
                 }
 
                 allChildren = allChildren.Distinct().ToList();

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilterForms.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Projections/TermsFilterForms.cs
@@ -53,6 +53,11 @@ namespace Orchard.Taxonomies.Projections {
                             Id: "ExcludeChildren", Name: "ExcludeChildren",
                             Title: T("Automatically exclude children terms in filtering"),
                             Value: "true"
+                        ),
+                        _TranslateTerms: Shape.Checkbox(
+                            Id: "TranslateTerms", Name: "TranslateTerms",
+                            Title: T("Automatically include terms' localizations in filtering"),
+                            Value: "true"
                         )
                     );
 


### PR DESCRIPTION
When there are several localisations for terms, it's currently required to select all of them in the filter for projections/queries.

This becomes troublesome to keep track of as more languages are added, and the localisations of terms are added to the tenant. This is especially an issue when accounting for the fact that the different permissions required (e.g. to handle localizing content, taxonomies and configuring queries) may be spread to different users.

In this PR, we tackle this by adding an option to the `TermsFilter` that would allow automatically localizing the selected terms (i.e. including their localized versions in the query).