### PR TITLE
Makes SmtpClient to Mailkit upgrade backward compatible

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Email/Models/SmtpSettingsPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Email/Models/SmtpSettingsPart.cs
@@ -37,7 +37,7 @@ namespace Orchard.Email.Models {
         public SmtpEncryptionMethod EncryptionMethod {
 #pragma warning disable CS0618 // Type or member is obsolete
             // Reading EnableSsl is necessary to keep the correct settings during the upgrade to MailKit.
-            get { return this.Retrieve(x => x.EncryptionMethod, EnableSsl ? SmtpEncryptionMethod.SslTls : SmtpEncryptionMethod.None); }
+            get { return this.Retrieve(x => x.EncryptionMethod, EnableSsl ? (Port == 587 ? SmtpEncryptionMethod.StartTls : SmtpEncryptionMethod.SslTls) : SmtpEncryptionMethod.None); }
 #pragma warning restore CS0618 // Type or member is obsolete
             set { this.Store(x => x.EncryptionMethod, value); }
         }


### PR DESCRIPTION
This change makes upgrade to mailkit backward compatible:
In all smtp providers, that we were able to test, upgrading to mailkit failed when smtp port was set to 587 because it supports only StartTls protocol