### PR TITLE
#8266: Security sensitive permissions (Lombiq Technologies: ORCH-214)

### DIFF
--- a/src/Orchard.Web/Core/Settings/Permissions.cs
+++ b/src/Orchard.Web/Core/Settings/Permissions.cs
@@ -6,7 +6,14 @@ namespace Orchard.Core.Settings
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageSettings = new Permission { Description = "Manage Settings", Name = "ManageSettings", IsSecurityCritical = true };
+        public static readonly Permission ManageSettings =
+            new Permission
+            {
+                Description = "Manage Settings",
+                Name = "ManageSettings",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Core/Settings/Permissions.cs
+++ b/src/Orchard.Web/Core/Settings/Permissions.cs
@@ -6,7 +6,7 @@ namespace Orchard.Core.Settings
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageSettings = new Permission { Description = "Manage Settings", Name = "ManageSettings" };
+        public static readonly Permission ManageSettings = new Permission { Description = "Manage Settings", Name = "ManageSettings", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Core/Settings/Permissions.cs
+++ b/src/Orchard.Web/Core/Settings/Permissions.cs
@@ -6,14 +6,7 @@ namespace Orchard.Core.Settings
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageSettings =
-            new Permission
-            {
-                Description = "Manage Settings",
-                Name = "ManageSettings",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
+        public static readonly Permission ManageSettings = new Permission { Description = "Manage Settings", Name = "ManageSettings", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Permissions.cs
@@ -6,41 +6,10 @@ namespace Orchard.AuditTrail
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ViewAuditTrail =
-            new Permission
-            {
-                Description = "View audit trail",
-                Name = "ViewAuditTrail",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
-
-        public static readonly Permission ManageAuditTrailSettings =
-            new Permission
-            {
-                Description = "Manage audit trail settings",
-                Name = "ManageAuditTrailSettings",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
-
-        public static readonly Permission ImportAuditTrail =
-            new Permission
-            {
-                Description = "Import audit trail",
-                Name = "ImportAuditTrail",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
-
-        public static readonly Permission ManageClientIpAddressSettings =
-            new Permission
-            {
-                Description = "Manage client IP address settings",
-                Name = "ManageClientIpAddressSettings",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
+        public static readonly Permission ViewAuditTrail = new Permission { Description = "View audit trail", Name = "ViewAuditTrail", IsSecurityCritical = true };
+        public static readonly Permission ManageAuditTrailSettings = new Permission { Description = "Manage audit trail settings", Name = "ManageAuditTrailSettings", IsSecurityCritical = true };
+        public static readonly Permission ImportAuditTrail = new Permission { Description = "Import audit trail", Name = "ImportAuditTrail", IsSecurityCritical = true };
+        public static readonly Permission ManageClientIpAddressSettings = new Permission { Description = "Manage client IP address settings", Name = "ManageClientIpAddressSettings", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Permissions.cs
@@ -6,10 +6,10 @@ namespace Orchard.AuditTrail
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ViewAuditTrail = new Permission { Description = "View audit trail", Name = "ViewAuditTrail" };
-        public static readonly Permission ManageAuditTrailSettings = new Permission { Description = "Manage audit trail settings", Name = "ManageAuditTrailSettings" };
-        public static readonly Permission ImportAuditTrail = new Permission { Description = "Import audit trail", Name = "ImportAuditTrail" };
-        public static readonly Permission ManageClientIpAddressSettings = new Permission { Description = "Manage client IP address settings", Name = "ManageClientIpAddressSettings" };
+        public static readonly Permission ViewAuditTrail = new Permission { Description = "View audit trail", Name = "ViewAuditTrail", IsSecurityCritical = true };
+        public static readonly Permission ManageAuditTrailSettings = new Permission { Description = "Manage audit trail settings", Name = "ManageAuditTrailSettings", IsSecurityCritical = true };
+        public static readonly Permission ImportAuditTrail = new Permission { Description = "Import audit trail", Name = "ImportAuditTrail", IsSecurityCritical = true };
+        public static readonly Permission ManageClientIpAddressSettings = new Permission { Description = "Manage client IP address settings", Name = "ManageClientIpAddressSettings", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.AuditTrail/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.AuditTrail/Permissions.cs
@@ -6,10 +6,41 @@ namespace Orchard.AuditTrail
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ViewAuditTrail = new Permission { Description = "View audit trail", Name = "ViewAuditTrail", IsSecurityCritical = true };
-        public static readonly Permission ManageAuditTrailSettings = new Permission { Description = "Manage audit trail settings", Name = "ManageAuditTrailSettings", IsSecurityCritical = true };
-        public static readonly Permission ImportAuditTrail = new Permission { Description = "Import audit trail", Name = "ImportAuditTrail", IsSecurityCritical = true };
-        public static readonly Permission ManageClientIpAddressSettings = new Permission { Description = "Manage client IP address settings", Name = "ManageClientIpAddressSettings", IsSecurityCritical = true };
+        public static readonly Permission ViewAuditTrail =
+            new Permission
+            {
+                Description = "View audit trail",
+                Name = "ViewAuditTrail",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
+
+        public static readonly Permission ManageAuditTrailSettings =
+            new Permission
+            {
+                Description = "Manage audit trail settings",
+                Name = "ManageAuditTrailSettings",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
+
+        public static readonly Permission ImportAuditTrail =
+            new Permission
+            {
+                Description = "Import audit trail",
+                Name = "ImportAuditTrail",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
+
+        public static readonly Permission ManageClientIpAddressSettings =
+            new Permission
+            {
+                Description = "Manage client IP address settings",
+                Name = "ManageClientIpAddressSettings",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Permissions.cs
@@ -7,7 +7,7 @@ namespace Orchard.ContentTypes
     public class Permissions : IPermissionProvider
     {
         public static readonly Permission ViewContentTypes = new Permission { Name = "ViewContentTypes", Description = "View content types" };
-        public static readonly Permission EditContentTypes = new Permission { Name = "EditContentTypes", Description = "Edit content types" };
+        public static readonly Permission EditContentTypes = new Permission { Name = "EditContentTypes", Description = "Edit content types", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Permissions.cs
@@ -7,15 +7,7 @@ namespace Orchard.ContentTypes
     public class Permissions : IPermissionProvider
     {
         public static readonly Permission ViewContentTypes = new Permission { Name = "ViewContentTypes", Description = "View content types" };
-
-        public static readonly Permission EditContentTypes =
-            new Permission
-            {
-                Name = "EditContentTypes",
-                Description = "Edit content types",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
+        public static readonly Permission EditContentTypes = new Permission { Name = "EditContentTypes", Description = "Edit content types", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.ContentTypes/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.ContentTypes/Permissions.cs
@@ -7,7 +7,15 @@ namespace Orchard.ContentTypes
     public class Permissions : IPermissionProvider
     {
         public static readonly Permission ViewContentTypes = new Permission { Name = "ViewContentTypes", Description = "View content types" };
-        public static readonly Permission EditContentTypes = new Permission { Name = "EditContentTypes", Description = "Edit content types", IsSecurityCritical = true };
+
+        public static readonly Permission EditContentTypes =
+            new Permission
+            {
+                Name = "EditContentTypes",
+                Description = "Edit content types",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Permissions.cs
@@ -6,23 +6,8 @@ namespace Orchard.ImportExport
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission Import =
-            new Permission
-            {
-                Description = "Import Data",
-                Name = "Import",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
-
-        public static readonly Permission Export =
-            new Permission
-            {
-                Description = "Export Data",
-                Name = "Export",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
+        public static readonly Permission Import = new Permission { Description = "Import Data", Name = "Import", IsSecurityCritical = true };
+        public static readonly Permission Export = new Permission { Description = "Export Data", Name = "Export", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Permissions.cs
@@ -6,8 +6,8 @@ namespace Orchard.ImportExport
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission Import = new Permission { Description = "Import Data", Name = "Import" };
-        public static readonly Permission Export = new Permission { Description = "Export Data", Name = "Export" };
+        public static readonly Permission Import = new Permission { Description = "Import Data", Name = "Import", IsSecurityCritical = true };
+        public static readonly Permission Export = new Permission { Description = "Export Data", Name = "Export", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.ImportExport/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.ImportExport/Permissions.cs
@@ -6,8 +6,23 @@ namespace Orchard.ImportExport
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission Import = new Permission { Description = "Import Data", Name = "Import", IsSecurityCritical = true };
-        public static readonly Permission Export = new Permission { Description = "Export Data", Name = "Export", IsSecurityCritical = true };
+        public static readonly Permission Import =
+            new Permission
+            {
+                Description = "Import Data",
+                Name = "Import",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
+
+        public static readonly Permission Export =
+            new Permission
+            {
+                Description = "Export Data",
+                Name = "Export",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Modules/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Modules/Permissions.cs
@@ -6,7 +6,14 @@ namespace Orchard.Modules
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageFeatures = new Permission { Description = "Manage Features", Name = "ManageFeatures", IsSecurityCritical = true };
+        public static readonly Permission ManageFeatures =
+            new Permission
+            {
+                Description = "Manage Features",
+                Name = "ManageFeatures",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Modules/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Modules/Permissions.cs
@@ -6,14 +6,7 @@ namespace Orchard.Modules
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageFeatures =
-            new Permission
-            {
-                Description = "Manage Features",
-                Name = "ManageFeatures",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
+        public static readonly Permission ManageFeatures = new Permission { Description = "Manage Features", Name = "ManageFeatures", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Modules/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Modules/Permissions.cs
@@ -6,7 +6,7 @@ namespace Orchard.Modules
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageFeatures = new Permission { Description = "Manage Features", Name = "ManageFeatures" };
+        public static readonly Permission ManageFeatures = new Permission { Description = "Manage Features", Name = "ManageFeatures", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Packaging/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Packaging/Permissions.cs
@@ -6,7 +6,14 @@ namespace Orchard.Packaging
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManagePackages = new Permission { Description = "Manage packages", Name = "ManagePackages", IsSecurityCritical = true };
+        public static readonly Permission ManagePackages =
+            new Permission
+            {
+                Description = "Manage packages",
+                Name = "ManagePackages",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Packaging/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Packaging/Permissions.cs
@@ -6,14 +6,7 @@ namespace Orchard.Packaging
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManagePackages =
-            new Permission
-            {
-                Description = "Manage packages",
-                Name = "ManagePackages",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
+        public static readonly Permission ManagePackages = new Permission { Description = "Manage packages", Name = "ManagePackages", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Packaging/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Packaging/Permissions.cs
@@ -6,7 +6,7 @@ namespace Orchard.Packaging
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManagePackages = new Permission { Description = "Manage packages", Name = "ManagePackages" };
+        public static readonly Permission ManagePackages = new Permission { Description = "Manage packages", Name = "ManagePackages", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Roles/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Controllers/AdminController.cs
@@ -65,7 +65,11 @@ namespace Orchard.Roles.Controllers
             if (!Services.Authorizer.Authorize(Permissions.ManageRoles, T("Not authorized to manage roles")))
                 return new HttpUnauthorizedResult();
 
-            var model = new RolesIndexViewModel { Rows = _roleService.GetRoles().OrderBy(r => r.Name).ToList() };
+            var model = new RolesIndexViewModel
+            {
+                Rows = _roleService.GetRoles().OrderBy(r => r.Name).ToList(),
+                SecurityCriticalPermissions = _roleService.GetSecurityCriticalPermissions()
+            };
 
             return View(model);
         }

--- a/src/Orchard.Web/Modules/Orchard.Roles/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Controllers/AdminController.cs
@@ -263,9 +263,11 @@ namespace Orchard.Roles.Controllers
                 {
                     RoleId = x.Id,
                     Name = x.Name,
-                    Granted = userRolesPart.Roles.Contains(x.Name)
+                    Granted = userRolesPart.Roles.Contains(x.Name),
+                    Permissions = _roleService.GetPermissionsForRoleByName(x.Name)
                 }).ToList(),
-                AuthorizedRoleIds = authorizedRoleIds
+                AuthorizedRoleIds = authorizedRoleIds,
+                SecurityCriticalPermissions = _roleService.GetSecurityCriticalPermissions()
             };
 
             // this calls the same view used by the driver that lets users with higher

--- a/src/Orchard.Web/Modules/Orchard.Roles/Controllers/AdminController.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Controllers/AdminController.cs
@@ -65,10 +65,15 @@ namespace Orchard.Roles.Controllers
             if (!Services.Authorizer.Authorize(Permissions.ManageRoles, T("Not authorized to manage roles")))
                 return new HttpUnauthorizedResult();
 
+            var securityCriticalPermissions = _roleService.GetSecurityCriticalPermissions().ToHashSet();
+            var roles = _roleService.GetRoles().OrderBy(r => r.Name).ToList();
+
             var model = new RolesIndexViewModel
             {
-                Rows = _roleService.GetRoles().OrderBy(r => r.Name).ToList(),
-                SecurityCriticalPermissions = _roleService.GetSecurityCriticalPermissions()
+                Rows = roles,
+                RolesWithSecurityCriticalPermissions = roles.ToDictionary(
+                    role => role.Name,
+                    role => role.RolesPermissions.Any(p => securityCriticalPermissions.Contains(p.Permission.Name)))
             };
 
             return View(model);
@@ -254,20 +259,21 @@ namespace Orchard.Roles.Controllers
             {
                 return new HttpUnauthorizedResult();
             }
+
+            var securityCriticalPermissions = _roleService.GetSecurityCriticalPermissions().ToHashSet();
             // create the ViewModel used to manage a user's roles
             var model = new UserRolesViewModel
             {
                 User = userRolesPart.As<IUser>(),
                 UserRoles = userRolesPart,
-                Roles = allRoles.Select(x => new UserRoleEntry
+                Roles = allRoles.Select(role => new UserRoleEntry
                 {
-                    RoleId = x.Id,
-                    Name = x.Name,
-                    Granted = userRolesPart.Roles.Contains(x.Name),
-                    Permissions = _roleService.GetPermissionsForRoleByName(x.Name)
+                    RoleId = role.Id,
+                    Name = role.Name,
+                    Granted = userRolesPart.Roles.Contains(role.Name),
+                    HasSecurityCriticalPermissions = role.RolesPermissions.Any(p => securityCriticalPermissions.Contains(p.Permission.Name))
                 }).ToList(),
                 AuthorizedRoleIds = authorizedRoleIds,
-                SecurityCriticalPermissions = _roleService.GetSecurityCriticalPermissions()
             };
 
             // this calls the same view used by the driver that lets users with higher

--- a/src/Orchard.Web/Modules/Orchard.Roles/Drivers/UserRolesPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Drivers/UserRolesPartDriver.cs
@@ -73,7 +73,7 @@ namespace Orchard.Roles.Drivers
                         RoleId = x.Id,
                         Name = x.Name,
                         Granted = userRolesPart.Roles.Contains(x.Name),
-                        Permissions = _roleService.GetPermissionsForRoleByName(x.Name),
+                        Permissions = _roleService.GetPermissionsForRoleByName(x.Name)
                     });
 
                 var model = new UserRolesViewModel

--- a/src/Orchard.Web/Modules/Orchard.Roles/Drivers/UserRolesPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Drivers/UserRolesPartDriver.cs
@@ -72,14 +72,17 @@ namespace Orchard.Roles.Drivers
                     {
                         RoleId = x.Id,
                         Name = x.Name,
-                        Granted = userRolesPart.Roles.Contains(x.Name)
+                        Granted = userRolesPart.Roles.Contains(x.Name),
+                        Permissions = _roleService.GetPermissionsForRoleByName(x.Name),
                     });
+
                 var model = new UserRolesViewModel
                 {
                     User = userRolesPart.As<IUser>(),
                     UserRoles = userRolesPart,
                     Roles = allRoles.ToList(),
-                    AuthorizedRoleIds = authorizedRoleIds
+                    AuthorizedRoleIds = authorizedRoleIds,
+                    SecurityCriticalPermissions = _roleService.GetSecurityCriticalPermissions()
                 };
                 return shapeHelper.EditorTemplate(TemplateName: TemplateName, Model: model, Prefix: Prefix);
             });

--- a/src/Orchard.Web/Modules/Orchard.Roles/Drivers/UserRolesPartDriver.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Drivers/UserRolesPartDriver.cs
@@ -67,23 +67,22 @@ namespace Orchard.Roles.Drivers
                 {
                     return null;
                 }
-                var allRoles = _allRoles.Value
-                    .Select(x => new UserRoleEntry
-                    {
-                        RoleId = x.Id,
-                        Name = x.Name,
-                        Granted = userRolesPart.Roles.Contains(x.Name),
-                        Permissions = _roleService.GetPermissionsForRoleByName(x.Name)
-                    });
 
+                var securityCriticalPermissions = _roleService.GetSecurityCriticalPermissions().ToHashSet();
                 var model = new UserRolesViewModel
                 {
                     User = userRolesPart.As<IUser>(),
                     UserRoles = userRolesPart,
-                    Roles = allRoles.ToList(),
+                    Roles = _allRoles.Value.Select(role => new UserRoleEntry
+                    {
+                        RoleId = role.Id,
+                        Name = role.Name,
+                        Granted = userRolesPart.Roles.Contains(role.Name),
+                        HasSecurityCriticalPermissions = role.RolesPermissions.Any(p => securityCriticalPermissions.Contains(p.Permission.Name))
+                    }).ToList(),
                     AuthorizedRoleIds = authorizedRoleIds,
-                    SecurityCriticalPermissions = _roleService.GetSecurityCriticalPermissions()
                 };
+
                 return shapeHelper.EditorTemplate(TemplateName: TemplateName, Model: model, Prefix: Prefix);
             });
 

--- a/src/Orchard.Web/Modules/Orchard.Roles/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Permissions.cs
@@ -12,24 +12,8 @@ namespace Orchard.Roles
     {
         private readonly IRepository<RoleRecord> _roleRepository;
 
-        public static readonly Permission ManageRoles =
-            new Permission
-            {
-                Description = "Managing Roles",
-                Name = "ManageRoles",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
-
-        public static readonly Permission AssignRoles =
-            new Permission
-            {
-                Description = "Assign Roles",
-                Name = "AssignRoles",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint,
-                ImpliedBy = new[] { ManageRoles }
-            };
+        public static readonly Permission ManageRoles = new Permission { Description = "Managing Roles", Name = "ManageRoles", IsSecurityCritical = true, };
+        public static readonly Permission AssignRoles = new Permission { Description = "Assign Roles", Name = "AssignRoles", IsSecurityCritical = true, ImpliedBy = new[] { ManageRoles } };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Roles/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Permissions.cs
@@ -12,8 +12,24 @@ namespace Orchard.Roles
     {
         private readonly IRepository<RoleRecord> _roleRepository;
 
-        public static readonly Permission ManageRoles = new Permission { Description = "Managing Roles", Name = "ManageRoles", IsSecurityCritical = true, };
-        public static readonly Permission AssignRoles = new Permission { Description = "Assign Roles", Name = "AssignRoles", IsSecurityCritical = true, ImpliedBy = new[] { ManageRoles } };
+        public static readonly Permission ManageRoles =
+            new Permission
+            {
+                Description = "Managing Roles",
+                Name = "ManageRoles",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
+
+        public static readonly Permission AssignRoles =
+            new Permission
+            {
+                Description = "Assign Roles",
+                Name = "AssignRoles",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint,
+                ImpliedBy = new[] { ManageRoles }
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Roles/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Permissions.cs
@@ -12,8 +12,8 @@ namespace Orchard.Roles
     {
         private readonly IRepository<RoleRecord> _roleRepository;
 
-        public static readonly Permission ManageRoles = new Permission { Description = "Managing Roles", Name = "ManageRoles" };
-        public static readonly Permission AssignRoles = new Permission { Description = "Assign Roles", Name = "AssignRoles", ImpliedBy = new[] { ManageRoles } };
+        public static readonly Permission ManageRoles = new Permission { Description = "Managing Roles", Name = "ManageRoles", IsSecurityCritical = true, };
+        public static readonly Permission AssignRoles = new Permission { Description = "Assign Roles", Name = "AssignRoles", IsSecurityCritical = true, ImpliedBy = new[] { ManageRoles } };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Roles/Services/IRoleService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Services/IRoleService.cs
@@ -14,6 +14,7 @@ namespace Orchard.Roles.Services
         void UpdateRole(int id, string roleName, IEnumerable<string> rolePermissions);
         void DeleteRole(int id);
         IDictionary<string, IEnumerable<Permission>> GetInstalledPermissions();
+        IEnumerable<string> GetSecurityCriticalPermissions();
         IEnumerable<string> GetPermissionsForRole(int id);
 
         IEnumerable<string> GetPermissionsForRoleByName(string name);

--- a/src/Orchard.Web/Modules/Orchard.Roles/Services/RoleService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Services/RoleService.cs
@@ -203,6 +203,22 @@ namespace Orchard.Roles.Services
             return installedPermissions;
         }
 
+        public IEnumerable<string> GetSecurityCriticalPermissions()
+        {
+            var securityCriticalPermissions = new List<string>();
+            foreach (var permissionProvider in _permissionProviders)
+            {
+                var permissions = permissionProvider.GetPermissions();
+                foreach (var permission in permissions)
+                {
+                    if (permission.IsSecurityCritical)
+                        securityCriticalPermissions.Add(permission.Name);
+                }
+            }
+
+            return securityCriticalPermissions;
+        }
+
         public IEnumerable<string> GetPermissionsForRole(int id)
         {
             var permissions = new List<string>();

--- a/src/Orchard.Web/Modules/Orchard.Roles/Services/RoleService.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Services/RoleService.cs
@@ -203,21 +203,8 @@ namespace Orchard.Roles.Services
             return installedPermissions;
         }
 
-        public IEnumerable<string> GetSecurityCriticalPermissions()
-        {
-            var securityCriticalPermissions = new List<string>();
-            foreach (var permissionProvider in _permissionProviders)
-            {
-                var permissions = permissionProvider.GetPermissions();
-                foreach (var permission in permissions)
-                {
-                    if (permission.IsSecurityCritical)
-                        securityCriticalPermissions.Add(permission.Name);
-                }
-            }
-
-            return securityCriticalPermissions;
-        }
+        public IEnumerable<string> GetSecurityCriticalPermissions() =>
+            _permissionProviders.SelectMany(pp => pp.GetPermissions().Where(p => p.IsSecurityCritical)).Select(p => p.Name);
 
         public IEnumerable<string> GetPermissionsForRole(int id)
         {

--- a/src/Orchard.Web/Modules/Orchard.Roles/ViewModels/RolesIndexViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/ViewModels/RolesIndexViewModel.cs
@@ -6,5 +6,7 @@ namespace Orchard.Roles.ViewModels
     public class RolesIndexViewModel
     {
         public IList<RoleRecord> Rows { get; set; }
+
+        public IEnumerable<string> SecurityCriticalPermissions { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Roles/ViewModels/RolesIndexViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/ViewModels/RolesIndexViewModel.cs
@@ -7,6 +7,6 @@ namespace Orchard.Roles.ViewModels
     {
         public IList<RoleRecord> Rows { get; set; }
 
-        public IEnumerable<string> SecurityCriticalPermissions { get; set; }
+        public Dictionary<string, bool> RolesWithSecurityCriticalPermissions { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Roles/ViewModels/UserRolesViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/ViewModels/UserRolesViewModel.cs
@@ -16,6 +16,7 @@ namespace Orchard.Roles.ViewModels
         public IUserRoles UserRoles { get; set; }
         public IList<UserRoleEntry> Roles { get; set; }
         public IList<int> AuthorizedRoleIds { get; set; }
+        public IEnumerable<string> SecurityCriticalPermissions { get; set; }
     }
 
     public class UserRoleEntry
@@ -23,5 +24,6 @@ namespace Orchard.Roles.ViewModels
         public int RoleId { get; set; }
         public string Name { get; set; }
         public bool Granted { get; set; }
+        public IEnumerable<string> Permissions { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Roles/ViewModels/UserRolesViewModel.cs
+++ b/src/Orchard.Web/Modules/Orchard.Roles/ViewModels/UserRolesViewModel.cs
@@ -16,7 +16,6 @@ namespace Orchard.Roles.ViewModels
         public IUserRoles UserRoles { get; set; }
         public IList<UserRoleEntry> Roles { get; set; }
         public IList<int> AuthorizedRoleIds { get; set; }
-        public IEnumerable<string> SecurityCriticalPermissions { get; set; }
     }
 
     public class UserRoleEntry
@@ -24,6 +23,6 @@ namespace Orchard.Roles.ViewModels
         public int RoleId { get; set; }
         public string Name { get; set; }
         public bool Granted { get; set; }
-        public IEnumerable<string> Permissions { get; set; }
+        public bool HasSecurityCriticalPermissions { get; set; }
     }
 }

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
@@ -1,77 +1,92 @@
+@using Orchard.Roles.ViewModels
+
 @model RoleEditViewModel
-@using Orchard.Roles.ViewModels;
 
 @{
     Style.Require("FontAwesome");
     Layout.Title = T("Edit Role").ToString();
 }
 
-@using(Html.BeginFormAntiForgeryPost()) {
+@using (Html.BeginFormAntiForgeryPost())
+{
     @Html.ValidationSummary();
     <fieldset>
         <legend>@T("Information")</legend>
         <label for="pageTitle">@T("Role Name:")</label>
-        @if (Model.Name == "Administrator") { // the one special case
+        @if (Model.Name == "Administrator")
+        { // the one special case
             <input id="Name" class="text" type="text" value="@Model.Name" readonly="readonly" />
             <input class="text" name="Name" type="hidden" value="@Model.Name" />
         }
-        else {
+        else
+        {
             <input id="Name" class="text" name="Name" type="text" value="@Model.Name" />
         }
         <input type="hidden" value="@Model.Id" name="Id" />
     </fieldset>
     <fieldset>
         <legend>@T("Permissions")</legend>
-        
-        <p>@T("Allow - Permission is granted explicitly.")</p>
-        <p>@T("Effective - Permission is implied by a higher level permission, or explicitly granted.")</p>
 
-        @foreach (var category in Model.RoleCategoryPermissions.Keys) {
-        <fieldset>
-            <legend>@category</legend>
-            <table class="items">
-                <colgroup>
-                    <col id="Col1" />
-                    <col id="Col2" />
-                </colgroup>
-                <thead>
-                    <tr>
-                        <th scope="col">@T("Permission")</th>
-                        <th scope="col">@T("Allow")</th>
-                        <th scope="col">@T("Effective")</th>
-                    </tr>
-                </thead>
-                @foreach (var permission in Model.RoleCategoryPermissions[category]) {
-                <tr>
-                    <td>@T(permission.Description)</td>
-                    <td style="width:60px;">
-                        @if (Model.CurrentPermissions.Contains(permission.Name)) {
-                            <input type="checkbox" value="true" name="Checkbox.@permission.Name" checked="checked"/>
-                         } 
-                         else {
-                            <input type="checkbox" value="true" name="Checkbox.@permission.Name"/>
-                        }
-                        @if (permission.IsSecurityCritical && !string.IsNullOrEmpty(permission.Hint)) {
-                            <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T(permission.Hint)"></i>
-                        }
-                    </td>    
-                    <td style="width:60px;">
-                    @if (Model.EffectivePermissions.Contains(permission.Name)) {
-                            <input type="checkbox" disabled="disabled" name="Effective.@permission.Name" checked="checked"/>
-                     } else {
-                            <input type="checkbox" disabled="disabled" name="Effective.@permission.Name"/>
-                        }
-                    </td>                
-                </tr>
-                }
-            </table>
+        <p>@T("Allow: Permission is granted explicitly.")</p>
+        <p>@T("Effective: Permission is implied by a higher level permission, or explicitly granted.")</p>
+
+        <br />
+
+        @foreach (var category in Model.RoleCategoryPermissions.Keys)
+        {
+            <fieldset>
+                <legend>@category</legend>
+                <table class="items">
+                    <colgroup>
+                        <col id="Col1" />
+                        <col id="Col2" />
+                    </colgroup>
+                    <thead>
+                        <tr>
+                            <th scope="col">@T("Permission")</th>
+                            <th scope="col">@T("Allow")</th>
+                            <th scope="col">@T("Effective")</th>
+                        </tr>
+                    </thead>
+                    @foreach (var permission in Model.RoleCategoryPermissions[category])
+                    {
+                        <tr>
+                            <td>@T(permission.Description)</td>
+                            <td style="width:60px;">
+                                @if (Model.CurrentPermissions.Contains(permission.Name))
+                                {
+                                    <input type="checkbox" value="true" name="Checkbox.@permission.Name" checked="checked" />
+                                }
+                                else
+                                {
+                                    <input type="checkbox" value="true" name="Checkbox.@permission.Name" />
+                                }
+                                @if (permission.IsSecurityCritical && !string.IsNullOrEmpty(permission.Hint))
+                                {
+                                    <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T(permission.Hint)"></i>
+                                }
+                            </td>
+                            <td style="width:60px;">
+                                @if (Model.EffectivePermissions.Contains(permission.Name))
+                                {
+                                    <input type="checkbox" disabled="disabled" name="Effective.@permission.Name" checked="checked" />
+                                }
+                                else
+                                {
+                                    <input type="checkbox" disabled="disabled" name="Effective.@permission.Name" />
+                                }
+                            </td>
+                        </tr>
+                    }
+                </table>
             </fieldset>
-            }
+        }
     </fieldset>
     <fieldset>
         <button class="primaryAction" type="submit" name="submit.Save" value="@T("Save")">@T("Save")</button>
-        @if (Model.Name != "Administrator") {
-        <button type="submit" name="submit.Delete" value="@T("Delete")" itemprop="RemoveUrl">@T("Delete")</button>
+        @if (Model.Name != "Administrator")
+        {
+            <button type="submit" name="submit.Delete" value="@T("Delete")" itemprop="RemoveUrl">@T("Delete")</button>
         }
     </fieldset>
 }

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
@@ -1,7 +1,10 @@
 @model RoleEditViewModel
 @using Orchard.Roles.ViewModels;
 
-@{ Layout.Title = T("Edit Role").ToString(); }
+@{
+    Style.Require("FontAwesome");
+    Layout.Title = T("Edit Role").ToString();
+}
 
 @using(Html.BeginFormAntiForgeryPost()) {
     @Html.ValidationSummary();
@@ -19,6 +22,10 @@
     </fieldset>
     <fieldset>
         <legend>@T("Permissions")</legend>
+        
+        <p>@T("Allow - Permission is granted explicitly.")</p>
+        <p>@T("Effective Permission is implied by a higher level permission, or explicitly granted.")</p>
+
         @foreach (var category in Model.RoleCategoryPermissions.Keys) {
         <fieldset>
             <legend>@category</legend>
@@ -38,6 +45,9 @@
                 <tr>
                     <td>@T(permission.Description)</td>
                     <td style="width:60px;">
+                        @if (permission.IsSecurityCritical && !string.IsNullOrEmpty(permission.Hint)) {
+                            <i class="fa-solid fa-triangle-exclamation" title="@T(permission.Hint)"></i>
+                        }
                         @if (Model.CurrentPermissions.Contains(permission.Name)) {
                             <input type="checkbox" value="true" name="Checkbox.@permission.Name" checked="checked"/>
                          } 

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
@@ -24,7 +24,7 @@
         <legend>@T("Permissions")</legend>
         
         <p>@T("Allow - Permission is granted explicitly.")</p>
-        <p>@T("Effective Permission is implied by a higher level permission, or explicitly granted.")</p>
+        <p>@T("Effective - Permission is implied by a higher level permission, or explicitly granted.")</p>
 
         @foreach (var category in Model.RoleCategoryPermissions.Keys) {
         <fieldset>
@@ -45,14 +45,14 @@
                 <tr>
                     <td>@T(permission.Description)</td>
                     <td style="width:60px;">
-                        @if (permission.IsSecurityCritical && !string.IsNullOrEmpty(permission.Hint)) {
-                            <i class="fa-solid fa-triangle-exclamation" title="@T(permission.Hint)"></i>
-                        }
                         @if (Model.CurrentPermissions.Contains(permission.Name)) {
                             <input type="checkbox" value="true" name="Checkbox.@permission.Name" checked="checked"/>
                          } 
                          else {
                             <input type="checkbox" value="true" name="Checkbox.@permission.Name"/>
+                        }
+                        @if (permission.IsSecurityCritical && !string.IsNullOrEmpty(permission.Hint)) {
+                            <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T(permission.Hint)"></i>
                         }
                     </td>    
                     <td style="width:60px;">

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
@@ -61,9 +61,12 @@
                                 {
                                     <input type="checkbox" value="true" name="Checkbox.@permission.Name" />
                                 }
-                                @if (permission.IsSecurityCritical && !string.IsNullOrEmpty(permission.Hint))
+                                @if (permission.IsSecurityCritical)
                                 {
-                                    <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T(permission.Hint)"></i>
+                                    <i class="fa-solid fa-triangle-exclamation" style="color: red"
+                                       title="@(string.IsNullOrEmpty(permission.Hint)
+                                            ? T("This permission could allow a user to elevate their other permissions. Grant it with extreme consideration.")
+                                            : T(permission.Hint))"></i>
                                 }
                             </td>
                             <td style="width:60px;">

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Edit.cshtml
@@ -64,9 +64,7 @@
                                 @if (permission.IsSecurityCritical)
                                 {
                                     <i class="fa-solid fa-triangle-exclamation" style="color: red"
-                                       title="@(string.IsNullOrEmpty(permission.Hint)
-                                            ? T("This permission could allow a user to elevate their other permissions. Grant it with extreme consideration.")
-                                            : T(permission.Hint))"></i>
+                                       title="@T("This permission could allow a user to elevate their other permissions. Grant it with extreme consideration.")"></i>
                                 }
                             </td>
                             <td style="width:60px;">

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
@@ -36,14 +36,14 @@
                 <tr>
                     <td><input type="checkbox" value="true" name="@("Checkbox." + row.Id)" /></td>
                     <td>
+                        @Html.ActionLink(row.Name, "Edit", new { row.Id })
                         @foreach (var item in row.RolesPermissions) {
                             if (Model.SecurityCriticalPermissions.Contains(item.Permission.Name)) {
-                                <i class="fa-solid fa-triangle-exclamation" title="@T("This role contains security critical permissions.")"></i>
+                                <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T("This role contains security critical permissions.")"></i>
                                 break;
                             }
 
                         }
-                        @Html.ActionLink(row.Name, "Edit", new { row.Id })
                     </td>
                     <td>
                         <ul class="action-links">

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
@@ -1,5 +1,6 @@
+@using Orchard.Roles.ViewModels
+
 @model RolesIndexViewModel
-@using Orchard.Roles.ViewModels;
 
 @{
     Script.Require("ShapesBase");
@@ -8,8 +9,9 @@
     Layout.Title = T("Roles").ToString();
 }
 
-@using (Html.BeginFormAntiForgeryPost()) {
-    @Html.ValidationSummary();
+@using (Html.BeginFormAntiForgeryPost())
+{
+    @Html.ValidationSummary()
     <fieldset class="bulk-actions">
         <label for="publishActions">@T("Actions:")</label>
         <select id="Select1" name="roleActions">
@@ -32,14 +34,18 @@
                     <th scope="col"></th>
                 </tr>
             </thead>
-            @foreach (var row in Model.Rows) {
+            @foreach (var row in Model.Rows)
+            {
                 <tr>
                     <td><input type="checkbox" value="true" name="@("Checkbox." + row.Id)" /></td>
                     <td>
                         @Html.ActionLink(row.Name, "Edit", new { row.Id })
-                        @foreach (var item in row.RolesPermissions) {
-                            if (Model.SecurityCriticalPermissions.Contains(item.Permission.Name)) {
-                                <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T("This role contains security critical permissions.")"></i>
+                        @foreach (var item in row.RolesPermissions)
+                        {
+                            if (Model.SecurityCriticalPermissions.Contains(item.Permission.Name))
+                            {
+                                <i class="fa-solid fa-triangle-exclamation" style="color: red"
+                                   title="@T("This role contains security critical permissions.")"></i>
                                 break;
                             }
                         }
@@ -49,9 +55,11 @@
                             <li class="action-link">
                                 @Html.ActionLink(T("Edit").ToString(), "Edit", new { row.Id })
                             </li>
-                            @if (row.Name != "Administrator") {
+                            @if (row.Name != "Administrator")
+                            {
                                 <li class="action-link">
-                                    <a href="@Url.Action("Delete", new {row.Id, returnUrl = ViewContext.RequestContext.HttpContext.Request.RawUrl})" itemprop="RemoveUrl UnsafeUrl">@T("Delete")</a>                       
+                                    <a href="@Url.Action("Delete", new {row.Id, returnUrl = ViewContext.RequestContext.HttpContext.Request.RawUrl})"
+                                       itemprop="RemoveUrl UnsafeUrl">@T("Delete")</a>
                                 </li>
                             }
                         </ul>

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
@@ -1,8 +1,9 @@
 @model RolesIndexViewModel
 @using Orchard.Roles.ViewModels;
-@using Orchard.Utility.Extensions;
+
 @{
     Script.Require("ShapesBase");
+    Style.Require("FontAwesome");
 
     Layout.Title = T("Roles").ToString();
 }
@@ -34,7 +35,16 @@
             @foreach (var row in Model.Rows) {
                 <tr>
                     <td><input type="checkbox" value="true" name="@("Checkbox." + row.Id)" /></td>
-                    <td>@Html.ActionLink(row.Name, "Edit", new { row.Id })</td>
+                    <td>
+                        @foreach (var item in row.RolesPermissions) {
+                            if (Model.SecurityCriticalPermissions.Contains(item.Permission.Name)) {
+                                <i class="fa-solid fa-triangle-exclamation" title="@T("This role contains security critical permissions.")"></i>
+                                break;
+                            }
+
+                        }
+                        @Html.ActionLink(row.Name, "Edit", new { row.Id })
+                    </td>
                     <td>
                         <ul class="action-links">
                             <li class="action-link">

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
@@ -42,7 +42,6 @@
                                 <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T("This role contains security critical permissions.")"></i>
                                 break;
                             }
-
                         }
                     </td>
                     <td>

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/Admin/Index.cshtml
@@ -40,14 +40,10 @@
                     <td><input type="checkbox" value="true" name="@("Checkbox." + row.Id)" /></td>
                     <td>
                         @Html.ActionLink(row.Name, "Edit", new { row.Id })
-                        @foreach (var item in row.RolesPermissions)
+                        @if (Model.RolesWithSecurityCriticalPermissions[row.Name])
                         {
-                            if (Model.SecurityCriticalPermissions.Contains(item.Permission.Name))
-                            {
-                                <i class="fa-solid fa-triangle-exclamation" style="color: red"
-                                   title="@T("This role contains security critical permissions.")"></i>
-                                break;
-                            }
+                            <i class="fa-solid fa-triangle-exclamation" style="color: red"
+                                title="@T("This role contains security critical permissions.")"></i>
                         }
                     </td>
                     <td>

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/EditorTemplates/Parts/Roles.UserRoles.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/EditorTemplates/Parts/Roles.UserRoles.cshtml
@@ -2,19 +2,22 @@
 @using Orchard.Roles.ViewModels
 @using System.Linq
 
+@model UserRolesViewModel
+
 @{
     Style.Require("FontAwesome");
 }
 
-@model UserRolesViewModel
-
 <fieldset>
     <legend>@T("Roles")</legend>
 
-    @if (Model.Roles.Count > 0) {
+    @if (Model.Roles.Count > 0)
+    {
         var index = 0;
-        foreach (var entry in Model.Roles) {
-            if (SystemRoles.GetSystemRoles().Contains(entry.Name)) {
+        foreach (var entry in Model.Roles)
+        {
+            if (SystemRoles.GetSystemRoles().Contains(entry.Name))
+            {
                 continue;
             }
 
@@ -22,23 +25,26 @@
             @Html.Hidden("Roles[" + index + "].Name", entry.Name)
 
             <div>
-                @if (Model.AuthorizedRoleIds.Contains(entry.RoleId)) {
+                @if (Model.AuthorizedRoleIds.Contains(entry.RoleId))
+                {
                     @Html.CheckBox("Roles[" + index + "].Granted", entry.Granted)
-                } else {
+                }
+                else
+                {
                     @Html.CheckBox("Roles[" + index + "].Granted", entry.Granted, new { disabled = true })
                 }
                 <label class="forcheckbox" for="@Html.FieldIdFor(m => m.Roles[index].Granted)">@entry.Name</label>
-                @foreach (var permission in entry.Permissions) {
-                    if (Model.SecurityCriticalPermissions.Contains(permission)) {
-                        <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T("This role contains security critical permissions.")"></i>
-                        break;
-                    }
+                @if (entry.HasSecurityCriticalPermissions)
+                {
+                    <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T("This role contains security critical permissions.")"></i>
                 }
             </div>
 
             index++;
         }
-    } else {
+    }
+    else
+    {
         <p>@T("There are no roles.")</p>
     }
 </fieldset>

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/EditorTemplates/Parts/Roles.UserRoles.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/EditorTemplates/Parts/Roles.UserRoles.cshtml
@@ -2,6 +2,10 @@
 @using Orchard.Roles.ViewModels
 @using System.Linq
 
+@{
+    Style.Require("FontAwesome");
+}
+
 @model UserRolesViewModel
 
 <fieldset>
@@ -22,6 +26,12 @@
                     @Html.CheckBox("Roles[" + index + "].Granted", entry.Granted)
                 } else {
                     @Html.CheckBox("Roles[" + index + "].Granted", entry.Granted, new { disabled = true })
+                }
+                @foreach (var permission in entry.Permissions) {
+                    if (Model.SecurityCriticalPermissions.Contains(permission)) {
+                        <i class="fa-solid fa-triangle-exclamation" title="@T("This role contains security critical permissions.")"></i>
+                        break;
+                    }
                 }
                 <label class="forcheckbox" for="@Html.FieldIdFor(m => m.Roles[index].Granted)">@entry.Name</label>
             </div>

--- a/src/Orchard.Web/Modules/Orchard.Roles/Views/EditorTemplates/Parts/Roles.UserRoles.cshtml
+++ b/src/Orchard.Web/Modules/Orchard.Roles/Views/EditorTemplates/Parts/Roles.UserRoles.cshtml
@@ -27,13 +27,13 @@
                 } else {
                     @Html.CheckBox("Roles[" + index + "].Granted", entry.Granted, new { disabled = true })
                 }
+                <label class="forcheckbox" for="@Html.FieldIdFor(m => m.Roles[index].Granted)">@entry.Name</label>
                 @foreach (var permission in entry.Permissions) {
                     if (Model.SecurityCriticalPermissions.Contains(permission)) {
-                        <i class="fa-solid fa-triangle-exclamation" title="@T("This role contains security critical permissions.")"></i>
+                        <i class="fa-solid fa-triangle-exclamation" style="color: red" title="@T("This role contains security critical permissions.")"></i>
                         break;
                     }
                 }
-                <label class="forcheckbox" for="@Html.FieldIdFor(m => m.Roles[index].Granted)">@entry.Name</label>
             </div>
 
             index++;

--- a/src/Orchard.Web/Modules/Orchard.Templates/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Templates/Permissions.cs
@@ -6,14 +6,7 @@ namespace Orchard.Templates
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageTemplates =
-            new Permission
-            {
-                Description = "Managing Templates",
-                Name = "ManageTemplates",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
+        public static readonly Permission ManageTemplates = new Permission { Description = "Managing Templates", Name = "ManageTemplates", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Templates/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Templates/Permissions.cs
@@ -6,7 +6,14 @@ namespace Orchard.Templates
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageTemplates = new Permission { Description = "Managing Templates", Name = "ManageTemplates", IsSecurityCritical = true };
+        public static readonly Permission ManageTemplates =
+            new Permission
+            {
+                Description = "Managing Templates",
+                Name = "ManageTemplates",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Templates/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Templates/Permissions.cs
@@ -6,7 +6,7 @@ namespace Orchard.Templates
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageTemplates = new Permission { Description = "Managing Templates", Name = "ManageTemplates" };
+        public static readonly Permission ManageTemplates = new Permission { Description = "Managing Templates", Name = "ManageTemplates", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Themes/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Themes/Permissions.cs
@@ -6,7 +6,14 @@ namespace Orchard.Themes
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ApplyTheme = new Permission { Description = "Apply a Theme", Name = "ApplyTheme", IsSecurityCritical = true };
+        public static readonly Permission ApplyTheme =
+            new Permission
+            {
+                Description = "Apply a Theme",
+                Name = "ApplyTheme",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Themes/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Themes/Permissions.cs
@@ -6,14 +6,7 @@ namespace Orchard.Themes
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ApplyTheme =
-            new Permission
-            {
-                Description = "Apply a Theme",
-                Name = "ApplyTheme",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
+        public static readonly Permission ApplyTheme = new Permission { Description = "Apply a Theme", Name = "ApplyTheme", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Themes/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Themes/Permissions.cs
@@ -6,7 +6,7 @@ namespace Orchard.Themes
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ApplyTheme = new Permission { Description = "Apply a Theme", Name = "ApplyTheme" };
+        public static readonly Permission ApplyTheme = new Permission { Description = "Apply a Theme", Name = "ApplyTheme", IsSecurityCritical = true };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Users/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Permissions.cs
@@ -7,9 +7,21 @@ namespace Orchard.Users
     public class Permissions : IPermissionProvider
     {
         public static readonly Permission ManageUsers =
-            new Permission { Description = "Managing Users", Name = "ManageUsers", IsSecurityCritical = true };
+            new Permission
+            {
+                Description = "Managing Users",
+                Name = "ManageUsers",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
+
         public static readonly Permission ViewUsers =
-            new Permission { Description = "View List of Users", Name = "ViewUsers", ImpliedBy = new[] { ManageUsers } };
+            new Permission
+            {
+                Description = "View List of Users",
+                Name = "ViewUsers",
+                ImpliedBy = new[] { ManageUsers }
+            };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Users/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Permissions.cs
@@ -7,21 +7,9 @@ namespace Orchard.Users
     public class Permissions : IPermissionProvider
     {
         public static readonly Permission ManageUsers =
-            new Permission
-            {
-                Description = "Managing Users",
-                Name = "ManageUsers",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
-
+            new Permission { Description = "Managing Users", Name = "ManageUsers", IsSecurityCritical = true };
         public static readonly Permission ViewUsers =
-            new Permission
-            {
-                Description = "View List of Users",
-                Name = "ViewUsers",
-                ImpliedBy = new[] { ManageUsers }
-            };
+            new Permission { Description = "View List of Users", Name = "ViewUsers", ImpliedBy = new[] { ManageUsers } };
 
         public virtual Feature Feature { get; set; }
 

--- a/src/Orchard.Web/Modules/Orchard.Users/Permissions.cs
+++ b/src/Orchard.Web/Modules/Orchard.Users/Permissions.cs
@@ -7,7 +7,7 @@ namespace Orchard.Users
     public class Permissions : IPermissionProvider
     {
         public static readonly Permission ManageUsers =
-            new Permission { Description = "Managing Users", Name = "ManageUsers" };
+            new Permission { Description = "Managing Users", Name = "ManageUsers", IsSecurityCritical = true };
         public static readonly Permission ViewUsers =
             new Permission { Description = "View List of Users", Name = "ViewUsers", ImpliedBy = new[] { ManageUsers } };
 

--- a/src/Orchard/Constants/PermissionsConstants.cs
+++ b/src/Orchard/Constants/PermissionsConstants.cs
@@ -1,8 +1,0 @@
-namespace Orchard.Security.Permissions
-{
-    public static class PermissionsConstants
-    {
-        public const string SecurityCriticalPermissionDefaultHint =
-            "This permission could allow a user to elevate their other permissions. Grant it with extreme consideration.";
-    }
-}

--- a/src/Orchard/Constants/PermissionsConstants.cs
+++ b/src/Orchard/Constants/PermissionsConstants.cs
@@ -1,0 +1,8 @@
+namespace Orchard.Security.Permissions
+{
+    public static class PermissionsConstants
+    {
+        public const string SecurityCriticalPermissionDefaultHint =
+            "This permission could allow a user to elevate their other permissions. Grant it with extreme consideration.";
+    }
+}

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -170,6 +170,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Constants\PermissionsConstants.cs" />
     <Compile Include="ContentManagement\Extensions\DriverResultExtensions.cs" />
     <Compile Include="ContentManagement\Handlers\CloneContentContext.cs" />
     <Compile Include="ContentManagement\IGlobalCriteriaProvider.cs" />

--- a/src/Orchard/Orchard.Framework.csproj
+++ b/src/Orchard/Orchard.Framework.csproj
@@ -170,7 +170,6 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Constants\PermissionsConstants.cs" />
     <Compile Include="ContentManagement\Extensions\DriverResultExtensions.cs" />
     <Compile Include="ContentManagement\Handlers\CloneContentContext.cs" />
     <Compile Include="ContentManagement\IGlobalCriteriaProvider.cs" />

--- a/src/Orchard/Security/Permissions/Permission.cs
+++ b/src/Orchard/Security/Permissions/Permission.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Orchard.Localization;
 
 namespace Orchard.Security.Permissions
 {
@@ -10,6 +11,13 @@ namespace Orchard.Security.Permissions
         public string Category { get; set; }
 
         public IEnumerable<Permission> ImpliedBy { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the permission is security critical.
+        /// </summary>
+        public bool IsSecurityCritical { get; set; }
+
+        public LocalizedString Hint { get; set; }
 
         public static Permission Named(string name)
         {

--- a/src/Orchard/Security/Permissions/Permission.cs
+++ b/src/Orchard/Security/Permissions/Permission.cs
@@ -12,7 +12,7 @@ namespace Orchard.Security.Permissions
         public IEnumerable<Permission> ImpliedBy { get; set; }
 
         /// <summary>
-        /// Gets a value indicating whether the permission is security critical.
+        /// Indicates whether this permission could allow a user to elevate their other permissions.
         /// </summary>
         public bool IsSecurityCritical { get; set; }
 

--- a/src/Orchard/Security/Permissions/Permission.cs
+++ b/src/Orchard/Security/Permissions/Permission.cs
@@ -16,8 +16,6 @@ namespace Orchard.Security.Permissions
         /// </summary>
         public bool IsSecurityCritical { get; set; }
 
-        public string Hint { get; set; }
-
         public static Permission Named(string name)
         {
             return new Permission { Name = name };

--- a/src/Orchard/Security/Permissions/Permission.cs
+++ b/src/Orchard/Security/Permissions/Permission.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Orchard.Localization;
 
 namespace Orchard.Security.Permissions
 {
@@ -17,7 +16,7 @@ namespace Orchard.Security.Permissions
         /// </summary>
         public bool IsSecurityCritical { get; set; }
 
-        public LocalizedString Hint { get; set; }
+        public string Hint { get; set; }
 
         public static Permission Named(string name)
         {

--- a/src/Orchard/Security/StandardPermissions.cs
+++ b/src/Orchard/Security/StandardPermissions.cs
@@ -10,14 +10,7 @@ namespace Orchard.Security
     {
         public static readonly Permission AccessAdminPanel = new Permission { Name = "AccessAdminPanel", Description = "Access admin panel" };
         public static readonly Permission AccessFrontEnd = new Permission { Name = "AccessFrontEnd", Description = "Access site front-end" };
-        public static readonly Permission SiteOwner =
-            new Permission
-            {
-                Name = "SiteOwner",
-                Description = "Site Owners Permission",
-                IsSecurityCritical = true,
-                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
-            };
+        public static readonly Permission SiteOwner = new Permission { Name = "SiteOwner", Description = "Site Owners Permission", IsSecurityCritical = true };
 
         public Feature Feature
         {

--- a/src/Orchard/Security/StandardPermissions.cs
+++ b/src/Orchard/Security/StandardPermissions.cs
@@ -10,7 +10,14 @@ namespace Orchard.Security
     {
         public static readonly Permission AccessAdminPanel = new Permission { Name = "AccessAdminPanel", Description = "Access admin panel" };
         public static readonly Permission AccessFrontEnd = new Permission { Name = "AccessFrontEnd", Description = "Access site front-end" };
-        public static readonly Permission SiteOwner = new Permission { Name = "SiteOwner", Description = "Site Owners Permission", IsSecurityCritical = true };
+        public static readonly Permission SiteOwner =
+            new Permission
+            {
+                Name = "SiteOwner",
+                Description = "Site Owners Permission",
+                IsSecurityCritical = true,
+                Hint = PermissionsConstants.SecurityCriticalPermissionDefaultHint
+            };
 
         public Feature Feature
         {

--- a/src/Orchard/Security/StandardPermissions.cs
+++ b/src/Orchard/Security/StandardPermissions.cs
@@ -10,7 +10,7 @@ namespace Orchard.Security
     {
         public static readonly Permission AccessAdminPanel = new Permission { Name = "AccessAdminPanel", Description = "Access admin panel" };
         public static readonly Permission AccessFrontEnd = new Permission { Name = "AccessFrontEnd", Description = "Access site front-end" };
-        public static readonly Permission SiteOwner = new Permission { Name = "SiteOwner", Description = "Site Owners Permission" };
+        public static readonly Permission SiteOwner = new Permission { Name = "SiteOwner", Description = "Site Owners Permission", IsSecurityCritical = true };
 
         public Feature Feature
         {


### PR DESCRIPTION
Fixes: https://github.com/OrchardCMS/Orchard/issues/8266

Here, I tried to mimic what we currently have in Orchard Core. It means we have a badge with the "_Security Critical_" text and a tooltip that reads "_This permission could allow a user to elevate their other permissions. Grant it with extreme consideration._". It appears before each _Allow_ checkbox when setting up a role's permissions. We also have a hint on that page describing the differences between the _Allow_ and _Effective_ settings.

In this PR, I have added the same hint to describe the _Allow_ and _Effective_ settings. We have an icon with an exclamation mark instead of a badge, and I used the exact text for the tooltip, as you can see in Orchard Core.

The tooltip text is the same as in Orchard Core.

I didn't want to include too much styling, so I used an icon from Font Awesome with the title HTML attribute.