### PR TITLE
Added chain to Slug token to enable TextTokens for Autoroute configuration

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Autoroute/Providers/SlugTokens.cs
+++ b/src/Orchard.Web/Modules/Orchard.Autoroute/Providers/SlugTokens.cs
@@ -41,6 +41,7 @@ namespace Orchard.Autoroute.Providers {
             context.For<IContent>("Content")
                 // {Content.Slug}
                 .Token("Slug", (content => content == null ? String.Empty : _slugService.Slugify(content)))
+                .Chain("Slug", "Text", (content => content == null ? String.Empty : _slugService.Slugify(content)))
                 .Token("Path", (content => {
                     var autoroutePart = content.As<AutoroutePart>();
                     if (autoroutePart == null) {


### PR DESCRIPTION
In reference to #8754 , I added a chain to the Slug token, mainly to let me limit the length of the autoroute path with a token like {Content.Slug.Limit:100}