### PR TITLE
Similar paths are now compared ignoring casing

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Services/AutorouteService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Services/AutorouteService.cs
@@ -186,7 +186,7 @@ namespace Orchard.Autoroute.Services {
         }
 
         public string GenerateUniqueSlug(AutoroutePart part, IEnumerable<string> existingPaths) {
-            if (existingPaths == null || !existingPaths.Contains(part.Path))
+            if (existingPaths == null || !existingPaths.Contains(part.Path, StringComparer.OrdinalIgnoreCase))
                 return part.Path;
 
             var version = existingPaths.Select(s => GetSlugVersion(part.Path, s)).OrderBy(i => i).LastOrDefault();
@@ -287,7 +287,8 @@ namespace Orchard.Autoroute.Services {
 
         private static int? GetSlugVersion(string path, string potentialConflictingPath) {
             int v;
-            var slugParts = potentialConflictingPath.Split(new[] { path }, StringSplitOptions.RemoveEmptyEntries);
+            // Matching needs to ignore case, so both paths are forced to lowercase.
+            var slugParts = potentialConflictingPath.ToLower().Split(new[] { path.ToLower() }, StringSplitOptions.RemoveEmptyEntries);
 
             if (slugParts.Length == 0)
                 return 2;


### PR DESCRIPTION
Reference issue: #8742 
Added StringComparer and forced lowercase where needed to ensure matching paths to ignore casing.
This changes apply to new content or when autoroute is changed. This means that, for existing content, if user does not change the  current url textbox, the path generation is skipped, thus keeping ambiguous paths if present.
For this reason I opened a draft pull request for the moment, to find a way to avoid this ambiguity for existing content.  This can be solved mainly in two ways:
1) Forcing the slug / url generation even if the matching between url and content routevaluedictionary is passed (https://github.com/OrchardCMS/Orchard/blob/9644ceda1f9b077d44aaa4ffaab103c19a59ddba/src/Orchard.Web/Modules/Orchard.Autoroute/Services/AutorouteService.cs#L217)
2) Adding a migration step (in Orchard.Autoroute or Orchard.Alias) forcing the regeneration of all ambiguous urls.