### PR TITLE
#8878: Fixing that Projection Manager should apply the Version Scope even if there are multiple filter groups

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/IProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/IProjectionManager.cs
@@ -5,6 +5,7 @@ using Orchard.Projections.Descriptors.Filter;
 using Orchard.Projections.Descriptors.Layout;
 using Orchard.Projections.Descriptors.Property;
 using Orchard.Projections.Descriptors.SortCriterion;
+using Orchard.Projections.Models;
 
 namespace Orchard.Projections.Services
 {
@@ -22,6 +23,11 @@ namespace Orchard.Projections.Services
 
         IEnumerable<ContentItem> GetContentItems(int queryId, int skip = 0, int count = 0);
         IEnumerable<ContentItem> GetContentItems(int queryId, ContentPart part, int skip = 0, int count = 0);
+
+        IEnumerable<IHqlQuery> GetContentQueries(
+            QueryPartRecord queryRecord,
+            IEnumerable<SortCriterionRecord> sortCriteria,
+            Dictionary<string, object> tokens);
 
         int GetCount(int queryId);
         int GetCount(int queryId, ContentPart part);

--- a/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
+++ b/src/Orchard.Web/Modules/Orchard.Projections/Services/ProjectionManager.cs
@@ -128,7 +128,7 @@ namespace Orchard.Projections.Services
             var queryRecord = _queryRepository.Get(queryId) ?? throw new ArgumentException("queryId");
 
             // Prepare tokens.
-            Dictionary<string, object> tokens = new Dictionary<string, object>();
+            var tokens = new Dictionary<string, object>();
             if (part != null)
             {
                 tokens.Add("Content", part.ContentItem);
@@ -151,17 +151,11 @@ namespace Orchard.Projections.Services
         {
             var availableSortCriteria = DescribeSortCriteria().ToList();
 
-            var queryRecord = _queryRepository.Get(queryId);
-
-            if (queryRecord == null)
-            {
-                throw new ArgumentException("queryId");
-            }
-
+            var queryRecord = _queryRepository.Get(queryId) ?? throw new ArgumentException("queryId");
             var contentItems = new List<ContentItem>();
 
             // Prepare tokens.
-            Dictionary<string, object> tokens = new Dictionary<string, object>();
+            var tokens = new Dictionary<string, object>();
             if (part != null)
             {
                 tokens.Add("Content", part.ContentItem);
@@ -186,7 +180,8 @@ namespace Orchard.Projections.Services
                 return Enumerable.Empty<ContentItem>();
             }
 
-            var groupQuery = _contentManager.HqlQuery().Where(alias => alias.Named("ci"), x => x.InG("Id", ids));
+            var version = queryRecord.VersionScope.ToVersionOptions();
+            var groupQuery = _contentManager.HqlQuery().ForVersion(version).Where(alias => alias.Named("ci"), x => x.InG("Id", ids));
 
             // Iterate over each sort criteria to apply the alterations to the query object.
             foreach (var sortCriterion in queryRecord.SortCriteria.OrderBy(s => s.Position))
@@ -200,8 +195,8 @@ namespace Orchard.Projections.Services
                     Tokens = tokens
                 };
 
-                string category = sortCriterion.Category;
-                string type = sortCriterion.Type;
+                var category = sortCriterion.Category;
+                var type = sortCriterion.Type;
 
                 // Find specific sort criterion.
                 var descriptor = availableSortCriteria
@@ -255,8 +250,8 @@ namespace Orchard.Projections.Services
                         Tokens = tokens
                     };
 
-                    string category = filter.Category;
-                    string type = filter.Type;
+                    var category = filter.Category;
+                    var type = filter.Type;
 
                     // Find specific filter.
                     var descriptor = availableFilters
@@ -287,8 +282,8 @@ namespace Orchard.Projections.Services
                         Tokens = tokens
                     };
 
-                    string category = sortCriterion.Category;
-                    string type = sortCriterion.Type;
+                    var category = sortCriterion.Category;
+                    var type = sortCriterion.Type;
 
                     // Find specific sort criterion.
                     var descriptor = availableSortCriteria


### PR DESCRIPTION
Fixes #8878

Also added `GetContentQueries` to `IProjectionManager`, which is already implemented by `ProjectionManager`, for more flexibility of usage.