### PR TITLE
#8747: Workaround for file extension with "." inside

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Media/Views/Admin/Add.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Media/Views/Admin/Add.cshtml
@@ -42,7 +42,7 @@
             var $in = $(this);
             var allowedExtensions = ' @Model.AllowedExtensions ';
             var filename = $in.val();
-            var ext = filename.slice(filename.lastIndexOf(".")).toLowerCase();
+            var ext = filename.slice(filename.lastIndexOf(".")).toLowerCase().replace('.','');
             var allowed = allowedExtensions == '  ' || allowedExtensions.indexOf(ext) != -1;
 
             if(!allowed) {


### PR DESCRIPTION
Fixes #8747 

replace "." char with "" in filename.lastIndexOf(".")).toLowerCase() to avoid failure in file type check (that happens sometimes)