### PR TITLE
Mailkit upgrade

### DIFF
--- a/src/Orchard.Web/Modules/Markdown/Markdown.csproj
+++ b/src/Orchard.Web/Modules/Markdown/Markdown.csproj
@@ -67,8 +67,8 @@
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Orchard.Web/Modules/Markdown/Web.config
+++ b/src/Orchard.Web/Modules/Markdown/Web.config
@@ -68,6 +68,10 @@
                        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
                        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
                 </dependentAssembly>
+             <dependentAssembly>
+                 <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+                 <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+             </dependentAssembly>
          </assemblyBinding>
   </runtime>
   <system.codedom>

--- a/src/Orchard.Web/Modules/Markdown/packages.config
+++ b/src/Orchard.Web/Modules/Markdown/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
 </packages>

--- a/src/Orchard.Web/Modules/Orchard.Email/Orchard.Email.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Email/Orchard.Email.csproj
@@ -55,8 +55,8 @@
     <Reference Include="BouncyCastle.Crypto, Version=1.9.0.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Portable.BouncyCastle.1.9.0\lib\net40\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
-    <Reference Include="MailKit, Version=3.1.0.0, Culture=neutral, PublicKeyToken=4e064fe7c44a8f1b, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\MailKit.3.1.1\lib\net48\MailKit.dll</HintPath>
+    <Reference Include="MailKit, Version=3.4.0.0, Culture=neutral, PublicKeyToken=4e064fe7c44a8f1b, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\MailKit.3.4.2\lib\net48\MailKit.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\lib\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
@@ -65,8 +65,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="MimeKit, Version=3.1.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\MimeKit.3.1.1\lib\net48\MimeKit.dll</HintPath>
+    <Reference Include="MimeKit, Version=3.4.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\MimeKit.3.4.2\lib\net48\MimeKit.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -80,8 +80,21 @@
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Security" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />

--- a/src/Orchard.Web/Modules/Orchard.Email/packages.config
+++ b/src/Orchard.Web/Modules/Orchard.Email/packages.config
@@ -1,13 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MailKit" version="3.1.1" targetFramework="net48" />
+  <package id="MailKit" version="3.4.2" targetFramework="net48" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net48" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
-  <package id="MimeKit" version="3.1.1" targetFramework="net48" />
+  <package id="MimeKit" version="3.4.2" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="Portable.BouncyCastle" version="1.9.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Since upgrading to mailkit, we've been having a few issues.

Specifically, it looked like the client (i.e. Orchard, where Mailkit is) didn't wait for the smtp server to acknowledge reception of message data. Often, we would get this error on our SMTP servers:
```
Client socket is disconnected! Disconnect exception encountered: False, IsDisconnected: True, This message will be rejected.
[...]
This issue is caused by the sending server not waiting for the DATA OK command
```

We tried to upgrade the version of the NuGet package, but there were several issues with its dependencies (https://github.com/jstedfast/MailKit/issues/1462, https://github.com/jstedfast/MimeKit/issues/872, https://github.com/dotnet/sdk/issues/31147) so we were only able to advance it to 3.4.2.

We then changed the code a bit, to explicitly disconnect from the STMP server and dispose of the smtpclient after sending each email. This seems to have improved things.
We couldn't replicate the error 100% of the time, but so far in our tests with this code it hasn't occurred yet.