### PR TITLE
#8640: Fixing consistency between different Enumeration Field flavors' data storage

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
@@ -33,7 +33,7 @@ namespace Orchard.Fields.Drivers {
                 if (part.IsNew() && string.IsNullOrEmpty(field.Value)) {
                     var settings = field.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
                     if (!string.IsNullOrWhiteSpace(settings.DefaultValue)) {
-                        field.Value = settings.DefaultValue;
+                        field.SelectedValues = new string[] { settings.DefaultValue };
                     }
                 }
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
@@ -4,46 +4,41 @@ using Orchard.ContentManagement.Handlers;
 using Orchard.Fields.Fields;
 using Orchard.Fields.Settings;
 using Orchard.Localization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Orchard.Fields.Drivers {
     public class EnumerationFieldDriver : ContentFieldDriver<EnumerationField> {
         public IOrchardServices Services { get; set; }
+
         private const string TemplateName = "Fields/Enumeration.Edit";
 
         public EnumerationFieldDriver(IOrchardServices services) {
             Services = services;
+
             T = NullLocalizer.Instance;
         }
 
         public Localizer T { get; set; }
 
-        private static string GetPrefix(ContentField field, ContentPart part) {
-            return part.PartDefinition.Name + "." + field.Name;
-        }
+        private static string GetPrefix(ContentField field, ContentPart part) =>
+            part.PartDefinition.Name + "." + field.Name;
 
-        private static string GetDifferentiator(EnumerationField field, ContentPart part) {
-            return field.Name;
-        }
+        private static string GetDifferentiator(EnumerationField field) => field.Name;
 
         protected override DriverResult Display(ContentPart part, EnumerationField field, string displayType, dynamic shapeHelper) {
-            return ContentShape("Fields_Enumeration", GetDifferentiator(field, part),
-                                () => shapeHelper.Fields_Enumeration());
+            return ContentShape("Fields_Enumeration", GetDifferentiator(field), () => shapeHelper.Fields_Enumeration());
         }
 
         protected override DriverResult Editor(ContentPart part, EnumerationField field, dynamic shapeHelper) {
-            return ContentShape("Fields_Enumeration_Edit", GetDifferentiator(field, part),
-                () => {
-                    if (part.IsNew() && String.IsNullOrEmpty(field.Value)) {
-                        var settings = field.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
-                        if (!String.IsNullOrWhiteSpace(settings.DefaultValue)) {
-                            field.Value = settings.DefaultValue;
-                        }
+            return ContentShape("Fields_Enumeration_Edit", GetDifferentiator(field), () => {
+                if (part.IsNew() && string.IsNullOrEmpty(field.Value)) {
+                    var settings = field.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
+                    if (!string.IsNullOrWhiteSpace(settings.DefaultValue)) {
+                        field.Value = settings.DefaultValue;
                     }
-                    return shapeHelper.EditorTemplate(TemplateName: TemplateName, Model: field, Prefix: GetPrefix(field, part));
-                });
+                }
+
+                return shapeHelper.EditorTemplate(TemplateName: TemplateName, Model: field, Prefix: GetPrefix(field, part));
+            });
         }
 
         protected override DriverResult Editor(ContentPart part, EnumerationField field, IUpdateModel updater, dynamic shapeHelper) {

--- a/src/Orchard.Web/Modules/Orchard.Fields/Fields/EnumerationField.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Fields/EnumerationField.cs
@@ -7,18 +7,23 @@ namespace Orchard.Fields.Fields {
         private const char Separator = ';';
 
         public string Value {
-            get { return Storage.Get<string>(); }
-            set { Storage.Set(value ?? String.Empty); }
+            get { return Storage.Get<string>().Trim(new char[] { Separator }); }
+            set {
+                Storage.Set(string.IsNullOrEmpty(value)
+                    ? string.Empty
+                    // we add the Separator around the value here
+                    : Separator + value.Trim(new char[] { Separator }) + Separator);
+            }
         }
 
         public string[] SelectedValues {
             get {
                 var value = Value;
-                if(string.IsNullOrWhiteSpace(value)) {
+                if (string.IsNullOrWhiteSpace(value)) {
                     return new string[0];
                 }
 
-                return value.Split(new [] { Separator }, StringSplitOptions.RemoveEmptyEntries);
+                return value.Split(new[] { Separator }, StringSplitOptions.RemoveEmptyEntries);
             }
 
             set {
@@ -26,7 +31,8 @@ namespace Orchard.Fields.Fields {
                     Value = String.Empty;
                 }
                 else {
-                    Value = Separator + string.Join(Separator.ToString(), value) + Separator;
+                    // we don't need to add the Separator around the string here anymore
+                    Value = string.Join(Separator.ToString(), value);
                 }
             }
         }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Fields/EnumerationField.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Fields/EnumerationField.cs
@@ -7,34 +7,16 @@ namespace Orchard.Fields.Fields {
         private const char Separator = ';';
 
         public string Value {
-            get { return Storage.Get<string>().Trim(new char[] { Separator }); }
-            set {
-                Storage.Set(string.IsNullOrEmpty(value)
-                    ? string.Empty
-                    // we add the Separator around the value here
-                    : Separator + value.Trim(new char[] { Separator }) + Separator);
-            }
+            get => Storage.Get<string>()?.Trim(Separator) ?? "";
+            set => Storage.Set(string.IsNullOrWhiteSpace(value)
+                ? string.Empty
+                // It is now the responsibility of this field to (re-)add the separators.
+                : Separator + value.Trim(Separator) + Separator);
         }
 
         public string[] SelectedValues {
-            get {
-                var value = Value;
-                if (string.IsNullOrWhiteSpace(value)) {
-                    return new string[0];
-                }
-
-                return value.Split(new[] { Separator }, StringSplitOptions.RemoveEmptyEntries);
-            }
-
-            set {
-                if (value == null || value.Length == 0) {
-                    Value = String.Empty;
-                }
-                else {
-                    // we don't need to add the Separator around the string here anymore
-                    Value = string.Join(Separator.ToString(), value);
-                }
-            }
+            get => Value?.Split(new[] { Separator }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
+            set => Value = value?.Length > 0 ? string.Join(Separator.ToString(), value) : "";
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
@@ -11,16 +11,16 @@
     <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text> }>@Model.DisplayName</label>
     @switch (settings.ListMode) {
         case ListMode.Dropdown:
-            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.Value), settings.Required ? new { required = "required" } : null)
+            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)
             break;
 
         case ListMode.Radiobutton:
             foreach (var option in options) {
                 if (string.IsNullOrWhiteSpace(option)) {
-                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.Value), settings.Required ? new { required = "required" } : null)<i>@T("unset")</i></label>
+                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)<i>@T("unset")</i></label>
                 }
                 else {
-                    <label>@Html.RadioButton("Value", option, (option == Model.Value), settings.Required ? new { required = "required" } : null)@option</label>
+                    <label>@Html.RadioButton("Value", option, (option == Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)@option</label>
                 }
             }
             break;

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
@@ -1,11 +1,14 @@
 ﻿@model Orchard.Fields.Fields.EnumerationField
+
 @using Orchard.Fields.Settings;
+
 @{
     var settings = Model.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
     string[] options = (!String.IsNullOrWhiteSpace(settings.Options)) ? settings.Options.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.None) : new string[] { T("Select an option").ToString() };
 }
+
 <fieldset>
-    <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text>  }>@Model.DisplayName</label>
+    <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text> }>@Model.DisplayName</label>
     @switch (settings.ListMode) {
         case ListMode.Dropdown:
             @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.Value), settings.Required ? new { required = "required" } : null)
@@ -14,9 +17,11 @@
         case ListMode.Radiobutton:
             foreach (var option in options) {
                 if (string.IsNullOrWhiteSpace(option)) {
-                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.Value), settings.Required ? new { required = "required" } : null)<i>@T("unset")</i></label>            }
+                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.Value), settings.Required ? new { required = "required" } : null)<i>@T("unset")</i></label>
+                }
                 else {
-                    <label>@Html.RadioButton("Value", option, (option == Model.Value), settings.Required ? new { required = "required" } : null)@option</label>         }
+                    <label>@Html.RadioButton("Value", option, (option == Model.Value), settings.Required ? new { required = "required" } : null)@option</label>
+                }
             }
             break;
 


### PR DESCRIPTION
Fixes #8460

Initial logic taken from https://github.com/OrchardCMS/Orchard/issues/8460#issuecomment-784337514.
This PR supersedes #8298 and targets 1.10.x instead, because the changes are backwards-compatible.

Tested with a custom content type that has each of the Enumeration Field flavors and saved the same values before/after the change:

**Before without anything selected (dropdown defaults to first item)**

```
<EnumerationCheckbox>;;</EnumerationCheckbox>
<EnumerationDropdown>qwer</EnumerationDropdown>
<EnumerationListbox>;;</EnumerationListbox>
```

**After without anything selected (dropdown defaults to first item)**

```
<EnumerationCheckbox></EnumerationCheckbox>
<EnumerationDropdown>;qwer;</EnumerationDropdown>
<EnumerationListbox></EnumerationListbox>
```

**Before with some values selected**

```
<EnumerationCheckbox>;;qwer;asdf;</EnumerationCheckbox>
<EnumerationDropdown>asdf</EnumerationDropdown>
<EnumerationListbox>;;qwer;asdf;</EnumerationListbox>
<EnumerationRadio>yxcv</EnumerationRadio>
```

**After with some values selected**

```
<EnumerationCheckbox>;qwer;asdf;</EnumerationCheckbox>
<EnumerationDropdown>;asdf;</EnumerationDropdown>
<EnumerationListbox>;qwer;asdf;</EnumerationListbox>
<EnumerationRadio>;yxcv;</EnumerationRadio>
```

Also fixed the issues in 5e48b76278f333f57d5e06458bcb0c7c6bcb865b Sébastien pointed out in https://github.com/OrchardCMS/Orchard/pull/8298#issuecomment-562302112.