### PR TITLE
#8828: Expose Redis API to clear multiple keys using wildcard syntax

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Caching/Services/ICacheStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.Caching/Services/ICacheStorageProvider.cs
@@ -8,4 +8,8 @@ namespace Orchard.Caching.Services {
         void Remove(string key);
         void Clear();
     }
+
+    public interface ICacheStorageProviderWithKeyPrefix : ICacheStorageProvider {
+        void Clear(string key);
+    }
 }

--- a/src/Orchard.Web/Modules/Orchard.Redis/Caching/RedisCacheStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.Redis/Caching/RedisCacheStorageProvider.cs
@@ -10,9 +10,13 @@ using System;
 
 namespace Orchard.Redis.Caching {
 
+    public interface IRedisCacheStorageProvider : ICacheStorageProvider {
+        void Clear(string key);
+    }
+
     [OrchardFeature("Orchard.Redis.Caching")]
     [OrchardSuppressDependency("Orchard.Caching.Services.DefaultCacheStorageProvider")]
-    public class RedisCacheStorageProvider : Component, ICacheStorageProvider {
+    public class RedisCacheStorageProvider : Component, IRedisCacheStorageProvider {
         public const string ConnectionStringKey = "Orchard.Redis.Cache";
 
         private readonly ShellSettings _shellSettings;
@@ -59,6 +63,10 @@ namespace Orchard.Redis.Caching {
 
         public void Clear() {
             _connectionMultiplexer.KeyDeleteWithPrefix(GetLocalizedKey("*"));
+        }
+
+        public void Clear(string key) {
+            _connectionMultiplexer.KeyDeleteWithPrefix(GetLocalizedKey($"{_shellSettings.Name}:{key}"));
         }
 
         private string GetLocalizedKey(string key) {

--- a/src/Orchard.Web/Modules/Orchard.Redis/Caching/RedisCacheStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.Redis/Caching/RedisCacheStorageProvider.cs
@@ -9,11 +9,6 @@ using StackExchange.Redis;
 using System;
 
 namespace Orchard.Redis.Caching {
-
-    public interface ICacheStorageProviderWithKeyPrefix : ICacheStorageProvider {
-        void Clear(string key);
-    }
-
     [OrchardFeature("Orchard.Redis.Caching")]
     [OrchardSuppressDependency("Orchard.Caching.Services.DefaultCacheStorageProvider")]
     public class RedisCacheStorageProvider : Component, ICacheStorageProviderWithKeyPrefix {

--- a/src/Orchard.Web/Modules/Orchard.Redis/Caching/RedisCacheStorageProvider.cs
+++ b/src/Orchard.Web/Modules/Orchard.Redis/Caching/RedisCacheStorageProvider.cs
@@ -10,13 +10,13 @@ using System;
 
 namespace Orchard.Redis.Caching {
 
-    public interface IRedisCacheStorageProvider : ICacheStorageProvider {
+    public interface ICacheStorageProviderWithKeyPrefix : ICacheStorageProvider {
         void Clear(string key);
     }
 
     [OrchardFeature("Orchard.Redis.Caching")]
     [OrchardSuppressDependency("Orchard.Caching.Services.DefaultCacheStorageProvider")]
-    public class RedisCacheStorageProvider : Component, IRedisCacheStorageProvider {
+    public class RedisCacheStorageProvider : Component, ICacheStorageProviderWithKeyPrefix {
         public const string ConnectionStringKey = "Orchard.Redis.Cache";
 
         private readonly ShellSettings _shellSettings;


### PR DESCRIPTION
This change adds a new `IRedisCacheStorageProvider.Clear` API that can be used to remove multiple keys from the cache using wildcard syntax.