### PR TITLE
#8268: Removing obsolete TermPart.SortObsolete (and TermsComparer) from Taxonomies

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
+++ b/src/Orchard.Web/Modules/Orchard.Taxonomies/Models/TermPart.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -82,84 +81,6 @@ namespace Orchard.Taxonomies.Models
         public static IEnumerable<TermPart> Sort(IEnumerable<TermPart> terms)
         {
             return terms.OrderBy(term => term.FullWeight);
-        }
-
-        [Obsolete]
-        public static IEnumerable<TermPart> SortObsolete(IEnumerable<TermPart> terms)
-        {
-            var list = terms.ToList();
-            var index = list.ToDictionary(x => x.FullPath);
-            return list.OrderBy(x => x, new TermsComparer(index));
-        }
-
-        [Obsolete]
-        private class TermsComparer : IComparer<TermPart>
-        {
-            private readonly IDictionary<string, TermPart> _index;
-
-            public TermsComparer(IDictionary<string, TermPart> index)
-            {
-                _index = index;
-            }
-
-            public int Compare(TermPart x, TermPart y)
-            {
-
-                // if two nodes have the same parent, then compare by weight, then by path  
-                // /1/2/3 vs /1/2/4 => 3 vs 4
-                if (x.Path == y.Path)
-                {
-                    var weight = y.Weight.CompareTo(x.Weight);
-
-                    if (weight != 0)
-                    {
-                        return weight;
-                    }
-
-                    // if same parent path and same weight, compare by name
-                    return string.Compare(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
-                }
-
-                // if two nodes have different parents
-
-                //    if the two nodes have the same root, the deeper is after (i.e. one starts with the other)
-                //    /1/2 vs /1/2/3 => /1/2 first
-
-                if (x.FullPath.StartsWith(y.FullPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    return 1;
-                }
-
-                if (y.FullPath.StartsWith(x.FullPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    return -1;
-                }
-
-                //    otherwise compare first none matching parent
-                //    /1/2 vs /1/3 => 2 vs 3
-                //    /2/3 vs /4 => 2 vs 4
-
-                var xPath = x.FullPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-                var yPath = y.FullPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-
-                string xFullPath = "", yFullPath = "";
-
-                for (var i = 0; i < Math.Min(xPath.Length, yPath.Length); i++)
-                {
-                    xFullPath += "/" + xPath[i];
-                    yFullPath += "/" + yPath[i];
-
-                    if (!xFullPath.Equals(yFullPath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        var xParent = _index[xFullPath];
-                        var yParent = _index[yFullPath];
-
-                        return Compare(xParent, yParent);
-                    }
-                }
-
-                return 0;
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes #8268