### PR TITLE
#8835: Merging imported SearchFields from recipes instead of overwriting them (Lombiq Technologies: ORCH-310)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Search/Drivers/SearchSettingsPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Search/Drivers/SearchSettingsPartDriver.cs
@@ -36,7 +36,9 @@ namespace Orchard.Search.Drivers
                     var model = new SearchSettingsIndexViewModel
                     {
                         SelectedIndex = part.SearchIndex,
-                        AvailableIndexes = _indexManager.HasIndexProvider() ? _indexManager.GetSearchIndexProvider().List().ToList() : new List<string>()
+                        AvailableIndexes = _indexManager.HasIndexProvider()
+                            ? _indexManager.GetSearchIndexProvider().List().ToList()
+                            : new List<string>()
                     };
 
                     if (updater != null)

--- a/src/Orchard.Web/Modules/Orchard.Search/Drivers/SearchSettingsPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Search/Drivers/SearchSettingsPartDriver.cs
@@ -5,6 +5,7 @@ using Orchard.ContentManagement.Drivers;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Indexing;
 using Orchard.Localization;
+using Orchard.Search.Helpers;
 using Orchard.Search.Models;
 using Orchard.Search.ViewModels;
 
@@ -35,7 +36,7 @@ namespace Orchard.Search.Drivers
                     var model = new SearchSettingsIndexViewModel
                     {
                         SelectedIndex = part.SearchIndex,
-                        AvailableIndexes = _indexManager.GetSearchIndexProvider().List().ToList()
+                        AvailableIndexes = _indexManager.HasIndexProvider() ? _indexManager.GetSearchIndexProvider().List().ToList() : new List<string>()
                     };
 
                     if (updater != null)
@@ -102,7 +103,9 @@ namespace Orchard.Search.Drivers
 
             context.ImportAttribute(part.PartDefinition.Name, "SearchFields", value =>
             {
-                part.Store("SearchFields", value);
+                part.Store(
+                    "SearchFields",
+                    SearchSettingsHelper.MergeSearchFields(part.SearchFields, SearchSettingsHelper.DeserializeSearchFields(value)));
             });
         }
     }

--- a/src/Orchard.Web/Modules/Orchard.Search/Helpers/SearchSettingsHelper.cs
+++ b/src/Orchard.Web/Modules/Orchard.Search/Helpers/SearchSettingsHelper.cs
@@ -37,5 +37,53 @@ namespace Orchard.Search.Helpers
         {
             return part.SearchFields.ContainsKey(index) ? part.SearchFields[index] : new string[0];
         }
+
+        public static string MergeSearchFields(IDictionary<string, string[]> existingSearchFields, IDictionary<string, string[]> searchFieldsToAdd)
+        {
+            var mergedSearchFields = new Dictionary<string, string[]>();
+
+            foreach (var searchFieldsToAddKey in searchFieldsToAdd.Keys)
+            {
+                var mergedSearchDocumentIndexes = Enumerable.Empty<string>();
+
+                if (existingSearchFields.TryGetValue(searchFieldsToAddKey, out var mergedSearchDocumentIndexesArray))
+                {
+                    var existingDocumentIndexes = existingSearchFields[searchFieldsToAddKey];
+
+                    var documentIndexesToAdd = searchFieldsToAdd[searchFieldsToAddKey];
+
+                    foreach (var documentIndexToAdd in documentIndexesToAdd)
+                    {
+                        if (!existingDocumentIndexes.Contains(documentIndexToAdd))
+                        {
+                            mergedSearchDocumentIndexes = mergedSearchDocumentIndexes
+                                .Concat(mergedSearchDocumentIndexesArray.Append(documentIndexToAdd))
+                                .Distinct();
+                        }
+                    }
+                }
+
+                if (mergedSearchDocumentIndexes.Any() && mergedSearchDocumentIndexesArray.Any())
+                {
+                    mergedSearchFields.Add(searchFieldsToAddKey,
+                        mergedSearchDocumentIndexes.Any() ? mergedSearchDocumentIndexes.ToArray() : mergedSearchDocumentIndexesArray);
+                }
+
+                if (!mergedSearchFields.ContainsKey(searchFieldsToAddKey))
+                {
+                    mergedSearchFields.Add(searchFieldsToAddKey, searchFieldsToAdd[searchFieldsToAddKey]);
+                }
+            }
+
+            foreach (var existingSearchFieldsToAdd in existingSearchFields.Keys)
+            {
+                if (!mergedSearchFields.ContainsKey(existingSearchFieldsToAdd))
+                {
+                    mergedSearchFields.Add(existingSearchFieldsToAdd, existingSearchFields[existingSearchFieldsToAdd]);
+                }
+            }
+
+            return SerializeSearchFields(mergedSearchFields);
+        }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Search/Helpers/SearchSettingsHelper.cs
+++ b/src/Orchard.Web/Modules/Orchard.Search/Helpers/SearchSettingsHelper.cs
@@ -27,28 +27,25 @@ namespace Orchard.Search.Helpers
             return dictionary;
         }
 
-        public static string SerializeSearchFields(IDictionary<string, string[]> value)
-        {
-            var data = string.Join("|", value.Select(x => string.Format("{0}:{1}", x.Key, string.Join(",", x.Value))));
-            return data;
-        }
+        public static string SerializeSearchFields(IDictionary<string, string[]> value) =>
+            string.Join("|", value.Select(x => string.Format("{0}:{1}", x.Key, string.Join(",", x.Value))));
 
-        public static string[] GetSearchFields(this SearchSettingsPart part, string index)
-        {
-            return part.SearchFields.ContainsKey(index) ? part.SearchFields[index] : new string[0];
-        }
+        public static string[] GetSearchFields(this SearchSettingsPart part, string index) =>
+            part.SearchFields.ContainsKey(index) ? part.SearchFields[index] : new string[0];
 
         /// <summary>
-        /// Merging the existing search indexes with their search fields by keeping the existing search indexes
-        /// and their search fields, but replacing the search fields of the existing search indexes.
+        /// Merge existing search index settings with those being imported, with the latter taking precedence.
         /// </summary>
-        /// <param name="existingSearchFields">The existing search indexes with their search fields.</param>
-        /// <param name="searchFieldsToAdd">The new search indexes with their search fields to import.</param>
+        /// <param name="existingSearchFields">The existing search indexes with their search fields. The key is the
+        /// index name and the value is the array of field names.</param>
+        /// <param name="searchFieldsToAdd">The new search indexes with their search fields to import. The key is the
+        /// index name and the value is the array of field names.</param>
         /// <returns>The merged search indexes with their search fields.</returns>
         public static string MergeSearchFields(IDictionary<string, string[]> existingSearchFields, IDictionary<string, string[]> searchFieldsToAdd)
         {
             var mergedSearchFields = new Dictionary<string, string[]>();
 
+            // Process new search fields to add first so they take precedence.
             foreach (var newSearchFieldsToAdd in searchFieldsToAdd.Keys)
             {
                 if (!mergedSearchFields.ContainsKey(newSearchFieldsToAdd))
@@ -57,6 +54,7 @@ namespace Orchard.Search.Helpers
                 }
             }
 
+            // Then add existing search fields that are not already present.
             foreach (var existingSearchFieldsToAdd in existingSearchFields.Keys)
             {
                 if (!mergedSearchFields.ContainsKey(existingSearchFieldsToAdd))

--- a/src/Orchard.Web/Modules/Orchard.Search/Helpers/SearchSettingsHelper.cs
+++ b/src/Orchard.Web/Modules/Orchard.Search/Helpers/SearchSettingsHelper.cs
@@ -38,40 +38,22 @@ namespace Orchard.Search.Helpers
             return part.SearchFields.ContainsKey(index) ? part.SearchFields[index] : new string[0];
         }
 
+        /// <summary>
+        /// Merging the existing search indexes with their search fields by keeping the existing search indexes
+        /// and their search fields, but replacing the search fields of the existing search indexes.
+        /// </summary>
+        /// <param name="existingSearchFields">The existing search indexes with their search fields.</param>
+        /// <param name="searchFieldsToAdd">The new search indexes with their search fields to import.</param>
+        /// <returns>The merged search indexes with their search fields.</returns>
         public static string MergeSearchFields(IDictionary<string, string[]> existingSearchFields, IDictionary<string, string[]> searchFieldsToAdd)
         {
             var mergedSearchFields = new Dictionary<string, string[]>();
 
-            foreach (var searchFieldsToAddKey in searchFieldsToAdd.Keys)
+            foreach (var newSearchFieldsToAdd in searchFieldsToAdd.Keys)
             {
-                var mergedSearchDocumentIndexes = Enumerable.Empty<string>();
-
-                if (existingSearchFields.TryGetValue(searchFieldsToAddKey, out var mergedSearchDocumentIndexesArray))
+                if (!mergedSearchFields.ContainsKey(newSearchFieldsToAdd))
                 {
-                    var existingDocumentIndexes = existingSearchFields[searchFieldsToAddKey];
-
-                    var documentIndexesToAdd = searchFieldsToAdd[searchFieldsToAddKey];
-
-                    foreach (var documentIndexToAdd in documentIndexesToAdd)
-                    {
-                        if (!existingDocumentIndexes.Contains(documentIndexToAdd))
-                        {
-                            mergedSearchDocumentIndexes = mergedSearchDocumentIndexes
-                                .Concat(mergedSearchDocumentIndexesArray.Append(documentIndexToAdd))
-                                .Distinct();
-                        }
-                    }
-                }
-
-                if (mergedSearchDocumentIndexes.Any() && mergedSearchDocumentIndexesArray.Any())
-                {
-                    mergedSearchFields.Add(searchFieldsToAddKey,
-                        mergedSearchDocumentIndexes.Any() ? mergedSearchDocumentIndexes.ToArray() : mergedSearchDocumentIndexesArray);
-                }
-
-                if (!mergedSearchFields.ContainsKey(searchFieldsToAddKey))
-                {
-                    mergedSearchFields.Add(searchFieldsToAddKey, searchFieldsToAdd[searchFieldsToAddKey]);
+                    mergedSearchFields.Add(newSearchFieldsToAdd, searchFieldsToAdd[newSearchFieldsToAdd]);
                 }
             }
 


### PR DESCRIPTION
Fixes: https://github.com/OrchardCMS/Orchard/issues/8835

You can test the changes by executing the following recipes with some test content:
[Search2.recipe.xml](https://github.com/user-attachments/files/23580538/Search2.recipe.xml)
[Search3.recipe.xml](https://github.com/user-attachments/files/23580539/Search3.recipe.xml)
[Search4.recipe.xml](https://github.com/user-attachments/files/23580540/Search4.recipe.xml)

This PR also fixes if you enable the **Search** module without an index implementation, navigating to **/Admin/Settings/Search** will throw an exception.