### PR TITLE
#8865: Replacing deprecated jQuery event alias with .on() method in the ImageEditor (Lombiq Technologies: ORCH-304)

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.ImageEditor/Scripts/image.editor.js
+++ b/src/Orchard.Web/Modules/Orchard.ImageEditor/Scripts/image.editor.js
@@ -9,7 +9,7 @@
     
     var awaiting = [];
     
-    $(imeImage).load(function () {
+    $(imeImage).on('load', function () {
         $(imeImage).off('load');
         for (var i = 0; i < awaiting.length; i++) {
             awaiting[i]();


### PR DESCRIPTION
Fixes: #8865
