### PR TITLE
Internal page links validation for LinkField

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Link.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Link.Edit.cshtml
@@ -25,7 +25,7 @@
     </div>
     <div class="editor-field">
         @(settings.Required ? Html.TextBoxFor(m => m.Value, new { @class = "text large", required = "required" }) : Html.TextBoxFor(m => m.Value, new { @class = "text large" }))
-        <span class="hint">@T("A valid url, i.e. http://orchardproject.net, /content/file.pdf, ...")</span>
+        <span class="hint">@T("A valid url, i.e. http://orchardproject.net, /content/file.pdf, #some_id, ...")</span>
     </div>
     @if (settings.LinkTextMode == LinkTextMode.Optional || settings.LinkTextMode == LinkTextMode.Required) {
         <div class="editor-label">


### PR DESCRIPTION
We need to validate internal page references to a tag id in LinkFields, so I patched the LinkFieldDriver to validate urls like "mysite/mypage#mydiv" or just "#mydiv".
I also changed the hint in the editor shape to add "#someId" to the examples for valid field values.

The field value is divided in prefix and anchor to be sure to properly validate the format of the actual page the field is linking to:
A value like "http://mysite.com/page#div" is divided in two separate validations:
- "http://mysite.com/page" is validated with the original Uri.IsWellFormedUriString(string) function.
- "div" is validated by checking for the presence of white spaces inside the string (white space is the only forbidden character for html 5 tag ids).