### PR TITLE
Moved embed video import to a dedicated service.

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Orchard.MediaLibrary.csproj
@@ -200,7 +200,9 @@
     <Compile Include="Security\MediaAuthorizationEventHandler.cs" />
     <Compile Include="Services\IMediaLibraryService.cs" />
     <Compile Include="Providers\IMediaFolderProvider.cs" />
+    <Compile Include="Services\IOEmbedService.cs" />
     <Compile Include="Services\MediaLibraryService.cs" />
+    <Compile Include="Services\OEmbedService.cs" />
     <Compile Include="Services\Shapes.cs" />
     <Compile Include="Services\XmlRpcHandler.cs" />
     <Compile Include="Settings\MediaLibraryPickerFieldEditorEvents.cs" />

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/IOEmbedService.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/IOEmbedService.cs
@@ -1,0 +1,7 @@
+﻿using System.Xml.Linq;
+
+namespace Orchard.MediaLibrary.Services {
+    public interface IOEmbedService : IDependency {
+        XDocument DownloadMediaData(string url);
+    }
+}

--- a/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/OEmbedService.cs
+++ b/src/Orchard.Web/Modules/Orchard.MediaLibrary/Services/OEmbedService.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using System.Xml.Linq;
+
+namespace Orchard.MediaLibrary.Services {
+    public class OEmbedService : IOEmbedService {
+        public XDocument DownloadMediaData(string url) {
+            var webClient = new WebClient { Encoding = Encoding.UTF8 };
+            XDocument doc = null;
+            try {
+                // <link rel="alternate" href="http://vimeo.com/api/oembed.xml?url=http%3A%2F%2Fvimeo.com%2F23608259" type="text/xml+oembed">
+                var source = webClient.DownloadString(url);
+
+                // seek type="text/xml+oembed" or application/xml+oembed
+                var oembedSignature = source.IndexOf("type=\"text/xml+oembed\"", StringComparison.OrdinalIgnoreCase);
+                if (oembedSignature == -1) {
+                    oembedSignature = source.IndexOf("type=\"application/xml+oembed\"", StringComparison.OrdinalIgnoreCase);
+                }
+                if (oembedSignature != -1) {
+                    var tagStart = source.Substring(0, oembedSignature).LastIndexOf('<');
+                    var tagEnd = source.IndexOf('>', oembedSignature);
+                    var tag = source.Substring(tagStart, tagEnd - tagStart);
+                    var matches = new Regex("href=\"([^\"]+)\"").Matches(tag);
+                    if (matches.Count > 0) {
+                        var href = matches[0].Groups[1].Value;
+                        try {
+                            var content = webClient.DownloadString(HttpUtility.HtmlDecode(href));
+                            doc = XDocument.Parse(content);
+                        } catch {
+                            // bubble exception
+                        }
+                    }
+                }
+            } catch {
+                doc = null;
+            }
+
+            if (doc == null) {
+                doc = new XDocument(
+                    new XDeclaration("1.0", "utf-8", "yes"),
+                    new XElement("oembed")
+                    );
+            }
+
+            return doc;
+        }
+    }
+}


### PR DESCRIPTION
As the title says, following #8804 I reverted oEmbedController to its original version and moved oembed import procedures in a dedicated service; this opens to the possible implementation of the media import from providers like Youtube and Vimeo in a different service.

Current implementation of the service, working for Youtube and Vimeo videos is here: [oEmbedProvidersService](https://github.com/LaserSrl/Laser.Orchard.Platform/blob/951fb317cbd71821cf91d5ba3d0bec010abe6496/src/Modules/Laser.Orchard.StartupConfig/Services/oEmbedProvidersService.cs)
It is not yet in the master branch, but will be merged soon (and current development branch removed).