### PR TITLE
fixes unsupported self closing divs 

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Media-Audio.Thumbnail.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Media-Audio.Thumbnail.cshtml
@@ -10,4 +10,4 @@
 }
 
 @* Don't render the audio tag as thumbnails or the whole file is downloaded automatically by browsers *@
-<div class="media-thumbnail media-thumbnail-@contentItem.ContentType.HtmlClassify() mime-type-@media.MimeType.HtmlClassify()" />
+<div class="media-thumbnail media-thumbnail-@contentItem.ContentType.HtmlClassify() mime-type-@media.MimeType.HtmlClassify()"></div>

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Media-Video.Thumbnail.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Views/Media-Video.Thumbnail.cshtml
@@ -10,4 +10,4 @@
 }
 
 @* Don't render the video tag as thumbnails or the whole file is downloaded automatically by browsers *@
-<div class="media-thumbnail media-thumbnail-@contentItem.ContentType.HtmlClassify() mime-type-@media.MimeType.HtmlClassify()" />
+<div class="media-thumbnail media-thumbnail-@contentItem.ContentType.HtmlClassify() mime-type-@media.MimeType.HtmlClassify()"></div>


### PR DESCRIPTION
Self-closing syntax (/>)…used on a non-void HTML element. Ignoring the slash and treating as a start tag.
Self-closing div is not a W3C valid markup