### PR TITLE
Added checks to properly display CustomForm content items at front end

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Orchard.CustomForms.csproj
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Orchard.CustomForms.csproj
@@ -146,6 +146,8 @@
     <Compile Include="Rules\CustomFormEvents.cs" />
     <Compile Include="Rules\IRulesManager.cs" />
     <Compile Include="Security\AuthorizationEventHandler.cs" />
+    <Compile Include="Services\EditorBuilderWrapper.cs" />
+    <Compile Include="Services\IEditorBuilderWrapper.cs" />
     <Compile Include="ViewModels\CustomFormIndexViewModel.cs" />
     <Compile Include="ViewModels\CustomFormPartEditViewModel.cs" />
   </ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Services/EditorBuilderWrapper.cs
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Services/EditorBuilderWrapper.cs
@@ -1,0 +1,22 @@
+﻿using Orchard.ContentManagement;
+
+namespace Orchard.CustomForms.Services {
+    public class EditorBuilderWrapper : IEditorBuilderWrapper {
+
+        private readonly IContentManager _contentManager;
+
+        public EditorBuilderWrapper(
+            IContentManager contentManager) {
+
+            _contentManager = contentManager;
+        }
+
+        public dynamic BuildEditor(IContent content) {
+            return _contentManager.BuildEditor(content);
+        }
+
+        public dynamic UpdateEditor(IContent content, IUpdateModel updateModel) {
+            return _contentManager.UpdateEditor(content, updateModel);
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Services/IEditorBuilderWrapper.cs
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Services/IEditorBuilderWrapper.cs
@@ -1,0 +1,8 @@
+﻿using Orchard.ContentManagement;
+
+namespace Orchard.CustomForms.Services {
+    public interface IEditorBuilderWrapper : IDependency {
+        dynamic BuildEditor(IContent content);
+        dynamic UpdateEditor(IContent content, IUpdateModel updateModel);
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Item/Create.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Item/Create.cshtml
@@ -1,7 +1,13 @@
 @using Orchard.ContentManagement
 @using Orchard.Utility.Extensions
 @using Orchard.ContentManagement.Aspects;
+@using Orchard.ContentManagement.MetaData;
+@using Orchard.ContentManagement.MetaData.Models;
+@using Orchard.Core.Contents.Settings;
+
 @{
+    IContentDefinitionManager _contentDefinitionManager = WorkContext.Resolve<IContentDefinitionManager>();
+
     ContentItem customForm = Model.ContentItem;
     string returnUrl = Model.ReturnUrl;
     var metadata = customForm.ContentManager.GetItemMetadata(customForm);
@@ -14,6 +20,18 @@
 
     var submitButtonText = String.IsNullOrEmpty(Model.ContentItem.CustomFormPart.SubmitButtonText) ? T("Submit").Text : Model.ContentItem.CustomFormPart.SubmitButtonText;
     var publishButtonText = String.IsNullOrEmpty(Model.ContentItem.CustomFormPart.PublishButtonText) ? T("Publish").Text : Model.ContentItem.CustomFormPart.PublishButtonText;
+
+    var showPublishButton = Model.ContentItem.CustomFormPart.SavePublishContentItem;
+    // Read type definition to check if content is draftable
+    var typeDefinition = _contentDefinitionManager
+        .ListTypeDefinitions()
+        .Where(x => String.Equals(x.Name, Model.ContentItem.CustomFormPart.ContentType, StringComparison.OrdinalIgnoreCase))
+        .FirstOrDefault();
+    if (typeDefinition != null) {
+        // Publish button has to be visible only if content is draftable AND is set to show the publish button
+        showPublishButton = showPublishButton &&
+            typeDefinition.Settings.GetModel<ContentTypeSettings>().Draftable;
+    }
 }
 
 @Display(New.Parts_Title().Title(displayText))
@@ -29,8 +47,22 @@
         @if (Model.ContentItem.CustomFormPart.SavePublishContentItem == false || Model.ContentItem.CustomFormPart.SaveContentItem == true) {
             <button type="submit" name="submit.Save" value="submit.Save">@submitButtonText</button>
         }
-        @if (Model.ContentItem.CustomFormPart.SavePublishContentItem == true) {
+        @if (showPublishButton) {
             <button type="submit" name="submit.Publish" value="submit.Publish">@publishButtonText</button>
         }
     </fieldset>
+
+
+    <div class="edit-item-secondary group">
+        @if (Model.Actions != null) {
+            <div class="edit-item-actions">
+                @Display(Model.Actions)
+            </div>
+        }
+        @if (Model.Sidebar != null) {
+            <div class="edit-item-sidebar group">
+                @Display(Model.Sidebar)
+            </div>
+        }
+    </div>
 }

--- a/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Parts.CustomForm.Wrapper.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.CustomForms/Views/Parts.CustomForm.Wrapper.cshtml
@@ -1,4 +1,10 @@
-﻿@{
+﻿@using Orchard.ContentManagement.MetaData;
+@using Orchard.ContentManagement.MetaData.Models;
+@using Orchard.Core.Contents.Settings;
+
+@{
+    IContentDefinitionManager _contentDefinitionManager = WorkContext.Resolve<IContentDefinitionManager>();
+
     dynamic editor = Model.Editor;
 
     if (TempData.ContainsKey("CustomFormWidget.InvalidCustomFormState")) {
@@ -7,18 +13,34 @@
 
     // remove default Save/Publish buttons
     editor.Zones["Sidebar"].Items.Clear();
+
+    var showPublishButton = Model.ContentItem.CustomFormPart.SavePublishContentItem;
+
+    // Read type definition to check if content is draftable
+    var typeDefinition = _contentDefinitionManager
+        .ListTypeDefinitions()
+        .Where(x => String.Equals(x.Name, Model.ContentItem.CustomFormPart.ContentType, StringComparison.OrdinalIgnoreCase))
+        .FirstOrDefault();
+    if (typeDefinition != null) {
+        // Publish button has to be visible only if content is draftable AND is set to show the publish button
+        showPublishButton = showPublishButton &&
+            typeDefinition.Settings.GetModel<ContentTypeSettings>().Draftable;
+    }
 }
 
 @using (Html.BeginFormAntiForgeryPost(Url.Action("Create", "Item", new { area = "Orchard.CustomForms", id = Model.ContentItem.Id }))) {
-    @Html.ValidationSummary()
+@Html.ValidationSummary()
     // Model is a Shape, calling Display() so that it is rendered using the most specific template for its Shape type
-    @Display(editor)
-    @Html.Hidden("returnUrl", Request.RawUrl, new { id = string.Empty });
-    @Html.Hidden("contentId", !string.IsNullOrWhiteSpace(Request.QueryString["contentId"]) ? Request.QueryString["contentId"] : "0", new { id = string.Empty });
-    <fieldset class="submit-button">
-            <button type="submit" name="submit.Save" value="submit.Save">@Model.ContentPart.SubmitButtonText</button>
-        @if (Model.ContentItem.CustomFormPart.SavePublishContentItem == true) {
-            <button type="submit" name="submit.Publish" value="submit.Publish">@Model.ContentPart.PublishButtonText</button>
-        }
-    </fieldset>
+@Display(editor)
+
+@Html.Hidden("returnUrl", Request.RawUrl, new { id = string.Empty });
+@Html.Hidden("contentId", !string.IsNullOrWhiteSpace(Request.QueryString["contentId"]) ? Request.QueryString["contentId"] : "0", new { id = string.Empty });
+
+<fieldset class="submit-button">
+
+    <button type="submit" name="submit.Save" value="submit.Save">@Model.ContentPart.SubmitButtonText</button>
+    @if (showPublishButton) {
+        <button type="submit" name="submit.Publish" value="submit.Publish">@Model.ContentPart.PublishButtonText</button>
+    }
+</fieldset>
 }


### PR DESCRIPTION
I know this is a deprecated module, but we are using its features for several products, so we are still mantaining it.

This patch checks that the publish button is properly displayed only when needed (content is draftable AND is set to show the publish button.
It also ensures the detail shape is displayed only when needed (e.g. it's not displayed anymore when display type is "SummaryAdmin", like inside a ContentPickerField select dialog).

Added EditorBuilderWrapper and its interface to make CustomForms easily extensible via other modules.