### PR TITLE
#8800: Reverting breaking changes to Enumeration Fields caused by #8789

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Drivers/EnumerationFieldDriver.cs
@@ -4,41 +4,46 @@ using Orchard.ContentManagement.Handlers;
 using Orchard.Fields.Fields;
 using Orchard.Fields.Settings;
 using Orchard.Localization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Orchard.Fields.Drivers {
     public class EnumerationFieldDriver : ContentFieldDriver<EnumerationField> {
         public IOrchardServices Services { get; set; }
-
         private const string TemplateName = "Fields/Enumeration.Edit";
 
         public EnumerationFieldDriver(IOrchardServices services) {
             Services = services;
-
             T = NullLocalizer.Instance;
         }
 
         public Localizer T { get; set; }
 
-        private static string GetPrefix(ContentField field, ContentPart part) =>
-            part.PartDefinition.Name + "." + field.Name;
+        private static string GetPrefix(ContentField field, ContentPart part) {
+            return part.PartDefinition.Name + "." + field.Name;
+        }
 
-        private static string GetDifferentiator(EnumerationField field) => field.Name;
+        private static string GetDifferentiator(EnumerationField field, ContentPart part) {
+            return field.Name;
+        }
 
         protected override DriverResult Display(ContentPart part, EnumerationField field, string displayType, dynamic shapeHelper) {
-            return ContentShape("Fields_Enumeration", GetDifferentiator(field), () => shapeHelper.Fields_Enumeration());
+            return ContentShape("Fields_Enumeration", GetDifferentiator(field, part),
+                                () => shapeHelper.Fields_Enumeration());
         }
 
         protected override DriverResult Editor(ContentPart part, EnumerationField field, dynamic shapeHelper) {
-            return ContentShape("Fields_Enumeration_Edit", GetDifferentiator(field), () => {
-                if (part.IsNew() && string.IsNullOrEmpty(field.Value)) {
-                    var settings = field.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
-                    if (!string.IsNullOrWhiteSpace(settings.DefaultValue)) {
-                        field.SelectedValues = new string[] { settings.DefaultValue };
+            return ContentShape("Fields_Enumeration_Edit", GetDifferentiator(field, part),
+                () => {
+                    if (part.IsNew() && String.IsNullOrEmpty(field.Value)) {
+                        var settings = field.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
+                        if (!String.IsNullOrWhiteSpace(settings.DefaultValue)) {
+                            field.Value = settings.DefaultValue;
+                        }
                     }
-                }
-
-                return shapeHelper.EditorTemplate(TemplateName: TemplateName, Model: field, Prefix: GetPrefix(field, part));
-            });
+                    return shapeHelper.EditorTemplate(TemplateName: TemplateName, Model: field, Prefix: GetPrefix(field, part));
+                });
         }
 
         protected override DriverResult Editor(ContentPart part, EnumerationField field, IUpdateModel updater, dynamic shapeHelper) {

--- a/src/Orchard.Web/Modules/Orchard.Fields/Fields/EnumerationField.cs
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Fields/EnumerationField.cs
@@ -7,16 +7,28 @@ namespace Orchard.Fields.Fields {
         private const char Separator = ';';
 
         public string Value {
-            get => Storage.Get<string>()?.Trim(Separator) ?? "";
-            set => Storage.Set(string.IsNullOrWhiteSpace(value)
-                ? string.Empty
-                // It is now the responsibility of this field to (re-)add the separators.
-                : Separator + value.Trim(Separator) + Separator);
+            get { return Storage.Get<string>(); }
+            set { Storage.Set(value ?? String.Empty); }
         }
 
         public string[] SelectedValues {
-            get => Value?.Split(new[] { Separator }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
-            set => Value = value?.Length > 0 ? string.Join(Separator.ToString(), value) : "";
+            get {
+                var value = Value;
+                if(string.IsNullOrWhiteSpace(value)) {
+                    return new string[0];
+                }
+
+                return value.Split(new [] { Separator }, StringSplitOptions.RemoveEmptyEntries);
+            }
+
+            set {
+                if (value == null || value.Length == 0) {
+                    Value = String.Empty;
+                }
+                else {
+                    Value = Separator + string.Join(Separator.ToString(), value) + Separator;
+                }
+            }
         }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Orchard.Fields.csproj
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Orchard.Fields.csproj
@@ -170,10 +170,6 @@
     <Compile Include="ViewModels\DateTimeFieldViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Controllers\" />
-    <Folder Include="Models\" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Views\Fields\Input.cshtml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
@@ -1,28 +1,51 @@
 ﻿@model Orchard.Fields.Fields.EnumerationField
+
 @using Orchard.Fields.Settings;
+
 @{
     var settings = Model.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
-    string[] options = (!String.IsNullOrWhiteSpace(settings.Options)) ? settings.Options.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.None) : new string[] { T("Select an option").ToString() };
+    string[] options = (!String.IsNullOrWhiteSpace(settings.Options)) ?
+        settings.Options.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.None)
+        : new string[] { T("Select an option").ToString() };
 }
+
 <fieldset>
     <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text> }>@Model.DisplayName</label>
     @switch (settings.ListMode) {
         case ListMode.Dropdown:
-            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)
+            @Html.DropDownListFor(
+                m => m.Value,
+                new SelectList(options, Model.SelectedValues.FirstOrDefault()),
+                settings.Required ? new { required = "required" } : null)
             break;
 
         case ListMode.Radiobutton:
             foreach (var option in options) {
                 if (string.IsNullOrWhiteSpace(option)) {
-                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)<i>@T("unset")</i></label> }
+                    <label>@Html.RadioButton(
+                          "Value",
+                          "",
+                          string.IsNullOrWhiteSpace(Model.SelectedValues.FirstOrDefault()),
+                          settings.Required ? new { required = "required" } : null)<i>@T("unset")</i>
+                    </label>
+                }
                 else {
-                    <label>@Html.RadioButton("Value", option, (option == Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)@option</label> }
+                    <label>@Html.RadioButton(
+                          "Value",
+                          option,
+                          option == Model.SelectedValues.FirstOrDefault(),
+                          settings.Required ? new { required = "required" } : null)@option
+                    </label>
+                }
             }
             break;
 
         case ListMode.Listbox:
             <input name="@Html.FieldNameFor(m => m.SelectedValues)" type="hidden" />
-            @Html.ListBoxFor(m => m.SelectedValues, new MultiSelectList(options, Model.SelectedValues), settings.Required ? new { required = "required" } : null)
+            @Html.ListBoxFor(
+                m => m.SelectedValues,
+                new MultiSelectList(options, Model.SelectedValues),
+                settings.Required ? new { required = "required" } : null)
             break;
 
         case ListMode.Checkbox:
@@ -32,7 +55,9 @@
                 index++;
                 if (!string.IsNullOrWhiteSpace(option)) {
                     <div>
-                        <input type="checkbox" name="@Html.FieldNameFor(m => m.SelectedValues)" value="@option" @((Model.SelectedValues != null && Model.SelectedValues.Contains(option)) ? "checked=\"checked\"" : "") class="check-box" id="@Html.FieldIdFor(m => m.SelectedValues)-@index" />
+                        <input type="checkbox" name="@Html.FieldNameFor(m => m.SelectedValues)" value="@option"
+                               @((Model.SelectedValues != null && Model.SelectedValues.Contains(option)) ? "checked=\"checked\"" : "")
+                               class="check-box" id="@Html.FieldIdFor(m => m.SelectedValues)-@index" />
                         <label class="forcheckbox" for="@Html.FieldIdFor(m => m.SelectedValues)-@index">@option</label>
                     </div>
                 }

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
@@ -5,18 +5,18 @@
     string[] options = (!String.IsNullOrWhiteSpace(settings.Options)) ? settings.Options.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.None) : new string[] { T("Select an option").ToString() };
 }
 <fieldset>
-    <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text>  }>@Model.DisplayName</label>
+    <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text> }>@Model.DisplayName</label>
     @switch (settings.ListMode) {
         case ListMode.Dropdown:
-            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.Value), settings.Required ? new { required = "required" } : null)
+            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)
             break;
 
         case ListMode.Radiobutton:
             foreach (var option in options) {
                 if (string.IsNullOrWhiteSpace(option)) {
-                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.Value), settings.Required ? new { required = "required" } : null)<i>@T("unset")</i></label>            }
+                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)<i>@T("unset")</i></label> }
                 else {
-                    <label>@Html.RadioButton("Value", option, (option == Model.Value), settings.Required ? new { required = "required" } : null)@option</label>         }
+                    <label>@Html.RadioButton("Value", option, (option == Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)@option</label> }
             }
             break;
 

--- a/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Fields/Views/EditorTemplates/Fields/Enumeration.Edit.cshtml
@@ -1,27 +1,22 @@
 ﻿@model Orchard.Fields.Fields.EnumerationField
-
 @using Orchard.Fields.Settings;
-
 @{
     var settings = Model.PartFieldDefinition.Settings.GetModel<EnumerationFieldSettings>();
     string[] options = (!String.IsNullOrWhiteSpace(settings.Options)) ? settings.Options.Split(new string[] { System.Environment.NewLine }, StringSplitOptions.None) : new string[] { T("Select an option").ToString() };
 }
-
 <fieldset>
-    <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text> }>@Model.DisplayName</label>
+    <label for="@Html.FieldIdFor(m => m.Value)" @if (settings.Required) { <text> class="required" </text>  }>@Model.DisplayName</label>
     @switch (settings.ListMode) {
         case ListMode.Dropdown:
-            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)
+            @Html.DropDownListFor(m => m.Value, new SelectList(options, Model.Value), settings.Required ? new { required = "required" } : null)
             break;
 
         case ListMode.Radiobutton:
             foreach (var option in options) {
                 if (string.IsNullOrWhiteSpace(option)) {
-                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)<i>@T("unset")</i></label>
-                }
+                    <label>@Html.RadioButton("Value", "", string.IsNullOrWhiteSpace(Model.Value), settings.Required ? new { required = "required" } : null)<i>@T("unset")</i></label>            }
                 else {
-                    <label>@Html.RadioButton("Value", option, (option == Model.SelectedValues.FirstOrDefault()), settings.Required ? new { required = "required" } : null)@option</label>
-                }
+                    <label>@Html.RadioButton("Value", option, (option == Model.Value), settings.Required ? new { required = "required" } : null)@option</label>         }
             }
             break;
 


### PR DESCRIPTION
This is an alternative to #8801. It reverts the changes merged in #8789, except those that fix the editor template of the EnumerationField. See Option 1 in https://github.com/OrchardCMS/Orchard/issues/8800#issuecomment-2486868481 for an explanation.