### PR TITLE
Using content item's ContentManager for lazy field loading instead of the injected one

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TermsPartHandler.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Handlers/TermsPartHandler.cs
@@ -65,7 +65,8 @@ namespace Orchard.Taxonomies.Handlers {
                 var tempField = field.Name;
                 field.TermsField.Loader(() => {
                     var fieldTermRecordIds = part.Record.Terms.Where(t => t.Field == tempField).Select(tci => tci.TermRecord.Id);
-                    var terms = _contentManager.GetMany<TermPart>(fieldTermRecordIds, VersionOptions.Published, queryHint);
+                    // Using context content item's ContentManager instead of injected one to avoid lifetime scope exceptions in case of LazyFields.
+                    var terms = part.ContentItem.ContentManager.GetMany<TermPart>(fieldTermRecordIds, VersionOptions.Published, queryHint);
                     return terms.ToList();
                 });
             }
@@ -73,7 +74,8 @@ namespace Orchard.Taxonomies.Handlers {
             part._termParts = new LazyField<IEnumerable<TermContentItemPart>>();
             part._termParts.Loader(() => {
                 var ids = part.Terms.Select(t => t.TermRecord.Id).Distinct();
-                var terms = _contentManager.GetMany<TermPart>(ids, VersionOptions.Published, queryHint)
+                // Using context content item's ContentManager instead of injected one to avoid lifetime scope exceptions in case of LazyFields.
+                var terms = part.ContentItem.ContentManager.GetMany<TermPart>(ids, VersionOptions.Published, queryHint)
                     .ToDictionary(t => t.Id, t => t);
                 return
                     part.Terms.Select(


### PR DESCRIPTION
In reference to issue #8760 and similar to pr #8725 (involving ContentPickerField and MediaLibraryPickerField), lazy field content items are now loaded using the content manager of the part instead of the injected content manager, which sometimes throws exceptions.