### PR TITLE
Ambiguity in LocalizedTaxonomyController action names

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
@@ -27,7 +27,7 @@ namespace Orchard.Taxonomies.Controllers {
         [OutputCache(NoStore = true, Duration = 0)]
         public override ActionResult GetTaxonomy(string contentTypeName, string taxonomyFieldName, int contentId, string culture, string selectedValues) {
             AdminFilter.Apply(_requestContext);
-            AdminFilter.Apply(_requestContext);
+            return base.GetTaxonomy(contentTypeName, taxonomyFieldName, contentId, culture, selectedValues);
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
@@ -24,7 +24,9 @@ namespace Orchard.Taxonomies.Controllers {
             _requestContext = requestContext;
         }
 
-        protected override void ApplyPreRequest() {
+        [OutputCache(NoStore = true, Duration = 0)]
+        public override ActionResult GetTaxonomy(string contentTypeName, string taxonomyFieldName, int contentId, string culture, string selectedValues) {
+            AdminFilter.Apply(_requestContext);
             AdminFilter.Apply(_requestContext);
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Routing;
+﻿using System.Web.Mvc;
+﻿﻿using System.Web.Routing;
 using Orchard.ContentManagement.MetaData;
 using Orchard.Environment.Extensions;
 using Orchard.Localization.Services;

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
@@ -1,5 +1,4 @@
-﻿using System.Web.Mvc;
-using System.Web.Routing;
+﻿using System.Web.Routing;
 using Orchard.ContentManagement.MetaData;
 using Orchard.Environment.Extensions;
 using Orchard.Localization.Services;

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/AdminLocalizedTaxonomyController.cs
@@ -24,11 +24,8 @@ namespace Orchard.Taxonomies.Controllers {
             _requestContext = requestContext;
         }
 
-        [OutputCache(NoStore = true, Duration = 0)]
-        public new ActionResult GetTaxonomy(string contentTypeName, string taxonomyFieldName, int contentId, string culture, string selectedValues) {
+        protected override void ApplyPreRequest() {
             AdminFilter.Apply(_requestContext);
-
-            return GetTaxonomyInternal(contentTypeName, taxonomyFieldName, contentId, culture, selectedValues);
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -36,6 +36,7 @@ namespace Orchard.Taxonomies.Controllers {
 
         [OutputCache(NoStore = true, Duration = 0)]
         public ActionResult GetTaxonomy(string contentTypeName, string taxonomyFieldName, int contentId, string culture, string selectedValues) {
+            ApplyPreRequest();
             return GetTaxonomyInternal(contentTypeName, taxonomyFieldName, contentId, culture, selectedValues);
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -35,7 +35,7 @@ namespace Orchard.Taxonomies.Controllers {
         }
 
         [OutputCache(NoStore = true, Duration = 0)]
-        public ActionResult GetTaxonomy(string contentTypeName, string taxonomyFieldName, int contentId, string culture, string selectedValues) {
+        public virtual ActionResult GetTaxonomy(string contentTypeName, string taxonomyFieldName, int contentId, string culture, string selectedValues) {
             return GetTaxonomyInternal(contentTypeName, taxonomyFieldName, contentId, culture, selectedValues);
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -125,5 +125,9 @@ namespace Orchard.Taxonomies.Controllers {
             var templateName = autocomplete ? "../EditorTemplates/Fields/TaxonomyField.Autocomplete" : "../EditorTemplates/Fields/TaxonomyField";
             return PartialView(templateName, viewModel);
         }
+
+        protected virtual void ApplyPreRequest() {
+            
+        }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -36,7 +36,6 @@ namespace Orchard.Taxonomies.Controllers {
 
         [OutputCache(NoStore = true, Duration = 0)]
         public ActionResult GetTaxonomy(string contentTypeName, string taxonomyFieldName, int contentId, string culture, string selectedValues) {
-            ApplyPreRequest();
             return GetTaxonomyInternal(contentTypeName, taxonomyFieldName, contentId, culture, selectedValues);
         }
 

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -125,7 +125,5 @@ namespace Orchard.Taxonomies.Controllers {
             var templateName = autocomplete ? "../EditorTemplates/Fields/TaxonomyField.Autocomplete" : "../EditorTemplates/Fields/TaxonomyField";
             return PartialView(templateName, viewModel);
         }
-
-        protected virtual void ApplyPreRequest() { }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -40,7 +40,7 @@ namespace Orchard.Taxonomies.Controllers {
             return GetTaxonomyInternal(contentTypeName, taxonomyFieldName, contentId, culture, selectedValues);
         }
 
-        protected ActionResult GetTaxonomyInternal (string contentTypeName, string taxonomyFieldName, int contentId, string culture, string selectedValues) {
+        protected ActionResult GetTaxonomyInternal(string contentTypeName, string taxonomyFieldName, int contentId, string culture, string selectedValues) {
             var viewModel = new TaxonomyFieldViewModel();
             bool autocomplete = false;
             var contentDefinition = _contentDefinitionManager.GetTypeDefinition(contentTypeName);

--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Controllers/LocalizedTaxonomyController.cs
@@ -127,8 +127,6 @@ namespace Orchard.Taxonomies.Controllers {
             return PartialView(templateName, viewModel);
         }
 
-        protected virtual void ApplyPreRequest() {
-            
-        }
+        protected virtual void ApplyPreRequest() { }
     }
 }


### PR DESCRIPTION
This fixes an ambiguity issue for the GetTaxonomy action of LocalizedTaxonomyController. There was a "new GetTaxonomy" action in AdminLocalizedTaxonomyController too that was ambiguous, failing to properly work. For this reason, the action has been removed from AdminLocalizedTaxonomyController and the admin filter is added via override of the ApplyPreRequest function.