### PR TITLE
#8836: Adding configurable script tag sanitization by adding valid elements as a configurable site setting for TinyMCE  (Lombiq Technologies: ORCH-307)

### DIFF
--- a/src/Orchard.Web/Modules/TinyMce/Handlers/TinyMceSettingsPartHandler.cs
+++ b/src/Orchard.Web/Modules/TinyMce/Handlers/TinyMceSettingsPartHandler.cs
@@ -1,0 +1,27 @@
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
+using Orchard.Localization;
+using TinyMce.Models;
+
+namespace TinyMce.Handlers
+{
+    public class TinyMceSettingsPartHandler : ContentHandler
+    {
+        public TinyMceSettingsPartHandler()
+        {
+            T = NullLocalizer.Instance;
+            Filters.Add(new ActivatingFilter<TinyMceSettingsPart>("Site"));
+            Filters.Add(new TemplateFilterForPart<TinyMceSettingsPart>("TinyMceSettings", "Parts.TinyMce.TinyMceSettings", "TinyMCE"));
+        }
+
+        public Localizer T { get; set; }
+
+        protected override void GetItemMetadata(GetContentItemMetadataContext context)
+        {
+            if (context.ContentItem.ContentType != "Site")
+                return;
+            base.GetItemMetadata(context);
+            context.Metadata.EditorGroupInfo.Add(new GroupInfo(T("TinyMCE")));
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/TinyMce/Models/TinyMceSettingsPart.cs
+++ b/src/Orchard.Web/Modules/TinyMce/Models/TinyMceSettingsPart.cs
@@ -1,0 +1,13 @@
+using Orchard.ContentManagement;
+
+namespace TinyMce.Models
+{
+    public class TinyMceSettingsPart : ContentPart
+    {
+        public string ValidElements
+        {
+            get { return this.Retrieve(x => x.ValidElements); }
+            set { this.Store(x => x.ValidElements, value); }
+        }
+    }
+}

--- a/src/Orchard.Web/Modules/TinyMce/Scripts/orchard-tinymce.js
+++ b/src/Orchard.Web/Modules/TinyMce/Scripts/orchard-tinymce.js
@@ -24,9 +24,7 @@ tinyMCE.init({
     ],
     toolbar: "undo redo cut copy paste | bold italic | bullist numlist outdent indent formatselect | alignleft aligncenter alignright alignjustify ltr rtl | " + mediaPlugins + " link " + contentPickerButtons + " unlink charmap | code htmlsnippetsbutton fullscreen",
     convert_urls: false,
-    valid_elements: "*[*]",
-    // Shouldn't be needed due to the valid_elements setting, but TinyMCE would strip script.src without it.
-    extended_valid_elements: "script[type|defer|src|language]",
+    valid_elements: validElements,
     //menubar: false,
     //statusbar: false,
     skin: "orchardlightgray",

--- a/src/Orchard.Web/Modules/TinyMce/TinyMce.csproj
+++ b/src/Orchard.Web/Modules/TinyMce/TinyMce.csproj
@@ -313,6 +313,8 @@
     <Content Include="Scripts\tinymce.min.js" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Handlers\TinyMceSettingsPartHandler.cs" />
+    <Compile Include="Models\TinyMceSettingsPart.cs" />
     <Compile Include="ResourceManifest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\TinyMceShapeDisplayEvent.cs" />
@@ -381,6 +383,7 @@
   <ItemGroup>
     <None Include="packages.config" />
     <Content Include="Views\DefinitionTemplates\ContentLinksSettings.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts.TinyMce.TinyMceSettings.cshtml" />
   </ItemGroup>
   <ItemGroup />
   <PropertyGroup>

--- a/src/Orchard.Web/Modules/TinyMce/Views/Body-Html.Editor.cshtml
+++ b/src/Orchard.Web/Modules/TinyMce/Views/Body-Html.Editor.cshtml
@@ -8,6 +8,7 @@
     var propertyName = Model.PropertyName != null ? (string)Model.PropertyName : "Text";
     var shellDescriptor = WorkContext.Resolve<ShellDescriptor>();
     var urlPrefix = WorkContext.Resolve<ShellSettings>().RequestUrlPrefix;
+    var validElements = WorkContext.CurrentSite.As<TinyMce.Models.TinyMceSettingsPart>().ValidElements;
     if (!string.IsNullOrWhiteSpace(urlPrefix)) {
         urlPrefix += "/";
     }
@@ -33,6 +34,7 @@
     var mediaLibraryEnabled = @(shellDescriptor.Features.Any(x => x.Name == "Orchard.MediaLibrary") ? "true" : "false");
     var contenPickerEnabled= @(shellDescriptor.Features.Any(x => x.Name == "Orchard.ContentPicker") ? "true" : "false");
     var tokensHtmlFilterEnabled= @(shellDescriptor.Features.Any(x => x.Name == "Orchard.Tokens.HtmlFilter") ? "true" : "false");
+    var validElements = "@validElements";
     var directionality = "@WorkContext.GetTextDirection((IContent)Model.ContentItem)";
     var language = "@Model.Language";
     var autofocus = "@(Model.AutoFocus == true ? ViewData.TemplateInfo.GetFullHtmlFieldId(propertyName) : null)";

--- a/src/Orchard.Web/Modules/TinyMce/Views/Body-Html.Editor.cshtml
+++ b/src/Orchard.Web/Modules/TinyMce/Views/Body-Html.Editor.cshtml
@@ -3,8 +3,8 @@
 @using Orchard.Environment.Descriptor.Models
 @using Orchard.Localization
 @using Orchard.Mvc.Extensions
-@using TinyMce.Settings
 @using TinyMce.Models
+@using TinyMce.Settings
 @{
     var propertyName = Model.PropertyName != null ? (string)Model.PropertyName : "Text";
     var shellDescriptor = WorkContext.Resolve<ShellDescriptor>();

--- a/src/Orchard.Web/Modules/TinyMce/Views/Body-Html.Editor.cshtml
+++ b/src/Orchard.Web/Modules/TinyMce/Views/Body-Html.Editor.cshtml
@@ -4,11 +4,12 @@
 @using Orchard.Localization
 @using Orchard.Mvc.Extensions
 @using TinyMce.Settings
+@using TinyMce.Models
 @{
     var propertyName = Model.PropertyName != null ? (string)Model.PropertyName : "Text";
     var shellDescriptor = WorkContext.Resolve<ShellDescriptor>();
     var urlPrefix = WorkContext.Resolve<ShellSettings>().RequestUrlPrefix;
-    var validElements = WorkContext.CurrentSite.As<TinyMce.Models.TinyMceSettingsPart>().ValidElements;
+    var validElements = WorkContext.CurrentSite.As<TinyMceSettingsPart>().ValidElements;
     if (!string.IsNullOrWhiteSpace(urlPrefix)) {
         urlPrefix += "/";
     }

--- a/src/Orchard.Web/Modules/TinyMce/Views/EditorTemplates/Parts.TinyMce.TinyMceSettings.cshtml
+++ b/src/Orchard.Web/Modules/TinyMce/Views/EditorTemplates/Parts.TinyMce.TinyMceSettings.cshtml
@@ -5,8 +5,8 @@
     <div>
         <label for="@Html.IdFor(m => m.ValidElements)">@T("Valid Elements")</label>
         @Html.TextBoxFor(m => m.ValidElements, new { @class = "text large" })
-        <span class="hint">@T("By default, TinyMCE sanitizes input and removes all script tags for security. If you want to disable this sanitization, set the value to: \"*[*],script[type|defer|src|language]\".")</span>
-        <span class="hint">@T("This configuration allows every element with every attribute, and explicitly adds support for script tags including type, defer, src, and language attributes. Be aware that this completely disables HTML sanitization and should only be used in trusted environments.")</span>
-        <span class="hint">@T("For more information about configuring allowed elements, refer to the <a href=\"https://www.tiny.cloud/docs/tinymce/6/content-filtering/#valid_elements\">TinyMCE documentation</a>.")</span>
+        <span class="hint">@T("Refer to the <a href=\"https://www.tiny.cloud/docs/tinymce/6/content-filtering/#valid_elements\">TinyMCE documentation</a> on configuring allowed elements.")</span>
+        <span class="hint">@T("<br/>By default, TinyMCE sanitizes input and removes all script tags for security. To restore the same behavior as prior to Orchard 1.11 instead, set this value to \"*[*],script[type|defer|src|language]\".")</span>
+        <span class="hint">@T("NOTE: This will allow every element with every attribute, and explicitly adds support for script tags, including the type, defer, src, and language attributes. Be aware that this completely disables HTML sanitization and should only be used in trusted environments.")</span>
     </div>
 </fieldset>

--- a/src/Orchard.Web/Modules/TinyMce/Views/EditorTemplates/Parts.TinyMce.TinyMceSettings.cshtml
+++ b/src/Orchard.Web/Modules/TinyMce/Views/EditorTemplates/Parts.TinyMce.TinyMceSettings.cshtml
@@ -1,0 +1,10 @@
+﻿@model TinyMce.Models.TinyMceSettingsPart
+
+<fieldset>
+    <legend>@T("TinyMCE")</legend>
+    <div>
+        <label for="@Html.IdFor(m => m.ValidElements)">@T("Valid Elements")</label>
+        @Html.TextBoxFor(m => m.ValidElements, new { @class = "text large" })
+        <span class="hint">@T("By default, TinyMCE sanitizes input and removes all script tags for security. If you want to disable this sanitization, set the value to: \"*[*],script[type|defer|src|language]\". This configuration allows every element with every attribute, and explicitly adds support for script tags including type, defer, src, and language attributes. Be aware that this completely disables HTML sanitization and should only be used in trusted environments. For more information about configuring allowed elements, refer to the TinyMCE documentation: https://www.tiny.cloud/docs/tinymce/6/content-filtering/#valid_elements")</span>
+    </div>
+</fieldset>

--- a/src/Orchard.Web/Modules/TinyMce/Views/EditorTemplates/Parts.TinyMce.TinyMceSettings.cshtml
+++ b/src/Orchard.Web/Modules/TinyMce/Views/EditorTemplates/Parts.TinyMce.TinyMceSettings.cshtml
@@ -1,10 +1,12 @@
-﻿@model TinyMce.Models.TinyMceSettingsPart
+@model TinyMce.Models.TinyMceSettingsPart
 
 <fieldset>
     <legend>@T("TinyMCE")</legend>
     <div>
         <label for="@Html.IdFor(m => m.ValidElements)">@T("Valid Elements")</label>
         @Html.TextBoxFor(m => m.ValidElements, new { @class = "text large" })
-        <span class="hint">@T("By default, TinyMCE sanitizes input and removes all script tags for security. If you want to disable this sanitization, set the value to: \"*[*],script[type|defer|src|language]\". This configuration allows every element with every attribute, and explicitly adds support for script tags including type, defer, src, and language attributes. Be aware that this completely disables HTML sanitization and should only be used in trusted environments. For more information about configuring allowed elements, refer to the TinyMCE documentation: https://www.tiny.cloud/docs/tinymce/6/content-filtering/#valid_elements")</span>
+        <span class="hint">@T("By default, TinyMCE sanitizes input and removes all script tags for security. If you want to disable this sanitization, set the value to: \"*[*],script[type|defer|src|language]\".")</span>
+        <span class="hint">@T("This configuration allows every element with every attribute, and explicitly adds support for script tags including type, defer, src, and language attributes. Be aware that this completely disables HTML sanitization and should only be used in trusted environments.")</span>
+        <span class="hint">@T("For more information about configuring allowed elements, refer to the <a href=\"https://www.tiny.cloud/docs/tinymce/6/content-filtering/#valid_elements\">TinyMCE documentation</a>.")</span>
     </div>
 </fieldset>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/Orchard/issues/8836

### Important Note
This is a breaking change, as users previously could add <script> tags to content using TinyMCE.

### Test Cases
Test script with type
`<script type="text/javascript">console.log("test");</script>`

Test script with defer
`<script src="/app.js" defer></script>`

Comprehensive HTML
```
<!DOCTYPE html>
<html>
<head>
    <title>HTML Test Case</title>
</head>
<body>

<h1>Main Heading <small>with small text</small></h1>
<h2>Subheading</h2>

<p>This is a <b>bold</b> text, this is <strong>strong</strong>, this is <i>italic</i>, 
<em>emphasized</em>, and this is <u>underlined</u>. Here is <mark>highlighted</mark> text.</p>

<p>A <span style="color:red;">red span</span> and a 
<span style="font-weight:bold; text-decoration:underline;">styled span</span>.</p>

<hr>

<h3>Links and Images</h3>
<p>
    <a href="https://example.com" target="_blank" rel="noopener">Example link</a><br>
    <img src="https://via.placeholder.com/150" alt="Placeholder Image" width="150" height="150">
</p>

<hr>

<h3>Lists</h3>

<ul>
    <li>Unordered list item 1</li>
    <li>Unordered list item 2</li>
    <li>Unordered list item 3
        <ul>
            <li>Nested unordered item</li>
        </ul>
    </li>
</ul>

<ol>
    <li>Ordered list item 1</li>
    <li>Ordered list item 2</li>
    <li>Ordered list item 3
        <ol>
            <li>Nested ordered item</li>
        </ol>
    </li>
</ol>

<hr>

<h3>Tables</h3>

<table border="1" cellpadding="5" cellspacing="0">
    <thead>
        <tr>
            <th>Header 1</th>
            <th>Header 2</th>
            <th>Header 3</th>
        </tr>
    </thead>

    <tbody>
        <tr>
            <td>Row 1, Cell 1</td>
            <td><b>Bold</b> inside table</td>
            <td><i>Italic</i> inside table</td>
        </tr>
        <tr>
            <td colspan="2">Colspan example</td>
            <td rowspan="2">Rowspan example</td>
        </tr>
        <tr>
            <td>Row 3, Cell 1</td>
            <td>Row 3, Cell 2</td>
        </tr>
    </tbody>

    <tfoot>
        <tr>
            <td>Footer 1</td>
            <td>Footer 2</td>
            <td>Footer 3</td>
        </tr>
    </tfoot>
</table>

<hr>

<h3>Blockquotes, Code, and Preformatted</h3>

<blockquote>
    This is a blockquote. It can contain <b>styled</b> text.
</blockquote>

<pre>
function test() {
    console.log("preformatted text block");
}
</pre>

<code>console.log("inline code");</code>

<hr>

<h3>Divs and Sections</h3>

<div style="border:1px solid #ccc; padding:10px;">
    <p>Div with padding and border.</p>
</div>

<section>
    <h4>Section Heading</h4>
    <p>Some text inside a section.</p>
</section>

<article>
    <h4>Article Heading</h4>
    <p>Some text inside an article.</p>
</article>

<hr>

<h3>Forms (optional – may be stripped)</h3>

<form>
    <label>Name: <input type="text" name="name"></label><br>
    <label>Email: <input type="email" name="email"></label><br>
    <textarea name="message">Test message</textarea><br>
    <button type="submit">Submit</button>
</form>

<hr>

<h3>Other Inline Elements</h3>

<p>
    <abbr title="Abbreviation Example">HTML</abbr>,
    <cite>Citation Example</cite>,
    <q>Quote Example</q>,
    <del>Deleted text</del>,
    <ins>Inserted text</ins>,
    <sup>superscript</sup>,
    <sub>subscript</sub>
</p>

<hr>

<h3>Custom and Exotic Tags (to test sanitization)</h3>

<custom-tag data-info="123">Custom tag content</custom-tag>
<weirdElement my-attr="abc">Weird element</weirdElement>

</body>
</html>
```