### PR TITLE
Fix for "Index out of bounds of array" when chaining CPF tokens

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ContentPicker/Tokens/FieldTokens.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentPicker/Tokens/FieldTokens.cs
@@ -3,6 +3,7 @@ using Orchard.ContentManagement;
 using Orchard.Events;
 using Orchard.ContentPicker.Fields;
 using Orchard.Localization;
+using NHibernate.Util;
 
 namespace Orchard.ContentPicker.Tokens {
     public interface ITokenProvider : IEventHandler {
@@ -28,7 +29,10 @@ namespace Orchard.ContentPicker.Tokens {
         public void Evaluate(dynamic context) {
             context.For<ContentPickerField>("ContentPickerField")
                 .Token("Content", (Func<ContentPickerField, object>)(field => field.Ids[0]))
-                .Chain("Content", "Content", (Func<ContentPickerField, object>)(field => _contentManager.Get(field.Ids[0])))
+                .Chain("Content", "Content", (Func<ContentPickerField, object>)(field => {
+                    var id = field.Ids.Any() ? field.Ids[0] : 0; 
+                    return _contentManager.Get(id);
+                }))
                 ;
         }
     }


### PR DESCRIPTION
When chaining tokens, if nothing was selected in a CPF, evaluation would log an error because it would seek an item out of the range of the array. (It would seek item at index 0 when no item was there).
In most real cases, the only consequence of this would have been "spam" in the error log, but that is annoying enough.