### PR TITLE
Added data annotation to have a proper validation on MenuText length 

### DIFF
--- a/src/Orchard.Web/Core/Navigation/ViewModels/MenuPartViewModel.cs
+++ b/src/Orchard.Web/Core/Navigation/ViewModels/MenuPartViewModel.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using Orchard.ContentManagement;
+using Orchard.Core.Navigation.Models;
 
 namespace Orchard.Core.Navigation.ViewModels {
     public class MenuPartViewModel {
@@ -7,7 +9,8 @@ namespace Orchard.Core.Navigation.ViewModels {
         public int CurrentMenuId { get; set; }
         public bool OnMenu { get; set; }
 
-        public ContentItem ContentItem { get; set; } 
+        public ContentItem ContentItem { get; set; }
+        [StringLength(MenuPartRecord.DefaultMenuTextLength)]
         public string MenuText { get; set; }
     }
 }


### PR DESCRIPTION
As the title says. I added a data annotation to validate MenuText length based on its maximum length on database (MenuPartRecord.DefaultMenuTextLength).

Reference issue: #8756 