### PR TITLE
Forced the handler to "publish" the fields of a menu to ensure "Value" is updated in Orchard Projections FieldIndexRecords instead of "LatestValue" only.

### DIFF
--- a/src/Orchard.Web/Core/Navigation/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Core/Navigation/Controllers/AdminController.cs
@@ -242,9 +242,12 @@ namespace Orchard.Core.Navigation.Controllers {
         [HttpPost, ActionName("Edit")]
         [Mvc.FormValueRequired("submit.Save")]
         public ActionResult EditPOST(int id, string returnUrl) {
+            var menuPart = _contentManager.GetLatest<MenuPart>(id);
+            var isPublished = menuPart.ContentItem.IsPublished();
             return EditPOST(id, returnUrl, contentItem => {
                 if (!contentItem.Has<IPublishingControlAspect>()
-                    && !contentItem.TypeDefinition.Settings.GetModel<ContentTypeSettings>().Draftable)
+                    && !contentItem.TypeDefinition.Settings.GetModel<ContentTypeSettings>().Draftable
+                    && isPublished)
                     _contentManager.Publish(contentItem);
             });
         }

--- a/src/Orchard.Web/Core/Navigation/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Core/Navigation/Controllers/AdminController.cs
@@ -244,8 +244,7 @@ namespace Orchard.Core.Navigation.Controllers {
         public ActionResult EditPOST(int id, string returnUrl) {
             return EditPOST(id, returnUrl, contentItem => {
                 if (!contentItem.Has<IPublishingControlAspect>()
-                    && !contentItem.TypeDefinition.Settings.GetModel<ContentTypeSettings>().Draftable
-                    && contentItem.IsPublished())
+                    && !contentItem.TypeDefinition.Settings.GetModel<ContentTypeSettings>().Draftable)
                     _contentManager.Publish(contentItem);
             });
         }


### PR DESCRIPTION
Following issue #8830 , this is the patch to avoid checking for the actual menu item publish state and save "Value" column inside StringFieldIndexRecords tables.