### PR TITLE
Fix to import Vimeo videos

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
@@ -103,11 +103,12 @@ namespace Orchard.MediaLibrary.Controllers {
 
                 var source = "";
 
+                var uri = GetRedirectUrl(url);
+
                 // Vimeo doesn't consent anymore the scraping of web pages, so the direct api call has to be enforced.
                 // In this case, the downloaded string is already the expected xml, in the format that needs to be parsed.
                 // Legacy process is done for non-Vimeo content.
                 // First of all, url domain is checked.
-                var uri = GetRedirectUrl(url);
                 var vimeo = uri.Host.Equals("vimeo.com", StringComparison.OrdinalIgnoreCase);
 
                 // Youtube changed the markup of the page of its videos, so the direct api call has to be enforced

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
@@ -86,10 +86,8 @@ namespace Orchard.MediaLibrary.Controllers {
 
                 // Vimeo doesn't consent anymore the scraping of web pages, so the direct api call has to be enforced.
                 // In this case, the downloaded string is already the expected xml, in the format that needs to be parsed.
-                // Legacy process is done either way.
-                // At the end of it, oembedSignature value will still be -1.
-                // So the downloaded string is parsed.
-                // Check if url is inside Vimeo domain.
+                // Legacy process is done for non-Vimeo content.
+                // First of all, url domain is checked.
                 var uri = new Uri(url);
                 var vimeo = uri.Host.Equals("vimeo.com", StringComparison.OrdinalIgnoreCase) ||
                     uri.Host.Equals("www.vimeo.com", StringComparison.OrdinalIgnoreCase);

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
@@ -56,25 +56,6 @@ namespace Orchard.MediaLibrary.Controllers {
             return View(viewModel);
         }
 
-        private Uri GetRedirectUrl(string url) {
-            var redirectedUrl = url;
-
-            Uri myUri = new Uri(url);
-            // Create a 'HttpWebRequest' object for the specified url.
-            HttpWebRequest myHttpWebRequest = (HttpWebRequest)WebRequest.Create(myUri);
-            // Send the request and wait for response.
-            HttpWebResponse myHttpWebResponse = (HttpWebResponse)myHttpWebRequest.GetResponse();
-
-            if (!myUri.Equals(myHttpWebResponse.ResponseUri)) {
-                myUri = myHttpWebResponse.ResponseUri;
-            }
-
-            // Release resources of response object.
-            myHttpWebResponse.Close();
-
-            return myUri;
-        }
-
         [HttpPost]
         [ActionName("Index")]
         [ValidateInput(false)]
@@ -103,7 +84,8 @@ namespace Orchard.MediaLibrary.Controllers {
 
                 var source = "";
 
-                var uri = GetRedirectUrl(url);
+                // Get the proper uri the provider redirects to
+                var uri = GetRedirectUri(url);
 
                 // Vimeo doesn't consent anymore the scraping of web pages, so the direct api call has to be enforced.
                 // In this case, the downloaded string is already the expected xml, in the format that needs to be parsed.
@@ -280,6 +262,25 @@ namespace Orchard.MediaLibrary.Controllers {
             }
 
             return RedirectToAction("Index", new { folderPath = replaceMedia.FolderPath, replaceId = replaceMedia.Id });
+        }
+
+        private Uri GetRedirectUri(string url) {
+            var redirectedUrl = url;
+
+            Uri myUri = new Uri(url);
+            // Create a 'HttpWebRequest' object for the specified url.
+            HttpWebRequest myHttpWebRequest = (HttpWebRequest)WebRequest.Create(myUri);
+            // Send the request and wait for response.
+            HttpWebResponse myHttpWebResponse = (HttpWebResponse)myHttpWebRequest.GetResponse();
+
+            if (!myUri.Equals(myHttpWebResponse.ResponseUri)) {
+                myUri = myHttpWebResponse.ResponseUri;
+            }
+
+            // Release resources of response object.
+            myHttpWebResponse.Close();
+
+            return myUri;
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
@@ -91,9 +91,22 @@ namespace Orchard.MediaLibrary.Controllers {
                 var uri = new Uri(url);
                 var vimeo = uri.Host.Equals("vimeo.com", StringComparison.OrdinalIgnoreCase) ||
                     uri.Host.Equals("www.vimeo.com", StringComparison.OrdinalIgnoreCase);
+
+                // Youtube changed the markup of the page of its videos, so the direct api call has to be enforced
+                // Api url is built based on the requested video
+                var youtube = uri.Host.Equals("youtu.be", StringComparison.OrdinalIgnoreCase) ||
+                    uri.Host.Equals("youtube.com", StringComparison.OrdinalIgnoreCase) ||
+                    uri.Host.Equals("www.youtube.com", StringComparison.OrdinalIgnoreCase);
+
                 if (vimeo) {
                     // Add api url to original url provided as a parameter
                     url = "http://vimeo.com/api/oembed.xml?url=" + url;
+                    source = webClient.DownloadString(url);
+
+                    viewModel.Content = XDocument.Parse(source);
+                } else if (youtube) {
+                    // Add api url to original url provided as a parameter
+                    url = "https://www.youtube.com/oembed?format=xml&url=" + url;
                     source = webClient.DownloadString(url);
 
                     viewModel.Content = XDocument.Parse(source);

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Controllers/OEmbedController.cs
@@ -265,8 +265,6 @@ namespace Orchard.MediaLibrary.Controllers {
         }
 
         private Uri GetRedirectUri(string url) {
-            var redirectedUrl = url;
-
             Uri myUri = new Uri(url);
             // Create a 'HttpWebRequest' object for the specified url.
             HttpWebRequest myHttpWebRequest = (HttpWebRequest)WebRequest.Create(myUri);


### PR DESCRIPTION
In reference to #8803 , added a fix to avoid the scraping of the "vimeo.com/xxxx" page (which replies with a 429 http error) by forcing the direct api call if Vimeo domain is recognized.