### PR TITLE
Corrections on media resizing process

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaProcessing/Orchard.MediaProcessing.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaProcessing/Orchard.MediaProcessing.csproj
@@ -123,6 +123,10 @@
       <Project>{642A49D7-8752-4177-80D6-BFBBCFAD3DE0}</Project>
       <Name>Orchard.Forms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Orchard.MediaLibrary\Orchard.MediaLibrary.csproj">
+      <Project>{73a7688a-5bd3-4f7e-adfa-ce36c5a10e3b}</Project>
+      <Name>Orchard.MediaLibrary</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Orchard.Tokens\Orchard.Tokens.csproj">
       <Project>{6f759635-13d7-4e94-bcc9-80445d63f117}</Project>
       <Name>Orchard.Tokens</Name>


### PR DESCRIPTION
In reference to issue #8745 , GetImageProfileUrl function has been patched to avoid some exceptions in case the media Orchard is trying to resize cannot be resize (for instance, in case it's a svg file).

I tried to comment the code as clearly as I could but, basically, I check if there is a ImagePart in the content item passed as a parameter of the GetImageProfileUrl function.
If there is no ImagePart, the media isn't processed and the file path returned is the original path with the "v" query string parameter to ensure it's the last version of the file and avoid client side browser cache issues.

I noticed sometimes no contentItem parameter is passed to the function: in those cases, Orchard tries to process / resize the file and could potentially trigger the same exceptions the patch would solve.
Example:
If ImageProfileManager is called via the following code inside a razor shape:

`var imgSrc = Display.ResizeMediaUrl(
                        Width: 250, Height: 250, Mode: "crop", Alignment: "middlecenter", Path: mediaPart.MediaUrl);`

and the media is a vector image, the file processing would fail triggering the exception described in the referenced issue.

So, this patch solves the described issue in most cases but image processing could still log exceptions.

Note: I added the reference to Orchard.MediaLibrary in a second commit because somehow TortoiseGit didn't add it to the first cherry-pick commit.